### PR TITLE
Fixing a bug in signing with cert (do not dispose crypto provider) etc.

### DIFF
--- a/src/ADAL.Common/AuthenticationContext.cs
+++ b/src/ADAL.Common/AuthenticationContext.cs
@@ -519,8 +519,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 {
                     newResult = await this.SendOAuth2RequestByRefreshTokenAsync(resource, result.RefreshToken, clientId, callState);
 
-                    // Id token is not returned by token endpoint when refresh token is redeemed. Therefore, we should copy tenant and user information from the cached token.
-                    newResult.UpdateTenantAndUserInfo(result.TenantId, result.UserInfo);
+                    if (newResult.IdToken == null)
+                    {
+                        // If Id token is not returned by token endpoint when refresh token is redeemed, we should copy tenant and user information from the cached token.
+                        newResult.UpdateTenantAndUserInfo(result.TenantId, result.IdToken, result.UserInfo);
+                    }
                 }
                 catch (AdalException) 
                 {

--- a/src/ADAL.Common/AuthenticationResult.cs
+++ b/src/ADAL.Common/AuthenticationResult.cs
@@ -138,9 +138,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return serializedObject;
         }
 
-        internal void UpdateTenantAndUserInfo(string tenantId, UserInfo userInfo)
+        internal void UpdateTenantAndUserInfo(string tenantId, string idToken, UserInfo userInfo)
         {
             this.TenantId = tenantId;
+            this.IdToken = idToken;
             if (userInfo != null)
             {
                 this.UserInfo = new UserInfo(userInfo);

--- a/src/ADAL.Common/OAuth2Response.cs
+++ b/src/ADAL.Common/OAuth2Response.cs
@@ -158,8 +158,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                         changePasswordUri = new Uri(idToken.PasswordChangeUrl);
                     }
 
-                    result.UpdateTenantAndUserInfo(tenantId, new UserInfo { UniqueId = uniqueId, DisplayableId = displayableId, GivenName = givenName, FamilyName = familyName, IdentityProvider = identityProvider, PasswordExpiresOn = passwordExpiresOffest, PasswordChangeUrl = changePasswordUri });
-                    result.IdToken = tokenResponse.IdToken;
+                    result.UpdateTenantAndUserInfo(tenantId, tokenResponse.IdToken, new UserInfo { UniqueId = uniqueId, DisplayableId = displayableId, GivenName = givenName, FamilyName = familyName, IdentityProvider = identityProvider, PasswordExpiresOn = passwordExpiresOffest, PasswordChangeUrl = changePasswordUri });
                 }
             }
             else if (tokenResponse.Error != null)

--- a/src/ADAL.NET/AuthenticationContext.cs
+++ b/src/ADAL.NET/AuthenticationContext.cs
@@ -733,17 +733,21 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
             await this.UpdateAuthorityTenantAsync(result.TenantId, callState);
 
+            string uniqueId = (result.UserInfo == null) ? null : result.UserInfo.UniqueId;
+            string displayableId = (result.UserInfo == null) ? null : result.UserInfo.DisplayableId;
+            resource = result.Resource;
+
             try
             {
-                this.NotifyBeforeAccessCache(resource, clientId, null, null);
-                this.tokenCacheManager.StoreToCache(result, result.Resource, clientId);
+                this.NotifyBeforeAccessCache(resource, clientId, uniqueId, displayableId);
+                this.tokenCacheManager.StoreToCache(result, resource, clientId);
 
                 LogReturnedToken(result, callState);
                 return result;
             }
             finally
             {
-                this.NotifyAfterAccessCache(resource, clientId, null, null);
+                this.NotifyAfterAccessCache(resource, clientId, uniqueId, displayableId);
             }
         }
 

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -127,6 +127,16 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="..\Test.ADAL.Common\Certs\valid_cert.pfx">
+      <Link>valid_cert.pfx</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\Test.ADAL.Common\Certs\valid_cert2.pfx">
+      <Link>valid_cert2.pfx</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>

--- a/tests/Test.ADAL.NET.Unit/UnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/UnitTests.cs
@@ -19,7 +19,9 @@
 using System;
 using System.Collections.Generic;
 using System.Security;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
