### PR TITLE
Another small B2C bug fix

### DIFF
--- a/src/ADAL.PCL/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.PCL/AcquireTokenHandlerBase.cs
@@ -356,7 +356,7 @@ namespace Microsoft.Experimental.IdentityModel.Clients.ActiveDirectory
                         "=== token Acquisition finished successfully. An access token was retuned:\n\tToken Hash: {0}\n\tExpiration Time: {1}\n\tUser Hash: {2}\n\t",
                         accessTokenHash,
                         result.ExpiresOn,
-                        result.UserInfo != null
+                        result.UserInfo != null && result.UserInfo.UniqueId != null
                             ? PlatformPlugin.CryptographyHelper.CreateSha256Hash(result.UserInfo.UniqueId)
                             : "null"));
             }

--- a/src/ADAL.PCL/ProfileInfo.cs
+++ b/src/ADAL.PCL/ProfileInfo.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Experimental.IdentityModel.Clients.ActiveDirectory
 {
     internal class ProfileInfoClaim
     {
-        public const string Version = "version";
+        public const string Version = "ver";
         public const string Subject = "sub";
         public const string TenantId = "tid";
         public const string PreferredUsername = "preferred_username";


### PR DESCRIPTION
I created a perfectly valid policy in B2C, but did not configure it to send the ‘name’ claim.  Therefore, the profile_info ADAL received from CPIM looks like:

```
{
    "ver": "1.0",
    "tid": "f494dfc5-cb2f-4d2d-b22b-9e6c68a0d72c",
    "sub": null,
    "name": null,
    "preferred_username": null,
    "idp": "facebook.com"
}
```

Which meant that when ADAL populated the UserInfo object, all 4 of its properties had a null value:

```
        internal UserInfo(UserInfo other)
        {
            this.UniqueId = other.UniqueId;
            this.DisplayableId = other.DisplayableId;
            this.Name = other.Name;
            this.Version = other.Version;
        }
```

And then in AcquireTokenHandlerBase.LogReturnedToken, ADAL tried to log the UserInfo.UniqueId, which was null: 

	PlatformPlugin.Logger.Information(this.CallState,
                    string.Format(
                        "=== token Acquisition finished successfully. An access token was retuned:\n\tToken Hash: {0}\n\tExpiration Time: {1}\n\tUser Hash: {2}\n\t",
                        accessTokenHash,
                        result.ExpiresOn,
                        result.UserInfo != null
                            ? PlatformPlugin.CryptographyHelper.CreateSha256Hash(result.UserInfo.UniqueId)
                            : "null"));

I also noticed that the version profile info claim was incorrect, so I fixed that.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/243%23issuecomment-139097608%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/243%23issuecomment-139097608%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40dstrockis__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cp%3E%5Cr%5Cn%20%20%20%20%20%20%20%20It%20looks%20like%20you%27re%20a%20Microsoft%20contributor%20%28Danny%20Strockis%29.%20If%20you%27re%20full-time%2C%20we%20DON%27T%20require%20a%20Contribution%20License%20Agreement.%20If%20you%20are%20a%20vendor%2C%20please%20DO%20sign%20the%20electronic%20Contribution%20License%20Agreement.%20It%20will%20take%202%20minutes%20and%20there%27s%20no%20faxing%21%20https%3A//cla.microsoft.com.%5Cr%5Cn%20%20%20%20%3C/p%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-09-10T02%3A22%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/243#issuecomment-139097608'>General Comment</a></b>
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> Hi __@dstrockis__, I'm your friendly neighborhood Microsoft Pull Request Bot (You can call me MSBOT). Thanks for your contribution!
<p>
It looks like you're a Microsoft contributor (Danny Strockis). If you're full-time, we DON'T require a Contribution License Agreement. If you are a vendor, please DO sign the electronic Contribution License Agreement. It will take 2 minutes and there's no faxing! https://cla.microsoft.com.
</p>
TTYL, MSBOT;


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/243?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/243?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/243'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>