### PR TITLE
Returning empty string instead of null in ADAL WinRT

### DIFF
--- a/src/ADAL.Common/AuthenticatorTemplate.cs
+++ b/src/ADAL.Common/AuthenticatorTemplate.cs
@@ -103,11 +103,18 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             {
                 TokenResponse tokenResponse = OAuth2Response.ReadErrorResponse(ex.Response);
                 clientMetrics.SetLastError(tokenResponse.ErrorCodes);
-                throw new AdalServiceException(
-                    AdalError.AuthorityValidationFailed,
-                    string.Format(CultureInfo.InvariantCulture, "{0}. {1}: {2}",
-                        AdalErrorMessage.AuthorityValidationFailed, tokenResponse.Error, tokenResponse.ErrorDescription),
-                    ex);
+
+                if (tokenResponse.Error == "invalid_instance")
+                {
+                    throw new AdalServiceException(AdalError.AuthorityNotInValidList, ex);
+                }
+                else
+                {
+                    throw new AdalServiceException(
+                        AdalError.AuthorityValidationFailed,
+                        string.Format(CultureInfo.InvariantCulture, "{0}. {1}: {2}", AdalErrorMessage.AuthorityValidationFailed, tokenResponse.Error, tokenResponse.ErrorDescription),
+                        ex);
+                }
             }
             finally
             {

--- a/src/ADAL.CommonWinRT/AuthenticationContext.cs
+++ b/src/ADAL.CommonWinRT/AuthenticationContext.cs
@@ -95,6 +95,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 result = new AuthenticationResult(ex);
             }
 
+            result.ReplaceNullStringPropertiesWithEmptyString();
+
             return result;
         }
     }

--- a/src/ADAL.CommonWinRT/AuthenticationResult.cs
+++ b/src/ADAL.CommonWinRT/AuthenticationResult.cs
@@ -105,5 +105,27 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// You can use this code for purposes such as implementing retry logic or error investigation.
         /// </summary>
         public int StatusCode { get; set; }
+
+        /// <summary>
+        /// The Windows Runtime string type is a value type and has no null value. 
+        /// The .NET projection prohibits passing a null .NET string across the Windows Runtime ABI boundary for this reason.
+        /// </summary>
+        internal void ReplaceNullStringPropertiesWithEmptyString()
+        {
+            this.AccessToken = this.AccessToken ?? string.Empty;
+            this.AccessTokenType = this.AccessTokenType ?? string.Empty;
+            this.Error = this.Error ?? string.Empty;
+            this.ErrorDescription = this.ErrorDescription ?? string.Empty;
+            this.IdToken = this.IdToken ?? string.Empty;
+            this.RefreshToken = this.RefreshToken ?? string.Empty;
+            this.TenantId = this.TenantId ?? string.Empty;
+            if (this.UserInfo != null)
+            {
+                this.UserInfo.DisplayableId = this.UserInfo.DisplayableId ?? string.Empty;
+                this.UserInfo.FamilyName = this.UserInfo.FamilyName ?? string.Empty;
+                this.UserInfo.GivenName = this.UserInfo.GivenName ?? string.Empty;
+                this.UserInfo.IdentityProvider = this.UserInfo.IdentityProvider ?? string.Empty;
+            }
+        }
     }
 }

