### PR TITLE
support for WS-Trust 2005

### DIFF
--- a/src/ADAL.Common/AcquireTokenNonInteractiveHandler.cs
+++ b/src/ADAL.Common/AcquireTokenNonInteractiveHandler.cs
@@ -102,10 +102,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                         throw new AdalException(AdalError.MissingFederationMetadataUrl);
                     }
 
-                    Uri wsTrustUrl = await MexParser.FetchWsTrustAddressFromMexAsync(userRealmResponse.FederationMetadataUrl, this.userCredential.UserAuthType, this.CallState);
-                    Logger.Information(this.CallState, "WS-Trust endpoint '{0}' fetched from MEX at '{1}'", wsTrustUrl, userRealmResponse.FederationMetadataUrl);
+                    WsTrustAddress wsTrustAddress = await MexParser.FetchWsTrustAddressFromMexAsync(userRealmResponse.FederationMetadataUrl, this.userCredential.UserAuthType, this.CallState);
+                    Logger.Information(this.CallState, "WS-Trust endpoint '{0}' fetched from MEX at '{1}'", wsTrustAddress.Uri, userRealmResponse.FederationMetadataUrl);
 
-                    WsTrustResponse wsTrustResponse = await WsTrustRequest.SendRequestAsync(wsTrustUrl, this.userCredential, this.CallState);
+                    WsTrustResponse wsTrustResponse = await WsTrustRequest.SendRequestAsync(wsTrustAddress, this.userCredential, this.CallState);
                     Logger.Information(this.CallState, "Token of type '{0}' acquired from WS-Trust endpoint", wsTrustResponse.TokenType);
 
                     // We assume that if the response token type is not SAML 1.1, it is SAML 2

--- a/src/ADAL.Common/Constants.cs
+++ b/src/ADAL.Common/Constants.cs
@@ -330,7 +330,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public static readonly XNamespace Soap12 = "http://schemas.xmlsoap.org/wsdl/soap12/";
         public static readonly XNamespace Wsa10 = "http://www.w3.org/2005/08/addressing";
         public static readonly XNamespace Trust = "http://docs.oasis-open.org/ws-sx/ws-trust/200512";
+        public static readonly XNamespace Trust2005 = "http://schemas.xmlsoap.org/ws/2005/02/trust";
         public static readonly XNamespace Issue = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue";
+        public static readonly XNamespace Issue2005 = "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue";
         public static readonly XNamespace SoapEnvelope = "http://www.w3.org/2003/05/soap-envelope";
     }
 }

--- a/src/ADAL.Common/MexParser.cs
+++ b/src/ADAL.Common/MexParser.cs
@@ -26,8 +26,23 @@ using System.Xml.Linq;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
+    internal enum WsTrustVersion
+    {
+        WsTrust13,
+        WsTrust2005
+    }
+
+    internal class WsTrustAddress
+    {
+        public Uri Uri { get; set; }
+
+        public WsTrustVersion Version { get; set; }
+    }
+
     internal class MexPolicy
     {
+        public WsTrustVersion Version { get; set; }
+
         public string Id { get; set; }   
 
         public UserAuthType AuthType { get; set; }
@@ -39,7 +54,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     {
         private const string WsTrustSoapTransport = "http://schemas.xmlsoap.org/soap/http";
 
-        public static async Task<Uri> FetchWsTrustAddressFromMexAsync(string federationMetadataUrl, UserAuthType userAuthType, CallState callState)
+        public static async Task<WsTrustAddress> FetchWsTrustAddressFromMexAsync(string federationMetadataUrl, UserAuthType userAuthType, CallState callState)
         {
             XDocument mexDocument = await FetchMexAsync(federationMetadataUrl, callState);
             return ExtractWsTrustAddressFromMex(mexDocument, userAuthType, callState);
@@ -70,20 +85,25 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return mexDocument;
         }
 
-        internal static Uri ExtractWsTrustAddressFromMex(XDocument mexDocument, UserAuthType userAuthType, CallState callState)
+        internal static WsTrustAddress ExtractWsTrustAddressFromMex(XDocument mexDocument, UserAuthType userAuthType, CallState callState)
         {
-            Uri url;
-
+            WsTrustAddress address = null;
+            MexPolicy policy = null;
             try
             {
                 Dictionary<string, MexPolicy> policies = ReadPolicies(mexDocument);
                 Dictionary<string, MexPolicy> bindings = ReadPolicyBindings(mexDocument, policies);
                 SetPolicyEndpointAddresses(mexDocument, bindings);
                 Random random = new Random();
-                MexPolicy policy = policies.Values.Where(p => p.Url != null && p.AuthType == userAuthType).OrderBy(p => random.Next()).FirstOrDefault();
+                //try ws-trust 1.3 first
+                policy = policies.Values.Where(p => p.Url != null && p.AuthType == userAuthType && p.Version == WsTrustVersion.WsTrust13).OrderBy(p => random.Next()).FirstOrDefault() ??
+                         policies.Values.Where(p => p.Url != null && p.AuthType == userAuthType).OrderBy(p => random.Next()).FirstOrDefault();
+
                 if (policy != null)
                 {
-                    url = policy.Url;
+                    address = new WsTrustAddress();
+                    address.Uri  = policy.Url;
+                    address.Version = policy.Version;
                 }
                 else if (userAuthType == UserAuthType.IntegratedAuth)
                 {
@@ -99,7 +119,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 throw new AdalException(AdalError.ParsingWsMetadataExchangeFailed, ex);
             }
 
-            return url;
+            return address;
         }
 
         private static Dictionary<string, MexPolicy> ReadPolicies(XContainer mexDocument)
@@ -117,16 +137,23 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 IEnumerable<XElement> all = exactlyOnePolicy.Descendants(XmlNamespace.Wsp + "All");
                 foreach (XElement element in all)
                 {
+                    XNamespace securityPolicy = XmlNamespace.Sp;
                     XElement auth = element.Elements(XmlNamespace.Http + "NegotiateAuthentication").FirstOrDefault();
                     if (auth != null)
                     {
-                        AddPolicy(policies, policy, UserAuthType.IntegratedAuth);
+                        AddPolicy(policies, policy, UserAuthType.IntegratedAuth, securityPolicy.Equals(XmlNamespace.Sp2005));
                     }
 
-                    auth = element.Elements(XmlNamespace.Sp + "SignedEncryptedSupportingTokens").FirstOrDefault();
+                    auth = element.Elements(securityPolicy + "SignedEncryptedSupportingTokens").FirstOrDefault();
                     if (auth == null)
                     {
-                        continue;
+                        //switch to sp2005
+                        securityPolicy = XmlNamespace.Sp2005;
+                        if ((auth = element.Elements(securityPolicy + "SignedSupportingTokens").FirstOrDefault()) ==
+                            null)
+                        {
+                            continue;
+                        }
                     }
 
                     XElement wspPolicy = auth.Elements(XmlNamespace.Wsp + "Policy").FirstOrDefault();
@@ -135,7 +162,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                         continue;
                     }
 
-                    XElement usernameToken = wspPolicy.Elements(XmlNamespace.Sp + "UsernameToken").FirstOrDefault();
+                    XElement usernameToken = wspPolicy.Elements(securityPolicy + "UsernameToken").FirstOrDefault();
                     if (usernameToken == null)
                     {
                         continue;
@@ -147,10 +174,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                         continue;
                     }
 
-                    XElement wssUsernameToken10 = wspPolicy2.Elements(XmlNamespace.Sp + "WssUsernameToken10").FirstOrDefault();
+                    XElement wssUsernameToken10 = wspPolicy2.Elements(securityPolicy + "WssUsernameToken10").FirstOrDefault();
                     if (wssUsernameToken10 != null)
                     {
-                        AddPolicy(policies, policy, UserAuthType.UsernamePassword);
+                        AddPolicy(policies, policy, UserAuthType.UsernamePassword, securityPolicy.Equals(XmlNamespace.Sp2005));
                     }
                 }
             }
@@ -192,7 +219,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     }
 
                     XAttribute soapAction = soapOperation.Attribute("soapAction");
