### PR TITLE
Fix for ADAL bug causing app crash

### DIFF
--- a/src/ADAL.Common/Authenticator.cs
+++ b/src/ADAL.Common/Authenticator.cs
@@ -35,7 +35,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         private static readonly AuthenticatorTemplateList AuthenticatorTemplateList = new AuthenticatorTemplateList();
 
-        private bool updatedFromTemplate; 
+        private bool updatedFromTemplate;
 
         public Authenticator(string authority, bool validateAuthority)
         {
@@ -116,14 +116,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 throw new ArgumentException(AdalErrorMessage.AuthorityUriInsecure, "authority");
             }
 
-            string path = authorityUri.AbsolutePath.Substring(1);
-            if (string.IsNullOrWhiteSpace(path))
-            {
-                throw new ArgumentException(AdalErrorMessage.AuthorityUriInvalidPath, "authority");
-            }
+            const string AdfsFirstPathMatch = "adfs";
+            AuthorityType authorityType = AuthorityType.AAD;
 
-            string firstPath = path.Substring(0, path.IndexOf("/", StringComparison.Ordinal));
-            AuthorityType authorityType = IsAdfsAuthority(firstPath) ? AuthorityType.ADFS : AuthorityType.AAD;
+            if (authorityUri.AbsolutePath.Length > 0
+                && authorityUri.AbsolutePath[0] == '/'
+                && authorityUri.AbsolutePath.Length > 1
+                && String.Compare(authorityUri.AbsolutePath, 1, AdfsFirstPathMatch, 0, AdfsFirstPathMatch.Length, StringComparison.OrdinalIgnoreCase) == 0)
+            {
+                authorityType = AuthorityType.ADFS;
+            }
 
             return authorityType;
         }
@@ -142,11 +144,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             var regex = new Regex(Regex.Escape(TenantlessTenantName), RegexOptions.IgnoreCase);
             return regex.Replace(authority, tenantId, 1);
-        }
-
-        private static bool IsAdfsAuthority(string firstPath)
-        {
-            return string.Compare(firstPath, "adfs", StringComparison.OrdinalIgnoreCase) == 0;
         }
     }
 }


### PR DESCRIPTION
Originally discovered via an [app crash report for the Git Credential Manager for Windows](https://github.com/Microsoft/Git-Credential-Manager-for-Windows/issues/17). The issue was traced to the `Microsoft.IdentityModel.Clients.ActiveDirectory.Authenticator.DetectAuthorityType` method which was apparently performing custom URL verification; and incorrectly.

Upon inspection, it seems the 'ctor was enforcing the need for at least one path part, which is an invalid requirement when validating a URL. This patch fixes the invalid validation while retaining the ADFS detection already present in the 'ctor.

* Stops an unnecessary Argument exception from being thrown.
* Removes assumption that URL ending in '/' have a path of length > 0.
* Removes unnecissary string allocations ala <string>.Substring calls and extra <string>.IndexOf calls.
* Removes unnecissary method call (though that call was likely inlined anyways).
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/252%23issuecomment-145623332%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/252%23issuecomment-145624677%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/252%23issuecomment-145625920%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/252%23issuecomment-145623332%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40whoisj__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cp%3E%5Cr%5Cn%20%20%20%20%20%20%20%20It%20looks%20like%20you%27re%20a%20Microsoft%20contributor%20%28J%20Wyman%29.%20If%20you%27re%20full-time%2C%20we%20DON%27T%20require%20a%20Contribution%20License%20Agreement.%20If%20you%20are%20a%20vendor%2C%20please%20DO%20sign%20the%20electronic%20Contribution%20License%20Agreement.%20It%20will%20take%202%20minutes%20and%20there%27s%20no%20faxing%21%20https%3A//cla.microsoft.com.%5Cr%5Cn%20%20%20%20%3C/p%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-10-05T18%3A27%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20like%20fun%20with%20CRLF%20has%20ensued.%20I%27ll%20attempt%20to%20rectify%20it%20ASAP.%22%2C%20%22created_at%22%3A%20%222015-10-05T18%3A33%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578325%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/whoisj%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Looks%20like%20fun%20with%20CRLF%20has%20ensued.%20I%27ll%20attempt%20to%20rectify%20it%20ASAP.%5Cr%5Cn%5Cr%5CnSorted.%20Enjoy.%22%2C%20%22created_at%22%3A%20%222015-10-05T18%3A38%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/11578325%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/whoisj%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/252#issuecomment-145623332'>General Comment</a></b>
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> Hi __@whoisj__, I'm your friendly neighborhood Microsoft Pull Request Bot (You can call me MSBOT). Thanks for your contribution!
<p>
It looks like you're a Microsoft contributor (J Wyman). If you're full-time, we DON'T require a Contribution License Agreement. If you are a vendor, please DO sign the electronic Contribution License Agreement. It will take 2 minutes and there's no faxing! https://cla.microsoft.com.
</p>
TTYL, MSBOT;
- <a href='https://github.com/whoisj'><img border=0 src='https://avatars.githubusercontent.com/u/11578325?v=3' height=16 width=16'></a> Looks like fun with CRLF has ensued. I'll attempt to rectify it ASAP.
- <a href='https://github.com/whoisj'><img border=0 src='https://avatars.githubusercontent.com/u/11578325?v=3' height=16 width=16'></a> > Looks like fun with CRLF has ensued. I'll attempt to rectify it ASAP.
Sorted. Enjoy.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/252?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/252?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/252'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>