### PR TITLE
Wrap a native call that may fail on alternative runtimes

### DIFF
--- a/src/ADAL.CommonDesktop/AdalIdHelper.cs
+++ b/src/ADAL.CommonDesktop/AdalIdHelper.cs
@@ -44,22 +44,30 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
             public static string GetProcessorArchitecture()
             {
-                SYSTEM_INFO systemInfo = new SYSTEM_INFO();
-                GetNativeSystemInfo(ref systemInfo);
-                switch (systemInfo.wProcessorArchitecture)
+                try
                 {
-                    case PROCESSOR_ARCHITECTURE_AMD64:
-                    case PROCESSOR_ARCHITECTURE_IA64:
-                        return "x64";
+                    SYSTEM_INFO systemInfo = new SYSTEM_INFO();
+                    GetNativeSystemInfo(ref systemInfo);
+                    switch (systemInfo.wProcessorArchitecture)
+                    {
+                        case PROCESSOR_ARCHITECTURE_AMD64:
+                        case PROCESSOR_ARCHITECTURE_IA64:
+                            return "x64";
 
-                    case PROCESSOR_ARCHITECTURE_ARM:
-                        return "ARM";
+                        case PROCESSOR_ARCHITECTURE_ARM:
+                            return "ARM";
 
-                    case PROCESSOR_ARCHITECTURE_INTEL:
-                        return "x86";
+                        case PROCESSOR_ARCHITECTURE_INTEL:
+                            return "x86";
 
-                    default:
-                        return "Unknown";
+                        default:
+                            return "Unknown";
+                    }
+                }
+                catch (System.EntryPointNotFoundException)
+                {
+                    // We're probably running on some kind of *NIX
+                    return "Unknown";
                 }
             }
 


### PR DESCRIPTION
Native calls like this prevent ADAL being run on alternative runtimes (e.g. Mono) - so catch the EntryPointNotFoundException and return an appropriate value.
"Unknown" is an acceptable response when this call succeeds, so it should be an acceptable response when the call fails too.

There are probably lots of other places that this happens, but this is the one that I'm hitting when trying to run ADAL on a headless *NIX system.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/125%23issuecomment-62084562%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/125%23issuecomment-67431299%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/125%23issuecomment-62084562%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Please%20send%20your%20pull%20request%20to%20%27servicing%27%20branch%20and%20we%20will%20take%20it.%20%27master%27%20branch%20is%20locked.%20Thanks.%22%2C%20%22created_at%22%3A%20%222014-11-07T01%3A55%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222014-12-18T02%3A09%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/125#issuecomment-62084562'>General Comment</a></b>
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> Please send your pull request to 'servicing' branch and we will take it. 'master' branch is locked. Thanks.

<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/125?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/125?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/125'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
