### PR TITLE
Fixing issue #114: Race condition can happen in parallel token requests ...

### DIFF
--- a/src/ADAL.NET.WindowsForms/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/ADAL.NET.WindowsForms/WindowsFormsWebAuthenticationDialogBase.cs
@@ -303,7 +303,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
 
             return new AdalServiceException(
                 AdalError.AuthenticationUiFailed,
-                string.Format("The browser based authentication dialog failed to complete for an unkown reason. StatusCode: {0}", statusCode)) { StatusCode = statusCode };
+                string.Format("The browser based authentication dialog failed to complete for an unknown reason. StatusCode: {0}", statusCode)) { StatusCode = statusCode };
         }
 
         protected static class DpiHelper

--- a/tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs
+++ b/tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs
@@ -65,16 +65,8 @@ namespace Test.ADAL.NET.Unit
                 Verify.IsNotNull(ex.ErrorCode, AdalError.UnknownUser);
             }
 
-            try
-            {
-                await UserRealmDiscoveryResponse.CreateByDiscoveryAsync(context.Authenticator.UserRealmUri, "ab@cd@ef", null);
-                Verify.Fail("Exception expected");
-            }
-            catch (AdalException ex)
-            {
-                Verify.IsNotNull(ex.ErrorCode, AdalError.UserRealmDiscoveryFailed);
-                Verify.IsNotNull(ex.InnerException);
-            }
+            userRealmResponse = await UserRealmDiscoveryResponse.CreateByDiscoveryAsync(context.Authenticator.UserRealmUri, "ab@cd@ef", null);
+            Verify.AreEqual("Unknown", userRealmResponse.AccountType);
 
             try
             {


### PR DESCRIPTION
...when sending client metrics