-                    if (soapAction == null || string.Compare(XmlNamespace.Issue.ToString(), soapAction.Value, StringComparison.OrdinalIgnoreCase) != 0)
+                    if (soapAction == null || (string.Compare(XmlNamespace.Issue.ToString(), soapAction.Value, StringComparison.OrdinalIgnoreCase) != 0
+                        && string.Compare(XmlNamespace.Issue2005.ToString(), soapAction.Value, StringComparison.OrdinalIgnoreCase) != 0))
                     {
                         continue;
                     }
@@ -247,7 +275,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
         }
 
-        private static void AddPolicy(IDictionary<string, MexPolicy> policies, XElement policy, UserAuthType policyAuthType)
+        private static void AddPolicy(IDictionary<string, MexPolicy> policies, XElement policy, UserAuthType policyAuthType, bool isWsTrust2005)
         {
             XElement binding = policy.Descendants(XmlNamespace.Sp + "TransportBinding").FirstOrDefault()
                           ?? policy.Descendants(XmlNamespace.Sp2005 + "TransportBinding").FirstOrDefault();
@@ -255,9 +283,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             if (binding != null)
             {
                 XAttribute id = policy.Attribute(XmlNamespace.Wsu + "Id");
+                WsTrustVersion version = WsTrustVersion.WsTrust13;
+
+                if (isWsTrust2005)
+                {
+                    version = WsTrustVersion.WsTrust2005;
+                }
+
                 if (id != null)
                 {
-                    policies.Add("#" + id.Value, new MexPolicy { Id = id.Value, AuthType = policyAuthType });
+                    policies.Add("#" + id.Value, new MexPolicy { Id = id.Value, AuthType = policyAuthType, Version = version });
                 }
             }
         }

--- a/src/ADAL.Common/WsTrustRequest.cs
+++ b/src/ADAL.Common/WsTrustRequest.cs
@@ -193,12 +193,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
                 // Expiry is 10 minutes after creation
                 DateTime expiryTime = currentTime.AddMinutes(10);    
-                string expiryTimString = DateTimeHelper.BuildTimeString(expiryTime);
+                string expiryTimeString = DateTimeHelper.BuildTimeString(expiryTime);
 
                     securityHeaderBuilder.AppendFormat(
                         "<o:Security s:mustUnderstand='1' xmlns:o='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'><u:Timestamp u:Id='_0'><u:Created>{0}</u:Created><u:Expires>{1}</u:Expires></u:Timestamp>{2}</o:Security>",
                         currentTimeString,
-                        expiryTimString,
+                        expiryTimeString,
                         messageCredentialsBuilder);
 
                 messageCredentialsBuilder.SecureClear();

--- a/src/ADAL.Common/WsTrustRequest.cs
+++ b/src/ADAL.Common/WsTrustRequest.cs
@@ -34,23 +34,23 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         // If both are specified, the wst:AppliesTo field takes precedence.
         // If we don't specify TokenType, it will return SAML v1.1
         private const string WsTrustEnvelopeTemplate =
-            @"<s:Envelope xmlns:s='http://www.w3.org/2003/05/soap-envelope' xmlns:a='http://www.w3.org/2005/08/addressing' xmlns:u='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd'>
+            @"<s:Envelope xmlns:s='http://www.w3.org/2003/05/soap-envelope' xmlns:a='http://www.w3.org/2005/08/addressing' xmlns:u='{0}'>
               <s:Header>
-              <a:Action s:mustUnderstand='1'>http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue</a:Action>
-              <a:messageID>urn:uuid:{0}</a:messageID>
+              <a:Action s:mustUnderstand='1'>{1}</a:Action>
+              <a:messageID>urn:uuid:{2}</a:messageID>
               <a:ReplyTo><a:Address>http://www.w3.org/2005/08/addressing/anonymous</a:Address></a:ReplyTo>
-              <a:To s:mustUnderstand='1'>{1}</a:To>
-              {2}
+              <a:To s:mustUnderstand='1'>{3}</a:To>
+              {4}
               </s:Header>
               <s:Body>
-              <trust:RequestSecurityToken xmlns:trust='http://docs.oasis-open.org/ws-sx/ws-trust/200512'>
+              <trust:RequestSecurityToken xmlns:trust='{5}'>
               <wsp:AppliesTo xmlns:wsp='http://schemas.xmlsoap.org/ws/2004/09/policy'>
               <a:EndpointReference>
-              <a:Address>{3}</a:Address>
+              <a:Address>{6}</a:Address>
               </a:EndpointReference>
               </wsp:AppliesTo>
-              <trust:KeyType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer</trust:KeyType>
-              <trust:RequestType>http://docs.oasis-open.org/ws-sx/ws-trust/200512/Issue</trust:RequestType>
+              <trust:KeyType>{7}</trust:KeyType>
+              <trust:RequestType>{8}</trust:RequestType>
               </trust:RequestSecurityToken>
               </s:Body>
               </s:Envelope>";
@@ -58,19 +58,25 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         // We currently send this for all requests. We may need to change it in the future.
         private const string DefaultAppliesTo = "urn:federation:MicrosoftOnline";
 
