### PR TITLE
escape xml chars in password field

### DIFF
--- a/src/ADAL.Common/WsTrustRequest.cs
+++ b/src/ADAL.Common/WsTrustRequest.cs
@@ -60,7 +60,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public static async Task<WsTrustResponse> SendRequestAsync(Uri url, UserCredential credential, CallState callState)
         {
             IHttpWebRequest request = NetworkPlugin.HttpWebRequestFactory.Create(url.AbsoluteUri);
-            request.ContentType = "application/soap+xml; charset=utf-8";
+            request.ContentType = "application/soap+xml;";
             if (credential.UserAuthType == UserAuthType.IntegratedAuth)
             {
                 SetKerberosOption(request);
@@ -109,7 +109,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             request.UseDefaultCredentials = true;
         }
 
-        private static StringBuilder BuildMessage(string appliesTo, string resource, UserCredential credential)
+        public static StringBuilder BuildMessage(string appliesTo, string resource, UserCredential credential)
         {
             // securityHeader will be empty string for Kerberos.
             StringBuilder securityHeaderBuilder = BuildSecurityHeader(credential);
@@ -138,7 +138,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 char[] passwordChars = null;
                 try
                 {
-                    passwordChars = credential.PasswordToCharArray();
+                    passwordChars = credential.EscapedPasswordToCharArray();
                     messageCredentialsBuilder.Append(passwordChars);
                 }
                 finally

--- a/src/ADAL.NET/UserCredential.cs
+++ b/src/ADAL.NET/UserCredential.cs
@@ -59,5 +59,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
             return (this.Password != null) ? this.Password.ToCharArray() : null;
         }
+
+        internal char[] EscapedPasswordToCharArray()
+        {
+            string password = this.Password;
+            password = password.Replace("&", "&amp;");
+            password = password.Replace("\"", "&quot;");
+            password = password.Replace("'", "&apos;");
+            password = password.Replace("<", "&lt;");
+            password = password.Replace(">", "&gt;");
+            return (password != null) ? password.ToCharArray() : null;
+        }
     }
 }

--- a/tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs
+++ b/tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs
@@ -25,6 +25,7 @@ using System.Xml.Linq;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Test.ADAL.Common;
+using System.Xml;
 
 namespace Test.ADAL.NET.Unit
 {
@@ -193,6 +194,24 @@ namespace Test.ADAL.NET.Unit
             {
                 Verify.IsNotNull(ex.ErrorCode, AdalError.FederatedServiceReturnedError);
                 Verify.IsNotNull(ex.InnerException);
+            }
+        }
+
+        [TestMethod]
+        [Description("WS-Trust Request Xml Format Test")]
+        [TestCategory("AdalDotNet")]
+        public async Task WsTrustRequestXmlFormatTest()
+        {
+            UserCredential cred = new UserCredential("user", "pass&<>\"'");
+            StringBuilder sb = WsTrustRequest.BuildMessage("https://appliesto", "resource", cred);
+            try
+            {
+                XmlDocument doc = new XmlDocument();
+                doc.LoadXml("<?xml version=\"1.0\"?>" + sb.ToString());
+            }
+            catch (Exception ex)
+            {
+                Verify.Fail("Not expected");
             }
         }
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/tushargupta51%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23issuecomment-114177489%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-06-22T16%3A53%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/803796%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/tushargupta51%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20c73bfab901f740c901e53c8b6976a94834bdaaa3%20src/ADAL.Common/WsTrustRequest.cs%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r32961186%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20this%20change%3F%22%2C%20%22created_at%22%3A%20%222015-06-22T17%3A38%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%2C%20%7B%22body%22%3A%20%22v3%20does%20not%20include%20that%2C%20so%20i%20made%20them%20similar.%22%2C%20%22created_at%22%3A%20%222015-06-22T18%3A34%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/ADAL.Common/WsTrustRequest.cs%3AL60-67%22%7D%2C%20%22Pull%20c73bfab901f740c901e53c8b6976a94834bdaaa3%20src/ADAL.NET/UserCredential.cs%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r32960542%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20don%27t%20you%20use%20a%20URL%20encoder%20instead%3F%22%2C%20%22created_at%22%3A%20%222015-06-22T17%3A33%3A03Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%2C%20%7B%22body%22%3A%20%22Why%20don%27t%20you%20use%20WebUtility.HtmlEncode%20instead%3F%22%2C%20%22created_at%22%3A%20%222015-06-22T17%3A37%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%2C%20%7B%22body%22%3A%20%22WebUtility.HtmlEncode%20is%20not%20the%20right%20one%20since%20it%20replaces%20single%20code%20to%20ampersand%2339%3B%20instead%20of%20ampersandapos%3B%22%2C%20%22created_at%22%3A%20%222015-06-22T18%3A34%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22Then%20isn%27t%20there%20any%20other%20method%20to%20do%20the%20right%20thing%3F%20Also%2C%20is%20the%20list%20of%20characters%20you%20replace%20above%20complete%3F%22%2C%20%22created_at%22%3A%20%222015-06-22T23%3A43%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%2C%20%7B%22body%22%3A%20%22List%20is%20complete%20for%20xml.%22%2C%20%22created_at%22%3A%20%222015-06-23T02%3A26%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/ADAL.NET/UserCredential.cs%3AL59-75%22%7D%2C%20%22Pull%20c73bfab901f740c901e53c8b6976a94834bdaaa3%20tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs%2032%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r32996975%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Signed%20off%20with%20a%20comment.%22%2C%20%22created_at%22%3A%20%222015-06-22T23%3A43%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3790715%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/afshins%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs%3AL197-221%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23issuecomment-114177489%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r32960542%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r32961051%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r32961186%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r32967538%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r32967639%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r32996962%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r32996975%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209%23discussion_r33004548%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/tushargupta51'><img src='https://avatars.githubusercontent.com/u/803796?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull c73bfab901f740c901e53c8b6976a94834bdaaa3 src/ADAL.NET/UserCredential.cs 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209#discussion_r32960542'>File: src/ADAL.NET/UserCredential.cs:L59-75</a></b>
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> Why don't you use a URL encoder instead?
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> Why don't you use WebUtility.HtmlEncode instead?
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> WebUtility.HtmlEncode is not the right one since it replaces single code to ampersand#39; instead of ampersandapos;
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> Then isn't there any other method to do the right thing? Also, is the list of characters you replace above complete?
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> List is complete for xml.
- [ ] <a href='#crh-comment-Pull c73bfab901f740c901e53c8b6976a94834bdaaa3 src/ADAL.Common/WsTrustRequest.cs 5'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209#discussion_r32961186'>File: src/ADAL.Common/WsTrustRequest.cs:L60-67</a></b>
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> Why this change?
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> v3 does not include that, so i made them similar.
- [ ] <a href='#crh-comment-Pull c73bfab901f740c901e53c8b6976a94834bdaaa3 tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs 32'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209#discussion_r32996975'>File: tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs:L197-221</a></b>
- <a href='https://github.com/afshins'><img border=0 src='https://avatars.githubusercontent.com/u/3790715?v=3' height=16 width=16'></a> Signed off with a comment.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/209'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>