+
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Test.ADAL.Common;
@@ -27,6 +29,8 @@ using Test.ADAL.Common;
 namespace Test.ADAL.NET.Unit
 {
     [TestClass]
+    [DeploymentItem("valid_cert.pfx")]
+    [DeploymentItem("valid_cert2.pfx")]
     public class UnitTests
     {
         private const string ComplexString = "asdfk+j0a-=skjwe43;1l234 1#$!$#%345903485qrq@#$!@#$!(rekr341!#$%Ekfaآزمايشsdsdfsddfdgsfgjsglk==CVADS";
@@ -273,6 +277,27 @@ namespace Test.ADAL.NET.Unit
         public void IncludeFormsAuthParamsTest()
         {
             Assert.IsFalse(OAuth2Request.IncludeFormsAuthParams());
+        }
+
+        [TestMethod]
+        [TestCategory("AdalDotNetUnit")]
+        [Description("Test to verify CryptographyHelper.SignWithCertificate")]
+        public void SignWithCertificateTest()
+        {
+            const string Message = "This is a test message";
+            string[] certs = { "valid_cert.pfx", "valid_cert2.pfx" };
+            for (int i = 0; i < 2; i++)
+            {
+                X509Certificate2 x509Certificate = new X509Certificate2(certs[i], "password");
+                byte[] signature = CryptographyHelper.SignWithCertificate(Message, x509Certificate);
+                Verify.IsNotNull(signature);
+
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+
+                signature = CryptographyHelper.SignWithCertificate(Message, x509Certificate);
+                Verify.IsNotNull(signature);
+            }
         }
 
         private static void RunAuthenticationParametersPositive(string authenticateHeader, string expectedAuthority, string excepectedResource)

--- a/tests/Test.ADAL.WinRT.Dashboard/CommandExecuter.cs
+++ b/tests/Test.ADAL.WinRT.Dashboard/CommandExecuter.cs
@@ -71,7 +71,7 @@ namespace Test.ADAL.WinRT.Dashboard
                         break;
                     }
 
-                    case CommandType.CreateContextAVC:
+                    case CommandType.CreateContextAVT:
                     {
                         TokenCache tokenCache = null;
                         if (arg.TokenCacheStoreType == TokenCacheStoreType.InMemory)
@@ -123,13 +123,13 @@ namespace Test.ADAL.WinRT.Dashboard
                         break;
                     }
 
-                    case CommandType.AquireTokenAsyncRCR:
+                    case CommandType.AquireTokenAsyncRCRe:
                     {
                         result = await context.AcquireTokenAsync(arg.Resource, arg.ClientId, arg.RedirectUri);
                         break;
                     }
 
-                    case CommandType.AquireTokenAsyncRCRPUX:
+                    case CommandType.AquireTokenAsyncRCRePUX:
                     {
                         result = await context.AcquireTokenAsync(arg.Resource, arg.ClientId, arg.RedirectUri, 
                             (arg.PromptBehavior == PromptBehaviorProxy.Always) ? PromptBehavior.Always :
@@ -138,7 +138,7 @@ namespace Test.ADAL.WinRT.Dashboard
                         break;
                     }
 
-                    case CommandType.AquireTokenAsyncRCRP:
+                    case CommandType.AquireTokenAsyncRCReP:
                     {
                         result = await context.AcquireTokenAsync(arg.Resource, arg.ClientId, arg.RedirectUri, 
                             (arg.PromptBehavior == PromptBehaviorProxy.Always) ? PromptBehavior.Always :
@@ -146,7 +146,7 @@ namespace Test.ADAL.WinRT.Dashboard
                         break;
                     }
 
-                    case CommandType.AquireTokenAsyncRCRPU:
+                    case CommandType.AquireTokenAsyncRCRePU:
                     {
                         result = await context.AcquireTokenAsync(arg.Resource, arg.ClientId, arg.RedirectUri,                            
                             (arg.PromptBehavior == PromptBehaviorProxy.Always) ? PromptBehavior.Always :
@@ -169,7 +169,7 @@ namespace Test.ADAL.WinRT.Dashboard
                         break;
                     }
 
-                    case CommandType.AcquireTokenByRefreshTokenAsyncRCR:
+                    case CommandType.AcquireTokenByRefreshTokenAsyncRCRe:
                     {
                         result = await context.AcquireTokenByRefreshTokenAsync(arg.RefreshToken, arg.ClientId, arg.Resource);
                         break;

--- a/tests/Test.ADAL.WinRT/AuthenticationContextCommand.cs
+++ b/tests/Test.ADAL.WinRT/AuthenticationContextCommand.cs
@@ -26,6 +26,20 @@ using Test.ADAL.Common;
 
 namespace Test.ADAL.WinRT
 {
+    /// <summary>
+    /// To indicate what API was called in the test app
+    /// Acronyms used:
+    /// A: Authority
+    /// V: ValidateAuthority
+    /// T: Token Cache
+    /// R: Resource
+    /// C: ClientId
+    /// Re: RedirectUri
+    /// P: PromptBehavior
+    /// U: UserId/UserName
+    /// Pa: Password
+    /// X: ExtraQueryParameters
+    /// </summary>
     enum CommandType
     {
         ClearDefaultTokenCache,
@@ -35,16 +49,16 @@ namespace Test.ADAL.WinRT
         SetUseCorporateNetwork,
         CreateContextA,
         CreateContextAV,
-        CreateContextAVC,
+        CreateContextAVT,
         AquireTokenAsyncRC,
         AquireTokenAsyncRCP,
         AquireTokenAsyncRCUPa,
-        AquireTokenAsyncRCR,
-        AquireTokenAsyncRCRP,
-        AquireTokenAsyncRCRPU,
+        AquireTokenAsyncRCRe,
+        AquireTokenAsyncRCReP,
+        AquireTokenAsyncRCRePU,
         AcquireTokenByRefreshTokenAsyncRC,
-        AcquireTokenByRefreshTokenAsyncRCR,
-        AquireTokenAsyncRCRPUX,
+        AcquireTokenByRefreshTokenAsyncRCRe,
+        AquireTokenAsyncRCRePUX,
         CreateFromResourceUrlAsync,
         CreateFromResponseAuthenticateHeader,
     }

--- a/tests/Test.ADAL.WinRT/AuthenticationContextProxy.cs
+++ b/tests/Test.ADAL.WinRT/AuthenticationContextProxy.cs
@@ -67,7 +67,7 @@ namespace Test.ADAL.Common
         public AuthenticationContextProxy(string authority, bool validateAuthority, TokenCacheStoreType tokenCacheStoreType)
         {
             CommandProxy.AddCommand(new AuthenticationContextCommand(
-                CommandType.CreateContextAVC,
+                CommandType.CreateContextAVT,
                 new CommandArguments { Authority = authority, ValidateAuthority = validateAuthority, TokenCacheStoreType = tokenCacheStoreType }));
         }
 
@@ -127,7 +127,7 @@ namespace Test.ADAL.Common
         public AuthenticationResultProxy AcquireToken(string resource, string clientId, Uri redirectUri)
         {
             return RunAsyncTask(AddCommandAndRunAsync(
-                CommandType.AquireTokenAsyncRCR,
+                CommandType.AquireTokenAsyncRCRe,
                 new CommandArguments { Resource = resource, ClientId = clientId, RedirectUri = redirectUri }));
         }
 
@@ -141,14 +141,14 @@ namespace Test.ADAL.Common
         public AuthenticationResultProxy AcquireToken(string resource, string clientId, Uri redirectUri, PromptBehaviorProxy promptBehavior)
         {
             return RunAsyncTask(AddCommandAndRunAsync(
-                CommandType.AquireTokenAsyncRCRP,
+                CommandType.AquireTokenAsyncRCReP,
                 new CommandArguments { Resource = resource, ClientId = clientId, RedirectUri = redirectUri, PromptBehavior = promptBehavior }));
         }
 
         public AuthenticationResultProxy AcquireToken(string resource, string clientId, Uri redirectUri, PromptBehaviorProxy promptBehavior, UserIdentifier userId)
         {
             return RunAsyncTask(AddCommandAndRunAsync(
-                CommandType.AquireTokenAsyncRCRPU,
+                CommandType.AquireTokenAsyncRCRePU,
                 new CommandArguments { Resource = resource, ClientId = clientId, RedirectUri = redirectUri, PromptBehavior = promptBehavior,
                                        UserName = (userId != null) ? userId.Id : null }));
         }
@@ -156,7 +156,7 @@ namespace Test.ADAL.Common
         public AuthenticationResultProxy AcquireToken(string resource, string clientId, Uri redirectUri, PromptBehaviorProxy promptBehavior, UserIdentifier userId, string extraQueryParameters)
         {
             return RunAsyncTask(AddCommandAndRunAsync(
-                CommandType.AquireTokenAsyncRCRPU,
+                CommandType.AquireTokenAsyncRCRePU,
                 new CommandArguments
                 {
                     Resource = resource,
@@ -178,7 +178,7 @@ namespace Test.ADAL.Common
         public async Task<AuthenticationResultProxy> AcquireTokenByRefreshTokenAsync(string refreshToken, string clientId, string resource)
         {
             return await AddCommandAndRunAsync(
-                CommandType.AcquireTokenByRefreshTokenAsyncRCR,
+                CommandType.AcquireTokenByRefreshTokenAsyncRCRe,
                 new CommandArguments { RefreshToken = refreshToken, ClientId = clientId, Resource = resource });
         }
 


### PR DESCRIPTION
Fixing a bug in signing with cert (do not dispose crypto provider)
Updating id token from original cached token if result from refresh token request does not have new id token
Minor fix to parameters of cache notification events in AcquireTokenByAuthorizationCode
Minor renames and adding comments in test code