-        public static async Task<WsTrustResponse> SendRequestAsync(Uri url, UserCredential credential, CallState callState)
+        public static async Task<WsTrustResponse> SendRequestAsync(WsTrustAddress wsTrustAddress, UserCredential credential, CallState callState)
         {
-            IHttpWebRequest request = NetworkPlugin.HttpWebRequestFactory.Create(url.AbsoluteUri);
+            IHttpWebRequest request = NetworkPlugin.HttpWebRequestFactory.Create(wsTrustAddress.Uri.AbsoluteUri);
             request.ContentType = "application/soap+xml;";
             if (credential.UserAuthType == UserAuthType.IntegratedAuth)
             {
                 SetKerberosOption(request);
             }
 
-            StringBuilder messageBuilder = BuildMessage(DefaultAppliesTo, url.AbsoluteUri, credential);
+            StringBuilder messageBuilder = BuildMessage(DefaultAppliesTo, wsTrustAddress, credential);
+            string soapAction = XmlNamespace.Issue.ToString();
+            if (wsTrustAddress.Version == WsTrustVersion.WsTrust2005)
+            {
+                soapAction = XmlNamespace.Issue2005.ToString();
+            }
+
             Dictionary<string, string> headers = new Dictionary<string, string> 
             { 
-                { "SOAPAction", XmlNamespace.Issue.ToString() }
+                { "SOAPAction", soapAction }
             };
 
             WsTrustResponse wstResponse;
@@ -79,7 +85,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             {
                 HttpHelper.SetPostRequest(request, new RequestParameters(messageBuilder), callState, headers);
                 IHttpWebResponse response = await request.GetResponseSyncOrAsync(callState);
-                wstResponse = WsTrustResponse.CreateFromResponse(response.GetResponseStream());
+                wstResponse = WsTrustResponse.CreateFromResponse(response.GetResponseStream(), wsTrustAddress.Version);
             }
             catch (WebException ex)
             {
@@ -97,7 +103,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
                 throw new AdalServiceException(
                     AdalError.FederatedServiceReturnedError,
-                    string.Format(AdalErrorMessage.FederatedServiceReturnedErrorTemplate, url, errorMessage),
+                    string.Format(AdalErrorMessage.FederatedServiceReturnedErrorTemplate, wsTrustAddress.Uri, errorMessage),
                     null,
                     ex);
             }
@@ -110,15 +116,33 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             request.UseDefaultCredentials = true;
         }
 
-        public static StringBuilder BuildMessage(string appliesTo, string resource, UserCredential credential)
+        public static StringBuilder BuildMessage(string appliesTo, WsTrustAddress wsTrustAddress,
+            UserCredential credential)
         {
             // securityHeader will be empty string for Kerberos.
-            StringBuilder securityHeaderBuilder = BuildSecurityHeader(credential);
+            StringBuilder securityHeaderBuilder = BuildSecurityHeader(wsTrustAddress, credential);
 
             string guid = Guid.NewGuid().ToString();
             StringBuilder messageBuilder = new StringBuilder(MaxExpectedMessageSize);
-            messageBuilder.AppendFormat(WsTrustEnvelopeTemplate, guid, resource, securityHeaderBuilder, appliesTo);
+            String schemaLocation = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
+            String soapAction = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue";
+            String rstTrustNamespace = "http://docs.oasis-open.org/ws-sx/ws-trust/200512";
+            String keyType = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/Bearer";
+            String requestType = "http://docs.oasis-open.org/ws-sx/ws-trust/200512/Issue";
 
+            if (wsTrustAddress.Version == WsTrustVersion.WsTrust2005)
+            {
+                soapAction = "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue";
+                rstTrustNamespace = "http://schemas.xmlsoap.org/ws/2005/02/trust";
+                keyType = "http://schemas.xmlsoap.org/ws/2005/05/identity/NoProofKey";
+                requestType = "http://schemas.xmlsoap.org/ws/2005/02/trust/Issue";
+            }
+
+            messageBuilder.AppendFormat(WsTrustEnvelopeTemplate, 
+                schemaLocation, soapAction,
+                                guid, wsTrustAddress.Uri, securityHeaderBuilder,
+                                rstTrustNamespace, appliesTo, keyType,
+                                requestType);
             securityHeaderBuilder.SecureClear();
 
             return messageBuilder;
@@ -134,7 +158,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
            return escapeStr;
        }
 
-        private static StringBuilder BuildSecurityHeader(UserCredential credential)
+        private static StringBuilder BuildSecurityHeader(WsTrustAddress address, UserCredential credential)
         {
             StringBuilder securityHeaderBuilder = new StringBuilder(MaxExpectedMessageSize);
 
@@ -143,9 +167,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             {
                 StringBuilder messageCredentialsBuilder = new StringBuilder(MaxExpectedMessageSize);
                 string guid = Guid.NewGuid().ToString();
-
-                messageCredentialsBuilder.AppendFormat("<o:UsernameToken u:Id='uuid-{0}'><o:Username>{1}</o:Username><o:Password>", guid, credential.UserName);
-
+                    messageCredentialsBuilder.AppendFormat(
+                        "<o:UsernameToken u:Id='uuid-{0}'><o:Username>{1}</o:Username><o:Password>", guid,
+                        credential.UserName);
                 char[] passwordChars = null;
                 try
                 {
@@ -159,8 +183,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     passwordChars.SecureClear();
                 }
 
-                messageCredentialsBuilder.AppendFormat("</o:Password></o:UsernameToken>");
-
+                    messageCredentialsBuilder.AppendFormat("</o:Password></o:UsernameToken>");
+                
                 //
                 // Timestamp the message
                 //
@@ -171,11 +195,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 DateTime expiryTime = currentTime.AddMinutes(10);    
                 string expiryTimString = DateTimeHelper.BuildTimeString(expiryTime);
 
-                securityHeaderBuilder.AppendFormat(
-                    "<o:Security s:mustUnderstand='1' xmlns:o='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'><u:Timestamp u:Id='_0'><u:Created>{0}</u:Created><u:Expires>{1}</u:Expires></u:Timestamp>{2}</o:Security>", 
-                    currentTimeString, 
-                    expiryTimString, 
-                    messageCredentialsBuilder);
+                    securityHeaderBuilder.AppendFormat(
+                        "<o:Security s:mustUnderstand='1' xmlns:o='http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd'><u:Timestamp u:Id='_0'><u:Created>{0}</u:Created><u:Expires>{1}</u:Expires></u:Timestamp>{2}</o:Security>",
+                        currentTimeString,
+                        expiryTimString,
+                        messageCredentialsBuilder);
 
                 messageCredentialsBuilder.SecureClear();
             }

--- a/src/ADAL.Common/WsTrustResponse.cs
+++ b/src/ADAL.Common/WsTrustResponse.cs
@@ -32,10 +32,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public string TokenType { get; private set; }
 
-        public static WsTrustResponse CreateFromResponse(Stream responseStream)
+        public static WsTrustResponse CreateFromResponse(Stream responseStream, WsTrustVersion version)
         {
             XDocument responseDocument = ReadDocumentFromResponse(responseStream);
-            return CreateFromResponseDocument(responseDocument);
+            return CreateFromResponseDocument(responseDocument, version);
         }
 
         public static string ReadErrorResponse(XDocument responseDocument, CallState callState)
@@ -87,34 +87,51 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
         }
 