--- a/tests/Test.ADAL.Common/AdalTests.cs
+++ b/tests/Test.ADAL.Common/AdalTests.cs
@@ -310,9 +310,9 @@ namespace Test.ADAL.Common
             if (sts.Type == StsType.AAD)
             {
                 Verify.AreEqual(sts.ValidUserName, result.UserInfo.DisplayableId);
-                Verify.IsNotNull(result.UserInfo.UniqueId);
-                Verify.IsNotNull(result.UserInfo.GivenName);
-                Verify.IsNotNull(result.UserInfo.FamilyName);
+                Verify.IsNotNullOrEmptyString(result.UserInfo.UniqueId);
+                Verify.IsNotNullOrEmptyString(result.UserInfo.GivenName);
+                Verify.IsNotNullOrEmptyString(result.UserInfo.FamilyName);
 
                 EndBrowserDialogSession();
                 Log.Comment("Waiting 2 seconds before next token request...");
@@ -388,7 +388,7 @@ namespace Test.ADAL.Common
             var context = new AuthenticationContextProxy(sts.TenantlessAuthority, sts.ValidateAuthority);
             AuthenticationResultProxy result = context.AcquireToken(sts.ValidResource, sts.ValidClientId, sts.ValidDefaultRedirectUri, PromptBehaviorProxy.Auto, sts.ValidUserId);
             VerifySuccessResult(sts, result);
-            Verify.IsNotNull(result.TenantId);
+            Verify.IsNotNullOrEmptyString(result.TenantId);
 
             AuthenticationContextProxy.SetCredentials(null, null);
             AuthenticationResultProxy result2 = context.AcquireToken(
@@ -424,7 +424,7 @@ namespace Test.ADAL.Common
             {
                 context = new AuthenticationContextProxy(sts.Authority.Replace("windows.net", "windows.unknown"), sts.ValidateAuthority);
                 result = context.AcquireToken(sts.ValidResource, sts.ValidClientId, sts.ValidDefaultRedirectUri, PromptBehaviorProxy.Auto, sts.ValidUserId);
-                VerifyErrorResult(result, "authority_not_in_valid_list", "invalid_instance");
+                VerifyErrorResult(result, "authority_not_in_valid_list", "authority");
             }
 #if TEST_ADAL_WINPHONE_UNIT
             catch (AdalServiceException ex)
@@ -479,8 +479,8 @@ namespace Test.ADAL.Common
             AuthenticationResultProxy result = await context.AcquireTokenAsync(sts.ValidResource, sts.ValidClientId, credential);
             VerifySuccessResult(sts, result);
             Verify.IsNotNull(result.UserInfo);
-            Verify.IsNotNull(result.UserInfo.UniqueId);
-            Verify.IsNotNull(result.UserInfo.DisplayableId);
+            Verify.IsNotNullOrEmptyString(result.UserInfo.UniqueId);
+            Verify.IsNotNullOrEmptyString(result.UserInfo.DisplayableId);
 
             AuthenticationContextProxy.Delay(2000);
 
@@ -716,18 +716,18 @@ namespace Test.ADAL.Common
             }
 
             Verify.AreEqual(AuthenticationStatusProxy.Success, result.Status, "AuthenticationResult.Status");
-            Verify.IsNotNull(result.AccessToken, "AuthenticationResult.AccessToken");
+            Verify.IsNotNullOrEmptyString(result.AccessToken, "AuthenticationResult.AccessToken");
             if (supportRefreshToken)
             {
-                Verify.IsNotNull(result.RefreshToken, "AuthenticationResult.RefreshToken");
+                Verify.IsNotNullOrEmptyString(result.RefreshToken, "AuthenticationResult.RefreshToken");
             }
             else
             {
-                Verify.IsNull(result.RefreshToken, "AuthenticationResult.RefreshToken");
+                Verify.IsNullOrEmptyString(result.RefreshToken, "AuthenticationResult.RefreshToken");
             }
 
-            Verify.IsNull(result.Error, "AuthenticationResult.Error");
-            Verify.IsNull(result.ErrorDescription, "AuthenticationResult.ErrorDescription");
+            Verify.IsNullOrEmptyString(result.Error, "AuthenticationResult.Error");
+            Verify.IsNullOrEmptyString(result.ErrorDescription, "AuthenticationResult.ErrorDescription");
 
             if (sts.Type != StsType.ADFS && supportUserInfo)
             {
@@ -767,18 +767,18 @@ namespace Test.ADAL.Common
         {
             Log.Comment(string.Format("Verifying error result '{0}':'{1}'...", result.Error, result.ErrorDescription));
             Verify.AreNotEqual(AuthenticationStatusProxy.Success, result.Status);
-            Verify.IsNull(result.AccessToken);
-            Verify.IsNotNull(result.Error);
-            Verify.IsNotNull(result.ErrorDescription);
+            Verify.IsNullOrEmptyString(result.AccessToken);
+            Verify.IsNotNullOrEmptyString(result.Error);
+            Verify.IsNotNullOrEmptyString(result.ErrorDescription);
             Verify.IsFalse(result.ErrorDescription.Contains("+"), "Error description should not be in URL form encoding!");
             Verify.IsFalse(result.ErrorDescription.Contains("%2"), "Error description should not be in URL encoding!");
 
-            if (error != null)
+            if (!string.IsNullOrEmpty(error))
             {
                 Verify.AreEqual(error, result.Error);
             }
 
-            if (errorDescriptionKeyword != null)
+            if (!string.IsNullOrEmpty(errorDescriptionKeyword))
             {
                 VerifyErrorDescriptionContains(result.ErrorDescription, errorDescriptionKeyword);
             }

--- a/tests/Test.ADAL.Common/AdalTests2.cs
+++ b/tests/Test.ADAL.Common/AdalTests2.cs
@@ -54,7 +54,7 @@ namespace Test.ADAL.Common
                 Trace.Listeners.Add(listener);
                 context.SetCorrelationId(Guid.Empty);
                 AuthenticationResultProxy result2 = await context.AcquireTokenByRefreshTokenAsync(result.RefreshToken, sts.ValidClientId);
-                Verify.IsNotNull(result2.AccessToken);
+                Verify.IsNotNullOrEmptyString(result2.AccessToken);
                 listener.Flush();
                 string trace = Encoding.UTF8.GetString(stream.ToArray(), 0, (int)stream.Position);
                 Verify.IsFalse(trace.Contains(correlationId.ToString()));

--- a/tests/Test.ADAL.Common/AuthenticationContextProxy.cs
+++ b/tests/Test.ADAL.Common/AuthenticationContextProxy.cs
@@ -35,7 +35,7 @@ namespace Test.ADAL.Common
             Verify.AreEqual(1, items.Count);
             Verify.AreEqual(result.AccessToken, items[0].AccessToken);
             Verify.AreEqual(result.RefreshToken, items[0].RefreshToken);
-            Verify.AreEqual(result.IdToken, items[0].IdToken);
+            Verify.AreEqual(result.IdToken ?? string.Empty, items[0].IdToken ?? string.Empty);
             Verify.IsTrue(stsType == StsType.ADFS || items[0].IdToken != null);
         }
     }

--- a/tests/Test.ADAL.Common/TokenCacheTests.cs
+++ b/tests/Test.ADAL.Common/TokenCacheTests.cs
@@ -561,14 +561,25 @@ namespace Test.ADAL.Common.Unit
 
         private static bool AreAuthenticationResultsEqual(AuthenticationResult result1, AuthenticationResult result2)
         {
-            return (result1.AccessToken == result2.AccessToken && result1.AccessTokenType == result2.AccessTokenType 
-                    && result1.IdToken == result2.IdToken && result1.IsMultipleResourceRefreshToken == result2.IsMultipleResourceRefreshToken
-                    && result1.RefreshToken == result2.RefreshToken && result1.TenantId == result2.TenantId
+            return (AreStringsEqual(result1.AccessToken, result2.AccessToken)
+                    && AreStringsEqual(result1.AccessTokenType, result2.AccessTokenType)
+                    && AreStringsEqual(result1.IdToken, result2.IdToken)
+                    && result1.IsMultipleResourceRefreshToken == result2.IsMultipleResourceRefreshToken
+                    && AreStringsEqual(result1.RefreshToken, result2.RefreshToken)
+                    && AreStringsEqual(result1.TenantId, result2.TenantId)
                     && (result1.UserInfo == null || result2.UserInfo == null || 
-                        (result1.UserInfo.DisplayableId == result2.UserInfo.DisplayableId
-                        && result1.UserInfo.FamilyName == result2.UserInfo.FamilyName && result1.UserInfo.GivenName == result2.UserInfo.GivenName
-                        && result1.UserInfo.IdentityProvider == result2.UserInfo.IdentityProvider && result1.UserInfo.PasswordChangeUrl == result2.UserInfo.PasswordChangeUrl
-                        && result1.UserInfo.PasswordExpiresOn == result2.UserInfo.PasswordExpiresOn && result1.UserInfo.UniqueId == result2.UserInfo.UniqueId)));
+                        (AreStringsEqual(result1.UserInfo.DisplayableId, result2.UserInfo.DisplayableId)
+                        && AreStringsEqual(result1.UserInfo.FamilyName, result2.UserInfo.FamilyName)
+                        && AreStringsEqual(result1.UserInfo.GivenName, result2.UserInfo.GivenName)
+                        && AreStringsEqual(result1.UserInfo.IdentityProvider, result2.UserInfo.IdentityProvider) 
+                        && result1.UserInfo.PasswordChangeUrl == result2.UserInfo.PasswordChangeUrl
+                        && result1.UserInfo.PasswordExpiresOn == result2.UserInfo.PasswordExpiresOn 
+                        && result1.UserInfo.UniqueId == result2.UserInfo.UniqueId)));
+        }
+
+        private static bool AreStringsEqual(string str1, string str2)
+        {
+            return (str1 == str2 || string.IsNullOrEmpty(str1) && string.IsNullOrEmpty(str2));
         }
 
         private static void AddToDictionary(TokenCache tokenCache, TokenCacheKey key, AuthenticationResult value)

