### PR TITLE
Fix for issue #129

### DIFF
--- a/src/ADAL.WinPhone/AcquireTokenInteractiveHandler.cs
+++ b/src/ADAL.WinPhone/AcquireTokenInteractiveHandler.cs
@@ -34,7 +34,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 tokenCache, 
                 (string)args.ContinuationData[WabArgName.Resource], 
                 (string)args.ContinuationData[WabArgName.ClientId],
-                new Uri((string)args.ContinuationData[WabArgName.RedirectUri]), 
+				GetRedirectUri((string)args.ContinuationData[WabArgName.RedirectUri]),	// Issue #129 - Windows Phone cannot handle ms-app URI's so use the placeholder URL for SSO
                 PromptBehavior.Always,  // This is simply to disable cache lookup. In fact, there is no authorize call at this point and promptBehavior is not applicable.
                 new UserIdentifier((string)args.ContinuationData[WabArgName.UserId],
                     (UserIdentifierType)((int)args.ContinuationData[WabArgName.UserIdType])),
@@ -45,6 +45,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             CallState callState = new CallState(new Guid((string)args.ContinuationData[WabArgName.CorrelationId]), false);
             this.authorizationResult = this.webUi.ProcessAuthorizationResult(args, callState);
         }
+
+		private static Uri GetRedirectUri(string url)
+		{
+			if (url.StartsWith("ms-app://", StringComparison.OrdinalIgnoreCase))
+			{
+				return Constant.SsoPlaceHolderUri;
+			}
+
+			return new Uri(url);
+		}
 
         protected override Task PreTokenRequest()
         {

--- a/src/ADAL.WinPhone/WebUI.cs
+++ b/src/ADAL.WinPhone/WebUI.cs
@@ -68,7 +68,15 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             switch (args.WebAuthenticationResult.ResponseStatus)
             {
                 case WebAuthenticationStatus.Success:
-                    result = OAuth2Response.ParseAuthorizeResponse(args.WebAuthenticationResult.ResponseData, callState);
+					// Issue #129 - Windows Phone cannot handle ms-app URI's so use the placeholder URL for SSO
+					var responseData = args.WebAuthenticationResult.ResponseData;
+					if(responseData.StartsWith("ms-app://", StringComparison.OrdinalIgnoreCase))
+					{
+						responseData = responseData.Substring(responseData.IndexOf('?'));
+						responseData = Constant.SsoPlaceHolderUri + responseData;
+					}
+
+					result = OAuth2Response.ParseAuthorizeResponse(responseData, callState);
                     break;
                 case WebAuthenticationStatus.ErrorHttp:
                     result = new AuthorizationResult(AdalError.AuthenticationFailed, args.WebAuthenticationResult.ResponseErrorDetail.ToString());


### PR DESCRIPTION
Added workarounds for URL parsing issue with ms-app URL's in Windows
Phone 8.1
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/137?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/137'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