-        internal static WsTrustResponse CreateFromResponseDocument(XDocument responseDocument)
+        internal static WsTrustResponse CreateFromResponseDocument(XDocument responseDocument, WsTrustVersion version)
         {
             Dictionary<string, string> tokenResponseDictionary = new Dictionary<string, string>();
 
             try
             {
-                XElement requestSecurityTokenResponseCollection =
-                    responseDocument.Descendants(XmlNamespace.Trust + "RequestSecurityTokenResponseCollection").FirstOrDefault();
-
-                if (requestSecurityTokenResponseCollection != null)
+                XNamespace t = XmlNamespace.Trust;
+                if (version == WsTrustVersion.WsTrust2005)
                 {
-                    IEnumerable<XElement> tokenResponses = responseDocument.Descendants(XmlNamespace.Trust + "RequestSecurityTokenResponse");
+                    t = XmlNamespace.Trust2005;
+                }
+                bool parseResponse = true;
+                if (version == WsTrustVersion.WsTrust13)
+                {
+                    XElement requestSecurityTokenResponseCollection =
+                        responseDocument.Descendants(t + "RequestSecurityTokenResponseCollection").FirstOrDefault();
+
+                    if (requestSecurityTokenResponseCollection == null)
+                    {
+                        parseResponse = false;
+                    }
+                }
+
+                if (parseResponse)
+                {
+                    IEnumerable<XElement> tokenResponses =
+                        responseDocument.Descendants(t + "RequestSecurityTokenResponse");
                     foreach (var tokenResponse in tokenResponses)
                     {
-                        XElement tokenTypeElement = tokenResponse.Elements(XmlNamespace.Trust + "TokenType").FirstOrDefault();
+                        XElement tokenTypeElement = tokenResponse.Elements(t + "TokenType").FirstOrDefault();
                         if (tokenTypeElement == null)
                         {
                             continue;
                         }
 
-                        XElement requestedSecurityToken = tokenResponse.Elements(XmlNamespace.Trust + "RequestedSecurityToken").FirstOrDefault();
+                        XElement requestedSecurityToken =
+                            tokenResponse.Elements(t + "RequestedSecurityToken").FirstOrDefault();
                         if (requestedSecurityToken == null)
                         {
                             continue;
                         }
 
                         // TODO #123622: We need to disable formatting due to a potential service bug. Remove the ToString argument when problem is fixed.
-                        tokenResponseDictionary.Add(tokenTypeElement.Value, requestedSecurityToken.FirstNode.ToString(SaveOptions.DisableFormatting));
+                        tokenResponseDictionary.Add(tokenTypeElement.Value,
+                            requestedSecurityToken.FirstNode.ToString(SaveOptions.DisableFormatting));
                     }
                 }
             }

--- a/tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs
+++ b/tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs
@@ -31,6 +31,7 @@ namespace Test.ADAL.NET.Unit
 {
     [TestClass]
     [DeploymentItem("TestMex.xml")]
+    [DeploymentItem("TestMex2005.xml")]
     public class NonInteractiveTests : AdalTestsBase
     {
         // Switch this to true to run test against actual service
@@ -102,6 +103,26 @@ namespace Test.ADAL.NET.Unit
             {
                 Verify.AreEqual(ex.ErrorCode, AdalError.AccessingWsMetadataExchangeFailed);
             }
+        }
+
+        [TestMethod]
+        [Description("WS-Trust Address Extraction Test")]
+        [TestCategory("AdalDotNet")]
+        public async Task WsTrust2005AddressExtractionTest()
+        {
+            XDocument mexDocument = null;
+            using (Stream stream = new FileStream("TestMex2005.xml", FileMode.Open))
+            {
+                mexDocument = XDocument.Load(stream);
+            }
+
+            Verify.IsNotNull(mexDocument);
+            WsTrustAddress wsTrustAddress = MexParser.ExtractWsTrustAddressFromMex(mexDocument, UserAuthType.IntegratedAuth, null);
+            Verify.IsNotNull(wsTrustAddress);
+            Verify.AreEqual(wsTrustAddress.Version, WsTrustVersion.WsTrust13);
+            wsTrustAddress = MexParser.ExtractWsTrustAddressFromMex(mexDocument, UserAuthType.UsernamePassword, null);
+            Verify.IsNotNull(wsTrustAddress);
+            Verify.AreEqual(wsTrustAddress.Version, WsTrustVersion.WsTrust2005);
         }
 
         [TestMethod]

--- a/tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs
+++ b/tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs
@@ -115,7 +115,7 @@ namespace Test.ADAL.NET.Unit
             UserRealmDiscoveryResponse userRealmResponse = await UserRealmDiscoveryResponse.CreateByDiscoveryAsync(context.Authenticator.UserRealmUri, federatedSts.ValidUserName, null);
             XDocument mexDocument = await FecthMexAsync(userRealmResponse.FederationMetadataUrl);
             Verify.IsNotNull(mexDocument);
-            Uri wsTrustAddress = MexParser.ExtractWsTrustAddressFromMex(mexDocument, UserAuthType.IntegratedAuth, null);
+            WsTrustAddress wsTrustAddress = MexParser.ExtractWsTrustAddressFromMex(mexDocument, UserAuthType.IntegratedAuth, null);
             Verify.IsNotNull(wsTrustAddress);
             wsTrustAddress = MexParser.ExtractWsTrustAddressFromMex(mexDocument, UserAuthType.UsernamePassword, null);
             Verify.IsNotNull(wsTrustAddress);
@@ -136,7 +136,7 @@ namespace Test.ADAL.NET.Unit
 
             try
             {
-                string modifiedMexDocumentContent = mexDocumentContent.Replace(wsTrustAddress.AbsoluteUri, string.Empty);
+                string modifiedMexDocumentContent = mexDocumentContent.Replace(wsTrustAddress.Uri.AbsoluteUri, string.Empty);
                 XDocument modifiedMexDocument = ConvertStringToXDocument(modifiedMexDocumentContent);
                 MexParser.ExtractWsTrustAddressFromMex(modifiedMexDocument, UserAuthType.UsernamePassword, null);
                 Verify.Fail("Exception expected");
@@ -159,7 +159,7 @@ namespace Test.ADAL.NET.Unit
             UserRealmDiscoveryResponse userRealmResponse = await UserRealmDiscoveryResponse.CreateByDiscoveryAsync(context.Authenticator.UserRealmUri, federatedSts.ValidUserName, null);
             XDocument mexDocument = await FecthMexAsync(userRealmResponse.FederationMetadataUrl);
             Verify.IsNotNull(mexDocument);
-            Uri wsTrustAddress = MexParser.ExtractWsTrustAddressFromMex(mexDocument, UserAuthType.UsernamePassword, null);
+            WsTrustAddress wsTrustAddress = MexParser.ExtractWsTrustAddressFromMex(mexDocument, UserAuthType.UsernamePassword, null);
             Verify.IsNotNull(wsTrustAddress);
 
             WsTrustResponse wstResponse = await WsTrustRequest.SendRequestAsync(wsTrustAddress, new UserCredential(federatedSts.ValidUserName, federatedSts.ValidPassword), null);
@@ -178,7 +178,8 @@ namespace Test.ADAL.NET.Unit
 
             try
             {
-                await WsTrustRequest.SendRequestAsync(new Uri(wsTrustAddress.AbsoluteUri + "x"), new UserCredential(federatedSts.ValidUserName, federatedSts.ValidPassword), null);
+                await WsTrustRequest.SendRequestAsync(new WsTrustAddress{Uri = new Uri(wsTrustAddress.Uri.AbsoluteUri + "x")}, 
+                    new UserCredential(federatedSts.ValidUserName, federatedSts.ValidPassword), null);
             }
             catch (AdalException ex)
             {
@@ -188,7 +189,7 @@ namespace Test.ADAL.NET.Unit
 
             try
             {
-                await WsTrustRequest.SendRequestAsync(new Uri(wsTrustAddress.AbsoluteUri), new UserCredential(federatedSts.ValidUserName, "InvalidPassword"), null);
+                await WsTrustRequest.SendRequestAsync(new WsTrustAddress { Uri = new Uri(wsTrustAddress.Uri.AbsoluteUri) }, new UserCredential(federatedSts.ValidUserName, "InvalidPassword"), null);
             }
             catch (AdalException ex)
             {
@@ -203,7 +204,7 @@ namespace Test.ADAL.NET.Unit
         public async Task WsTrustRequestXmlFormatTest()
         {
             UserCredential cred = new UserCredential("user", "pass&<>\"'");
-            StringBuilder sb = WsTrustRequest.BuildMessage("https://appliesto", "resource", cred);
+            StringBuilder sb = WsTrustRequest.BuildMessage("https://appliesto", new WsTrustAddress { Uri = new Uri("resource") }, cred);
             try
             {
                 XmlDocument doc = new XmlDocument();

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -144,6 +144,9 @@
     <Content Include="TestMex.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="TestMex2005.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\Test.ADAL.Common\Certs\valid_cert.pfx">

--- a/tests/Test.ADAL.NET.Unit/TestMex2005.xml
+++ b/tests/Test.ADAL.NET.Unit/TestMex2005.xml
@@ -1,0 +1,814 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:t="http://schemas.xmlsoap.org/ws/2005/02/trust" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:tns="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice" xmlns:msc="http://schemas.microsoft.com/ws/2005/12/wsdl/contract" xmlns:wsam="http://www.w3.org/2007/05/addressing/metadata" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:wsa10="http://www.w3.org/2005/08/addressing" xmlns:wsa="http://schemas.xmlsoap.org/ws/2004/08/addressing" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl" xmlns:wsx="http://schemas.xmlsoap.org/ws/2004/09/mex" xmlns:wsap="http://schemas.xmlsoap.org/ws/2004/08/addressing/policy" xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" xmlns:trust="http://docs.oasis-open.org/ws-sx/ws-trust/200512" xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy" name="SecurityTokenService" targetNamespace="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice">
+  <wsp:Policy wsu:Id="CustomBinding_IWSTrustFeb2005Async_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <msis:DomainInternet xmlns:msis="http://schemas.microsoft.com/ws/2009/12/identityserver/"/>
+        <http:NegotiateAuthentication xmlns:http="http://schemas.microsoft.com/ws/06/2004/policy/http"/>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrustFeb2005Async_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:RequireThumbprintReference/>
+                <sp:WssX509V3Token10/>
+              </wsp:Policy>
+            </sp:X509Token>
+            <mssp:RsaToken xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true"/>
+            <sp:SignedParts>
+              <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+            </sp:SignedParts>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportRefThumbprint/>
+          </wsp:Policy>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrustFeb2005Async1_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="true"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="UserNameWSTrustBinding_IWSTrustFeb2005Async_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SymmetricBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:ProtectionToken>
+              <wsp:Policy>
+                <sp:X509Token sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never">
+                  <wsp:Policy>
+                    <sp:RequireDerivedKeys/>
+                    <sp:RequireThumbprintReference/>
+                    <sp:WssX509V3Token10/>
+                  </wsp:Policy>
+                </sp:X509Token>
+              </wsp:Policy>
+            </sp:ProtectionToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+            <sp:EncryptSignature/>
+            <sp:OnlySignEntireHeadersAndBody/>
+          </wsp:Policy>
+        </sp:SymmetricBinding>
+        <sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:WssUsernameToken10/>
+              </wsp:Policy>
+            </sp:UsernameToken>
+          </wsp:Policy>
+        </sp:SignedSupportingTokens>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <mssp:RsaToken xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true"/>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportRefThumbprint/>
+            <sp:MustSupportRefEncryptedKey/>
+          </wsp:Policy>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="UserNameWSTrustBinding_IWSTrustFeb2005Async_TrustFeb2005IssueAsync_Input_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body/>
+          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+        </sp:SignedParts>
+        <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body/>
+        </sp:EncryptedParts>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="UserNameWSTrustBinding_IWSTrustFeb2005Async_TrustFeb2005IssueAsync_output_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:SignedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body/>
+          <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="From" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="FaultTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="ReplyTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="MessageID" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="RelatesTo" Namespace="http://www.w3.org/2005/08/addressing"/>
+          <sp:Header Name="Action" Namespace="http://www.w3.org/2005/08/addressing"/>
+        </sp:SignedParts>
+        <sp:EncryptedParts xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <sp:Body/>
+        </sp:EncryptedParts>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="UserNameWSTrustBinding_IWSTrustFeb2005Async1_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:SignedSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:UsernameToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:WssUsernameToken10/>
+              </wsp:Policy>
+            </sp:UsernameToken>
+          </wsp:Policy>
+        </sp:SignedSupportingTokens>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <mssp:RsaToken xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true"/>
+            <sp:SignedParts>
+              <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+            </sp:SignedParts>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:IssuedToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <sp:RequestSecurityTokenTemplate>
+                <t:KeyType>
+                  http://schemas.xmlsoap.org/ws/2005/02/trust/PublicKey
+                </t:KeyType>
+                <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</t:EncryptWith>
+                <t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</t:SignatureAlgorithm>
+                <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>
+                <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>
+              </sp:RequestSecurityTokenTemplate>
+              <wsp:Policy>
+                <sp:RequireInternalReference/>
+              </wsp:Policy>
+            </sp:IssuedToken>
+            <mssp:RsaToken xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true"/>
+            <sp:SignedParts>
+              <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+            </sp:SignedParts>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken RequireClientCertificate="false"/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:IssuedToken sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/AlwaysToRecipient">
+              <sp:RequestSecurityTokenTemplate>
+                <t:KeyType>
+                  http://schemas.xmlsoap.org/ws/2005/02/trust/SymmetricKey
+                </t:KeyType>
+                <t:KeySize>256</t:KeySize>
+                <t:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptWith>
+                <t:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</t:SignatureAlgorithm>
+                <t:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</t:CanonicalizationAlgorithm>
+                <t:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</t:EncryptionAlgorithm>
+              </sp:RequestSecurityTokenTemplate>
+              <wsp:Policy>
+                <sp:RequireInternalReference/>
+              </wsp:Policy>
+            </sp:IssuedToken>
+            <mssp:RsaToken xmlns:mssp="http://schemas.microsoft.com/ws/2005/07/securitypolicy" sp:IncludeToken="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy/IncludeToken/Never" wsp:Optional="true"/>
+            <sp:SignedParts>
+              <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+            </sp:SignedParts>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust10 xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust10>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="CertificateWSTrustBinding_IWSTrust13Async_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy>
+            <sp:X509Token sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+              <wsp:Policy>
+                <sp:RequireThumbprintReference/>
+                <sp:WssX509V3Token10/>
+              </wsp:Policy>
+            </sp:X509Token>
+            <sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true"/>
+            <sp:SignedParts>
+              <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+            </sp:SignedParts>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy>
+            <sp:MustSupportRefThumbprint/>
+          </wsp:Policy>
+        </sp:Wss11>
+        <sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust13>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrust13Async_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy>
+            <sp:IssuedToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+              <sp:RequestSecurityTokenTemplate>
+                <trust:KeyType>
+                  http://docs.oasis-open.org/ws-sx/ws-trust/200512/PublicKey
+                </trust:KeyType>
+                <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>
+                <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:EncryptWith>
+                <trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#rsa-sha1</trust:SignatureAlgorithm>
+                <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>
+                <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>
+              </sp:RequestSecurityTokenTemplate>
+              <wsp:Policy>
+                <sp:RequireInternalReference/>
+              </wsp:Policy>
+            </sp:IssuedToken>
+            <sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true"/>
+            <sp:SignedParts>
+              <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+            </sp:SignedParts>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust13>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsp:Policy wsu:Id="IssuedTokenWSTrustBinding_IWSTrust13Async1_policy">
+    <wsp:ExactlyOne>
+      <wsp:All>
+        <sp:TransportBinding xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy>
+            <sp:TransportToken>
+              <wsp:Policy>
+                <sp:HttpsToken/>
+              </wsp:Policy>
+            </sp:TransportToken>
+            <sp:AlgorithmSuite>
+              <wsp:Policy>
+                <sp:Basic256/>
+              </wsp:Policy>
+            </sp:AlgorithmSuite>
+            <sp:Layout>
+              <wsp:Policy>
+                <sp:Strict/>
+              </wsp:Policy>
+            </sp:Layout>
+            <sp:IncludeTimestamp/>
+          </wsp:Policy>
+        </sp:TransportBinding>
+        <sp:EndorsingSupportingTokens xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy>
+            <sp:IssuedToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/AlwaysToRecipient">
+              <sp:RequestSecurityTokenTemplate>
+                <trust:KeyType>
+                  http://docs.oasis-open.org/ws-sx/ws-trust/200512/SymmetricKey
+                </trust:KeyType>
+                <trust:KeySize>256</trust:KeySize>
+                <trust:KeyWrapAlgorithm>http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p</trust:KeyWrapAlgorithm>
+                <trust:EncryptWith>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptWith>
+                <trust:SignatureAlgorithm>http://www.w3.org/2000/09/xmldsig#hmac-sha1</trust:SignatureAlgorithm>
+                <trust:CanonicalizationAlgorithm>http://www.w3.org/2001/10/xml-exc-c14n#</trust:CanonicalizationAlgorithm>
+                <trust:EncryptionAlgorithm>http://www.w3.org/2001/04/xmlenc#aes256-cbc</trust:EncryptionAlgorithm>
+              </sp:RequestSecurityTokenTemplate>
+              <wsp:Policy>
+                <sp:RequireInternalReference/>
+              </wsp:Policy>
+            </sp:IssuedToken>
+            <sp:KeyValueToken sp:IncludeToken="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702/IncludeToken/Never" wsp:Optional="true"/>
+            <sp:SignedParts>
+              <sp:Header Name="To" Namespace="http://www.w3.org/2005/08/addressing"/>
+            </sp:SignedParts>
+          </wsp:Policy>
+        </sp:EndorsingSupportingTokens>
+        <sp:Wss11 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy/>
+        </sp:Wss11>
+        <sp:Trust13 xmlns:sp="http://docs.oasis-open.org/ws-sx/ws-securitypolicy/200702">
+          <wsp:Policy>
+            <sp:MustSupportIssuedTokens/>
+            <sp:RequireClientEntropy/>
+            <sp:RequireServerEntropy/>
+          </wsp:Policy>
+        </sp:Trust13>
+        <wsaw:UsingAddressing/>
+      </wsp:All>
+    </wsp:ExactlyOne>
+  </wsp:Policy>
+  <wsdl:types>
+    <xsd:schema targetNamespace="http://schemas.microsoft.com/ws/2008/06/identity/securitytokenservice/Imports">
+      <xsd:import schemaLocation="https://sts.usystech.net/adfs/services/trust/mex?xsd=xsd0" namespace="http://schemas.microsoft.com/Message"/>
+      <xsd:import schemaLocation="https://sts.usystech.net/adfs/services/trust/mex?xsd=xsd1" namespace="http://schemas.xmlsoap.org/ws/2005/02/trust"/>
+      <xsd:import schemaLocation="https://sts.usystech.net/adfs/services/trust/mex?xsd=xsd2" namespace="http://docs.oasis-open.org/ws-sx/ws-trust/200512"/>
+    </xsd:schema>
+  </wsdl:types>
+  <wsdl:message name="IWSTrustFeb2005Async_TrustFeb2005IssueAsync_InputMessage">
+    <wsdl:part name="request" element="t:RequestSecurityToken"/>
+  </wsdl:message>
+  <wsdl:message name="IWSTrustFeb2005Async_TrustFeb2005IssueAsync_OutputMessage">
+    <wsdl:part name="TrustFeb2005IssueAsyncResult" element="t:RequestSecurityTokenResponse"/>
+  </wsdl:message>
+  <wsdl:message name="IWSTrust13Async_Trust13IssueAsync_InputMessage">
+    <wsdl:part name="request" element="trust:RequestSecurityToken"/>
+  </wsdl:message>
+  <wsdl:message name="IWSTrust13Async_Trust13IssueAsync_OutputMessage">
+    <wsdl:part name="Trust13IssueAsyncResult" element="trust:RequestSecurityTokenResponseCollection"/>
+  </wsdl:message>
+  <wsdl:portType name="IWSTrustFeb2005Async">
+    <wsdl:operation name="TrustFeb2005IssueAsync">
+      <wsdl:input wsaw:Action="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" message="tns:IWSTrustFeb2005Async_TrustFeb2005IssueAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://schemas.xmlsoap.org/ws/2005/02/trust/RSTR/Issue" message="tns:IWSTrustFeb2005Async_TrustFeb2005IssueAsync_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:portType name="IWSTrust13Async">
+    <wsdl:operation name="Trust13IssueAsync">
+      <wsdl:input wsaw:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" message="tns:IWSTrust13Async_Trust13IssueAsync_InputMessage"/>
+      <wsdl:output wsaw:Action="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RSTRC/IssueFinal" message="tns:IWSTrust13Async_Trust13IssueAsync_OutputMessage"/>
+    </wsdl:operation>
+  </wsdl:portType>
+  <wsdl:binding name="CustomBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+    <wsp:PolicyReference URI="#CustomBinding_IWSTrustFeb2005Async_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="TrustFeb2005IssueAsync">
+      <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="CertificateWSTrustBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+    <wsp:PolicyReference URI="#CertificateWSTrustBinding_IWSTrustFeb2005Async_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="TrustFeb2005IssueAsync">
+      <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="CertificateWSTrustBinding_IWSTrustFeb2005Async1" type="tns:IWSTrustFeb2005Async">
+    <wsp:PolicyReference URI="#CertificateWSTrustBinding_IWSTrustFeb2005Async1_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="TrustFeb2005IssueAsync">
+      <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="UserNameWSTrustBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+    <wsp:PolicyReference URI="#UserNameWSTrustBinding_IWSTrustFeb2005Async_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="TrustFeb2005IssueAsync">
+      <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+      <wsdl:input>
+        <wsp:PolicyReference URI="#UserNameWSTrustBinding_IWSTrustFeb2005Async_TrustFeb2005IssueAsync_Input_policy"/>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <wsp:PolicyReference URI="#UserNameWSTrustBinding_IWSTrustFeb2005Async_TrustFeb2005IssueAsync_output_policy"/>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="UserNameWSTrustBinding_IWSTrustFeb2005Async1" type="tns:IWSTrustFeb2005Async">
+    <wsp:PolicyReference URI="#UserNameWSTrustBinding_IWSTrustFeb2005Async1_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="TrustFeb2005IssueAsync">
+      <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async" type="tns:IWSTrustFeb2005Async">
+    <wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrustFeb2005Async_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="TrustFeb2005IssueAsync">
+      <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1" type="tns:IWSTrustFeb2005Async">
+    <wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="TrustFeb2005IssueAsync">
+      <soap12:operation soapAction="http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="CertificateWSTrustBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+    <wsp:PolicyReference URI="#CertificateWSTrustBinding_IWSTrust13Async_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Trust13IssueAsync">
+      <soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrust13Async" type="tns:IWSTrust13Async">
+    <wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrust13Async_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Trust13IssueAsync">
+      <soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:binding name="IssuedTokenWSTrustBinding_IWSTrust13Async1" type="tns:IWSTrust13Async">
+    <wsp:PolicyReference URI="#IssuedTokenWSTrustBinding_IWSTrust13Async1_policy"/>
+    <soap12:binding transport="http://schemas.xmlsoap.org/soap/http"/>
+    <wsdl:operation name="Trust13IssueAsync">
+      <soap12:operation soapAction="http://docs.oasis-open.org/ws-sx/ws-trust/200512/RST/Issue" style="document"/>
+      <wsdl:input>
+        <soap12:body use="literal"/>
+      </wsdl:input>
+      <wsdl:output>
+        <soap12:body use="literal"/>
+      </wsdl:output>
+    </wsdl:operation>
+  </wsdl:binding>
+  <wsdl:service name="SecurityTokenService">
+    <wsdl:port name="CustomBinding_IWSTrustFeb2005Async" binding="tns:CustomBinding_IWSTrustFeb2005Async">
+      <soap12:address location="https://sts.usystech.net/adfs/services/trust/2005/windowstransport"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>
+          https://sts.usystech.net/adfs/services/trust/2005/windowstransport
+        </wsa10:Address>
+        <Identity xmlns="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+          <Spn>host/sts.usystech.net</Spn>
+        </Identity>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="CertificateWSTrustBinding_IWSTrustFeb2005Async" binding="tns:CertificateWSTrustBinding_IWSTrustFeb2005Async">
+      <soap12:address location="https://sts.usystech.net/adfs/services/trust/2005/certificatemixed"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>
+          https://sts.usystech.net/adfs/services/trust/2005/certificatemixed
+        </wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="CertificateWSTrustBinding_IWSTrustFeb2005Async1" binding="tns:CertificateWSTrustBinding_IWSTrustFeb2005Async1">
+      <soap12:address location="https://sts.usystech.net:49443/adfs/services/trust/2005/certificatetransport"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>
+          https://sts.usystech.net:49443/adfs/services/trust/2005/certificatetransport
+        </wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="UserNameWSTrustBinding_IWSTrustFeb2005Async" binding="tns:UserNameWSTrustBinding_IWSTrustFeb2005Async">
+      <soap12:address location="http://sts.usystech.net/adfs/services/trust/2005/username"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>
+          http://sts.usystech.net/adfs/services/trust/2005/username
+        </wsa10:Address>
+        <Identity xmlns="http://schemas.xmlsoap.org/ws/2006/02/addressingidentity">
+          <KeyInfo xmlns="http://www.w3.org/2000/09/xmldsig#">
+            <X509Data>
+              <X509Certificate>
+                MIIFDTCCA/WgAwIBAgIQB64+CRmpRmmV6WZdZEpD+jANBgkqhkiG9w0BAQsFADBNMQswCQYDVQQGEwJVUzEVMBMGA1UEChMMRGlnaUNlcnQgSW5jMScwJQYDVQQDEx5EaWdpQ2VydCBTSEEyIFNlY3VyZSBTZXJ2ZXIgQ0EwHhcNMTUwNjIzMDAwMDAwWhcNMTYwNzExMTIwMDAwWjBbMQswCQYDVQQGEwJVUzENMAsGA1UECBMEVXRhaDEOMAwGA1UEBxMFU2FuZHkxFDASBgNVBAoTC0ZyZWQgRHVhcnRlMRcwFQYDVQQDDA4qLnVzeXN0ZWNoLm5ldDCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMJkd0UKklEa0oRZElGJw9ydFKZtpCOy6KMfQOKBk20a1wFBwWgSEza+sL4ykLeZTo+J+7QuNXs/JaT3eXcJGRGLKSXJSQ2K2CQkNgb7VzOjlRn5rJrgG0wKuEAzA376odoxIUppUdgGNYcBVd2Lfkct63Pff55Qi+K1PDqrOwtJ/YuIfRlZNktgO6NaTsGBQQLmzh2zXZyGMJ5iObwv9F5/RhtlZKAu37B6DPzJv8jfcjOOFWa4wyxBlRV1GacypPCXGUI81cfTb1eRA97Cwx2EEM1QcP2OQXHjJ3DIlgHzL+ZY6KFoU3rkzA5/R1q/s14FGSTepwuDi6IkeuPm2ZcCAwEAAaOCAdkwggHVMB8GA1UdIwQYMBaAFA+AYRyCMWHVLyjnjUY4tCzhxtniMB0GA1UdDgQWBBT/B07Ibzv4xAj47dCQyqSGKI3coTAnBgNVHREEIDAegg4qLnVzeXN0ZWNoLm5ldIIMdXN5c3RlY2gubmV0MA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwawYDVR0fBGQwYjAvoC2gK4YpaHR0cDovL2NybDMuZGlnaWNlcnQuY29tL3NzY2Etc2hhMi1nNC5jcmwwL6AtoCuGKWh0dHA6Ly9jcmw0LmRpZ2ljZXJ0LmNvbS9zc2NhLXNoYTItZzQuY3JsMEIGA1UdIAQ7MDkwNwYJYIZIAYb9bAEBMCowKAYIKwYBBQUHAgEWHGh0dHBzOi8vd3d3LmRpZ2ljZXJ0LmNvbS9DUFMwfAYIKwYBBQUHAQEEcDBuMCQGCCsGAQUFBzABhhhodHRwOi8vb2NzcC5kaWdpY2VydC5jb20wRgYIKwYBBQUHMAKGOmh0dHA6Ly9jYWNlcnRzLmRpZ2ljZXJ0LmNvbS9EaWdpQ2VydFNIQTJTZWN1cmVTZXJ2ZXJDQS5jcnQwDAYDVR0TAQH/BAIwADANBgkqhkiG9w0BAQsFAAOCAQEAS+pFrDx+MWkLSv7ZymBm/i3BtO9ko+bop8d6I8jzEYGd4p4pwovARw0olGjubdbtuVx7HV1HzKyBVA4U+Pz1FgMAD43mcysg02FdZyeaIOCyqPN4m3Cnk1ml5n10My6en9pM5DUwnF4/R9AFJ2uvaGlurBRKGGbd1skH1bdl7QF5UTtyP+c+mw6bznONMo3G2O0NJy3ZVJf4vHbFjSU/5JHvZH8jXAaoYPxddQ88T3zF6zDXC75OqZtB1TrF1XIqaq2kPdy7r48N5X/fCXkHwnAx1+wQhSwbbt0yfhYWWkbaS8A503VrNAtKLch2aQYVmzg2guh4fq9RPfgBTbD7FA==
+              </X509Certificate>
+            </X509Data>
+          </KeyInfo>
+        </Identity>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="UserNameWSTrustBinding_IWSTrustFeb2005Async1" binding="tns:UserNameWSTrustBinding_IWSTrustFeb2005Async1">
+      <soap12:address location="https://sts.usystech.net/adfs/services/trust/2005/usernamemixed"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>
+          https://sts.usystech.net/adfs/services/trust/2005/usernamemixed
+        </wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async" binding="tns:IssuedTokenWSTrustBinding_IWSTrustFeb2005Async">
+      <soap12:address location="https://sts.usystech.net/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>
+          https://sts.usystech.net/adfs/services/trust/2005/issuedtokenmixedasymmetricbasic256
+        </wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1" binding="tns:IssuedTokenWSTrustBinding_IWSTrustFeb2005Async1">
+      <soap12:address location="https://sts.usystech.net/adfs/services/trust/2005/issuedtokenmixedsymmetricbasic256"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>
+          https://sts.usystech.net/adfs/services/trust/2005/issuedtokenmixedsymmetricbasic256
+        </wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="CertificateWSTrustBinding_IWSTrust13Async" binding="tns:CertificateWSTrustBinding_IWSTrust13Async">
+      <soap12:address location="https://sts.usystech.net/adfs/services/trust/13/certificatemixed"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>
+          https://sts.usystech.net/adfs/services/trust/13/certificatemixed
+        </wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="IssuedTokenWSTrustBinding_IWSTrust13Async" binding="tns:IssuedTokenWSTrustBinding_IWSTrust13Async">
+      <soap12:address location="https://sts.usystech.net/adfs/services/trust/13/issuedtokenmixedasymmetricbasic256"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>
+          https://sts.usystech.net/adfs/services/trust/13/issuedtokenmixedasymmetricbasic256
+        </wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+    <wsdl:port name="IssuedTokenWSTrustBinding_IWSTrust13Async1" binding="tns:IssuedTokenWSTrustBinding_IWSTrust13Async1">
+      <soap12:address location="https://sts.usystech.net/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256"/>
+      <wsa10:EndpointReference>
+        <wsa10:Address>
+          https://sts.usystech.net/adfs/services/trust/13/issuedtokenmixedsymmetricbasic256
+        </wsa10:Address>
+      </wsa10:EndpointReference>
+    </wsdl:port>
+  </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
support for WS-Trust 2005
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/223%23discussion_r35997221%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/223%23discussion_r35997813%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%205021a1d4968aa64a1f235a2124fb94efd3b8bc53%20src/ADAL.Common/MexParser.cs%2052%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/223%23discussion_r35997813%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Why%20is%20this%20randomized%3F%22%2C%20%22created_at%22%3A%20%222015-07-31T17%3A51%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7756476%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aj-michael%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/ADAL.Common/MexParser.cs%3AL85-110%22%7D%2C%20%22Pull%205021a1d4968aa64a1f235a2124fb94efd3b8bc53%20src/ADAL.Common/WsTrustRequest.cs%20163%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/223%23discussion_r35997221%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22typo%20for%20expiryTimeString%22%2C%20%22created_at%22%3A%20%222015-07-31T17%3A46%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/ADAL.Common/WsTrustRequest.cs%3AL195-206%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 5021a1d4968aa64a1f235a2124fb94efd3b8bc53 src/ADAL.Common/WsTrustRequest.cs 163'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/223#discussion_r35997221'>File: src/ADAL.Common/WsTrustRequest.cs:L195-206</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> typo for expiryTimeString
- [x] <a href='#crh-comment-Pull 5021a1d4968aa64a1f235a2124fb94efd3b8bc53 src/ADAL.Common/MexParser.cs 52'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/223#discussion_r35997813'>File: src/ADAL.Common/MexParser.cs:L85-110</a></b>
- <a href='https://github.com/aj-michael'><img border=0 src='https://avatars.githubusercontent.com/u/7756476?v=3' height=16 width=16'></a> Why is this randomized?


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/223?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/223?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/223'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>