--- a/tests/Test.ADAL.Common/Verify.cs
+++ b/tests/Test.ADAL.Common/Verify.cs
@@ -72,6 +72,16 @@ namespace Test.ADAL.Common
             Assert.IsNotNull(variable, message);
         }
 
+        internal static void IsNullOrEmptyString(string variable, string message = null)
+        {
+            Assert.IsTrue(string.IsNullOrEmpty(variable), message);
+        }
+
+        internal static void IsNotNullOrEmptyString(string variable, string message = null)
+        {
+            Assert.IsFalse(string.IsNullOrEmpty(variable), message);
+        }
+
         internal static void Fail(string message, params object[] args)
         {
             Assert.IsTrue(false, message, args);

--- a/tests/Test.ADAL.NET/AdalTests.cs
+++ b/tests/Test.ADAL.NET/AdalTests.cs
@@ -120,7 +120,7 @@ namespace Test.ADAL.Common
 
             var credential = new ClientCredential(sts.ValidConfidentialClientId, sts.ValidConfidentialClientSecret);
             result = await context.AcquireTokenAsync(sts.ValidResource, credential);
-            Verify.IsNotNull(result.AccessToken);
+            Verify.IsNotNullOrEmptyString(result.AccessToken);
 
             result = await context.AcquireTokenAsync(null, credential);
             VerifyErrorResult(result, Sts.InvalidArgumentError, "resource");
@@ -145,7 +145,7 @@ namespace Test.ADAL.Common
 
             var certificate = new ClientAssertionCertificate(sts.ValidConfidentialClientId, new X509Certificate2(sts.ConfidentialClientCertificateName, sts.ConfidentialClientCertificatePassword));
             result = await context.AcquireTokenAsync(sts.ValidResource, certificate);
-            Verify.IsNotNull(result.AccessToken);
+            Verify.IsNotNullOrEmptyString(result.AccessToken);
 
             result = await context.AcquireTokenAsync(null, certificate);
             VerifyErrorResult(result, Sts.InvalidArgumentError, "resource");
@@ -205,7 +205,7 @@ namespace Test.ADAL.Common
             AuthenticationResultProxy result = null;
             ClientAssertion validCredential = CreateClientAssertion(sts.Authority, sts.ValidConfidentialClientId, sts.ConfidentialClientCertificateName, sts.ConfidentialClientCertificatePassword);
             result = await context.AcquireTokenAsync(sts.ValidResource, validCredential);
-            Verify.IsNotNull(result.AccessToken);
+            Verify.IsNotNullOrEmptyString(result.AccessToken);
 
             result = await context.AcquireTokenAsync(null, validCredential);
             VerifyErrorResult(result, Sts.InvalidArgumentError, "resource");
@@ -444,13 +444,13 @@ namespace Test.ADAL.Common
                 result[i] = await context.AcquireTokenAsync(sts.ValidResource, certificate);
                 Log.Comment("Error: " + result[i].Error);
                 Log.Comment("Error Description: " + result[i].ErrorDescription);
-                Verify.IsNotNull(result[i].AccessToken);
+                Verify.IsNotNullOrEmptyString(result[i].AccessToken);
             });
 
             result[0] = await context.AcquireTokenAsync(sts.ValidResource, certificate);
             Log.Comment("Error: " + result[0].Error);
             Log.Comment("Error Description: " + result[0].ErrorDescription);
