### PR TITLE
Persistent cache for both Android and iOS

### DIFF
--- a/src/ADAL.PCL.iOS/TokenCachePlugin.cs
+++ b/src/ADAL.PCL.iOS/TokenCachePlugin.cs
@@ -16,8 +16,11 @@
 // limitations under the License.
 //----------------------------------------------------------------------
 
+using Foundation;
+using Security;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -26,12 +29,66 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
     internal class TokenCachePlugin : ITokenCachePlugin
     {
+        private const string LocalSettingsContainerName = "ActiveDirectoryAuthenticationLibrary";
+
         public void BeforeAccess(TokenCacheNotificationArgs args)
         {
+            if (args.TokenCache.Count > 0)
+            {
+                // We assume that the cache has not changed since last write
+                return;
+            }
+
+            try
+            {
+                SecStatusCode res;
+                var rec = new SecRecord(SecKind.GenericPassword)
+                {
+                    Generic = NSData.FromString(LocalSettingsContainerName)
+                };
+
+                var match = SecKeyChain.QueryAsRecord(rec, out res);
+                if (res == SecStatusCode.Success && match != null && match.ValueData != null)
+                {
+                    byte[] dataBytes = match.ValueData.ToArray();
+                    if (dataBytes != null)
+                    {
+                        args.TokenCache.Deserialize(dataBytes);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                PlatformPlugin.Logger.Warning(null, "Failed to load cache: " + ex);
+                // Ignore as the cache seems to be corrupt
+            }
         }
         
         public void AfterAccess(TokenCacheNotificationArgs args)
         {
+            if (args.TokenCache.HasStateChanged)
+            {
+                try
+                {
+                    var s = new SecRecord(SecKind.GenericPassword)
+                    {
+                        Generic = NSData.FromString(LocalSettingsContainerName)
+                    };
+
+                    var err = SecKeyChain.Remove(s);
+                    if (args.TokenCache.Count > 0)
+                    {
+                        s.ValueData = NSData.FromArray(args.TokenCache.Serialize());
+                        err = SecKeyChain.Add(s);
+                    }
+
+                    args.TokenCache.HasStateChanged = false;
+                }
+                catch (Exception ex)
+                {
+                    PlatformPlugin.Logger.Warning(null, "Failed to save cache: " + ex);
+                }
+            }
         }
     }
 }

--- a/src/ADAL.PCL/TokenCache.cs
+++ b/src/ADAL.PCL/TokenCache.cs
@@ -54,8 +54,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                                 BeforeAccess = PlatformPlugin.TokenCachePlugin.BeforeAccess,
                                 AfterAccess = PlatformPlugin.TokenCachePlugin.AfterAccess
                             };