-            Verify.IsNotNull(result[0].AccessToken);
+            Verify.IsNotNullOrEmptyString(result[0].AccessToken);
         }
 
         internal static async Task AcquireTokenByAuthorizationCodeWithCacheTest(Sts sts)
@@ -575,8 +575,8 @@ namespace Test.ADAL.Common
             Log.Comment("Verifying success result...");
 
             Verify.IsNotNull(result);
-            Verify.IsNotNull(result.AccessToken, "AuthenticationResult.AccessToken");
-            Verify.IsNotNull(result.RefreshToken, "AuthenticationResult.RefreshToken");
+            Verify.IsNotNullOrEmptyString(result.AccessToken, "AuthenticationResult.AccessToken");
+            Verify.IsNotNullOrEmptyString(result.RefreshToken, "AuthenticationResult.RefreshToken");
             long expiresIn = (long)(result.ExpiresOn - DateTime.UtcNow).TotalSeconds;
             Log.Comment("Verifying token expiration...");
             Verify.IsGreaterThanOrEqual(expiresIn, (long)0, "Token Expiration");

--- a/tests/Test.ADAL.WinRT.Unit/UnitTests.cs
+++ b/tests/Test.ADAL.WinRT.Unit/UnitTests.cs
@@ -97,7 +97,7 @@ namespace Test.ADAL.WinRT.Unit
             AuthenticationResult result = await context.AcquireTokenAsync(sts.ValidResource, sts.ValidClientId,
                 new Uri("ms-app://s-1-15-2-2097830667-3131301884-2920402518-3338703368-1480782779-4157212157-3811015497/"));
 
-            Verify.IsNotNull(result.Error);
+            Verify.IsNotNullOrEmptyString(result.Error);
             Verify.AreEqual(result.Error, Sts.InvalidArgumentError);
             Verify.IsTrue(result.ErrorDescription.Contains("redirectUri"));
             Verify.IsTrue(result.ErrorDescription.Contains("ms-app"));
@@ -105,7 +105,7 @@ namespace Test.ADAL.WinRT.Unit
             result = await context.AcquireTokenAsync(sts.ValidResource, sts.ValidClientId,
                 WebAuthenticationBroker.GetCurrentApplicationCallbackUri());
 
-            Verify.IsNotNull(result.Error);
+            Verify.IsNotNullOrEmptyString(result.Error);
             Verify.AreEqual(result.Error, Sts.InvalidArgumentError);
             Verify.IsTrue(result.ErrorDescription.Contains("redirectUri"));
             Verify.IsTrue(result.ErrorDescription.Contains("ms-app"));


### PR DESCRIPTION
Also, fixing instance discovery error type