-
-            DefaultShared.BeforeAccess(null);
         }
 
         /// <summary>


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166%23discussion_r26719071%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166%23discussion_r26719583%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166%23discussion_r26721510%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166%23discussion_r26722865%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166%23discussion_r26779832%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166%23discussion_r26786015%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166%23discussion_r26786081%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%20a3b25b49ec67e0e19795e7be45fe889a08872300%20src/ADAL.PCL.Android/TokenCachePlugin.cs%2037%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166%23discussion_r26721510%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Need%20to%20check%20if%20it%20is%20acceptable%20to%20store%20without%20encryption.%20Otherwise%2C%20looks%20good%20to%20me.%22%2C%20%22created_at%22%3A%20%222015-03-19T00%3A34%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20should%20be%20OK%20for%20the%20preview.%20I%20have%20opened%20an%20issue%20to%20follow%20up%20on%20encryption.%22%2C%20%22created_at%22%3A%20%222015-03-19T18%3A53%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/ADAL.PCL.Android/TokenCachePlugin.cs%3AL16-94%22%7D%2C%20%22Pull%20a3b25b49ec67e0e19795e7be45fe889a08872300%20src/ADAL.PCL.iOS/TokenCachePlugin.cs%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166%23discussion_r26719071%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22iOS%20uses%20MSOpenTech.ADAL.1%20as%20the%20generic%20name.%20your%20container%20should%20be%20named%20the%20same%20otherwise%20if%20the%20developer%20moves%20to%20native%20library%2C%20and%20updates%20the%20app%2C%20the%20keychain%20data%20will%20not%20be%20accessible.%22%2C%20%22created_at%22%3A%20%222015-03-18T23%3A46%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20not%20sure%20if%20I%20follow.%20The%20structure%20of%20cache%20in%20ADAL%20.NET%20and%20ADAL%20iOS%20%28native%29%20are%20different%2C%20so%20how%20do%20you%20expect%20the%20cache%20from%20one%20to%20work%20for%20another%3F%20Or%20I%20may%20be%20missing%20something%20here.%22%2C%20%22created_at%22%3A%20%222015-03-18T23%3A55%3A23Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%2C%20%7B%22body%22%3A%20%22eventually%2C%20we%20will%20be%20same.%20It%20would%20be%20better%20to%20follow%20native%27s%20platform%27s%20naming%20convention.%22%2C%20%22created_at%22%3A%20%222015-03-19T01%3A05%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20am%20not%20sure%20if%20we%20ever%20need%20to%20switch%20from%20Xamarin%20to%20Native%20while%20expecting%20all%20the%20previous%20tokens%20be%20still%20usable%21%20However%2C%20if%20you%20still%20insist%2C%20then%20decode%20the%20name%20you%20suggest%20for%20me%3A%5Cr%5Cn%5Cr%5Cn1.%20Why%20MSOpenTech%3F%20We%20do%20not%20publish%20our%20binaries%20under%20that%20name%3F%5Cr%5Cn2.%20What%20is%20.1%20at%20the%20end%3F%20Is%20this%20the%20version%3F%20If%20so%2C%20.NET%20token%20cache%20schema%20is%20already%202.%20%22%2C%20%22created_at%22%3A%20%222015-03-19T17%3A50%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%2C%20%7B%22body%22%3A%20%22Discussed%20this%20with%20Kanishk%20offiline%20and%20he%20signed%20off.%22%2C%20%22created_at%22%3A%20%222015-03-19T18%3A52%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/ADAL.PCL.iOS/TokenCachePlugin.cs%3AL29-95%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull a3b25b49ec67e0e19795e7be45fe889a08872300 src/ADAL.PCL.iOS/TokenCachePlugin.cs 16'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166#discussion_r26719071'>File: src/ADAL.PCL.iOS/TokenCachePlugin.cs:L29-95</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> iOS uses MSOpenTech.ADAL.1 as the generic name. your container should be named the same otherwise if the developer moves to native library, and updates the app, the keychain data will not be accessible.
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> I am not sure if I follow. The structure of cache in ADAL .NET and ADAL iOS (native) are different, so how do you expect the cache from one to work for another? Or I may be missing something here.
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> eventually, we will be same. It would be better to follow native's platform's naming convention.
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> I am not sure if we ever need to switch from Xamarin to Native while expecting all the previous tokens be still usable! However, if you still insist, then decode the name you suggest for me:
1. Why MSOpenTech? We do not publish our binaries under that name?
2. What is .1 at the end? Is this the version? If so, .NET token cache schema is already 2.
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> Discussed this with Kanishk offiline and he signed off.
- [ ] <a href='#crh-comment-Pull a3b25b49ec67e0e19795e7be45fe889a08872300 src/ADAL.PCL.Android/TokenCachePlugin.cs 37'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166#discussion_r26721510'>File: src/ADAL.PCL.Android/TokenCachePlugin.cs:L16-94</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> Need to check if it is acceptable to store without encryption. Otherwise, looks good to me.
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> This should be OK for the preview. I have opened an issue to follow up on encryption.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/166'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>