### PR TITLE
send pkeyauth header all the time. launch intent for MAM

### DIFF
--- a/src/ADAL.PCL.Android/ADAL.PCL.Android.csproj
+++ b/src/ADAL.PCL.Android/ADAL.PCL.Android.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <Reference Include="Mono.Android" />
     <Reference Include="System" />
+    <Reference Include="System.Collections" />
     <Reference Include="System.Threading.Tasks" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime" />

--- a/src/ADAL.PCL.Android/BrokerConstants.cs
+++ b/src/ADAL.PCL.Android/BrokerConstants.cs
@@ -119,6 +119,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public const string ChallangeResponseContext = "Context";
 
+        public const string ChallangeResponseVersion = "Version";
+
         /**
          * Certificate authorities are passed with delimiter.
          */

--- a/src/ADAL.PCL.Android/BrokerHelper.cs
+++ b/src/ADAL.PCL.Android/BrokerHelper.cs
@@ -68,6 +68,25 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
         public void AcquireToken(IDictionary<string, string> brokerPayload)
         {
+
+            if (brokerPayload.ContainsKey("broker_install_url"))
+            {
+                string url = brokerPayload["broker_install_url"];
+                Uri uri = new Uri(url);
+                string query = uri.Query;
+                if (query.StartsWith("?"))
+                {
+                    query = query.Substring(1);
+                }
+
+                Dictionary<string, string> keyPair = EncodingHelper.ParseKeyValueList(query, '&', true, false, null);
+
+                PlatformParameters pp = PlatformParameters as PlatformParameters;
+                pp.CallerActivity.StartActivity(new Intent(Intent.ActionView, Android.Net.Uri.Parse(keyPair["app_link"])));
+                
+                throw new AdalException(AdalErrorEx.BrokerApplicationRequired, AdalErrorMessageEx.BrokerApplicationRequired);
+            }
+
             Context mContext = Application.Context;
             AuthenticationRequest request = new AuthenticationRequest(brokerPayload);
             PlatformParameters platformParams = PlatformParameters as PlatformParameters;
@@ -108,12 +127,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
                 // Only happens with callback since silent call does not show UI
                 PlatformPlugin.Logger.Verbose(null, "Launch activity for Authenticator");
-                /*mAuthorizationCallback = callbackHandle.callback;
-                request.setRequestId(callbackHandle.callback.hashCode());*/
                 PlatformPlugin.Logger.Verbose(null, "Starting Authentication Activity");
-                /*putWaitingRequest(callbackHandle.callback.hashCode(),
-                    new AuthenticationRequestState(callbackHandle.callback.hashCode(), request,
-                        callbackHandle.callback));*/
                 if (resultEx == null)
                 {
                     PlatformPlugin.Logger.Verbose(null, "Initial request to authenticator");

--- a/src/ADAL.PCL.Android/Constants.cs
+++ b/src/ADAL.PCL.Android/Constants.cs
@@ -23,6 +23,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public const string MissingDigestShaAlgorithm = "missing_digest_sha_algorithm";
         public const string SignatureVerificationFailed = "signature_verification_failed";
         public const string NoBrokerAccountFound = "broker_account_not_found";
+        public const string BrokerApplicationRequired = "broker_application_required";
     }
 
     internal static class AdalErrorMessageEx
@@ -36,6 +37,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public const string MissingDigestShaAlgorithm = "Digest SHA algorithm does not exists";
         public const string SignatureVerificationFailed = "Error in verifying broker app's signature";
         public const string NoBrokerAccountFound = "No account found in broker app";
+        public const string BrokerApplicationRequired = "Broker application must be installed to continue authentication";
     }
 
     internal static class BrokerResponseCode

--- a/src/ADAL.PCL.Android/DeviceAuthHelper.cs
+++ b/src/ADAL.PCL.Android/DeviceAuthHelper.cs
@@ -38,7 +38,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public Task<string> CreateDeviceAuthChallengeResponse(IDictionary<string, string> challengeData)
         {
-            throw new NotImplementedException();
+            return Task.FromResult(string.Format(@"PKeyAuth Context=""{0}"",Version=""{1}""", challengeData[BrokerConstants.ChallangeResponseContext], challengeData[BrokerConstants.ChallangeResponseVersion]));
         }
     }
 }

--- a/src/ADAL.PCL/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.PCL/AcquireTokenHandlerBase.cs
@@ -122,7 +122,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     {
                         await this.PreTokenRequest();
                         
-                        // check if broker app is required for authentication.
+                        // check if broker app installation is required for authentication.
                         if (this.BrokerInvocationRequired())
                         {
                             resultEx = await PlatformPlugin.BrokerHelper.AcquireTokenUsingBroker(brokerParameters);

--- a/src/ADAL.PCL/EncodingHelper.cs
+++ b/src/ADAL.PCL/EncodingHelper.cs
@@ -71,7 +71,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return builder.ToString();
         }
 
-        public static Dictionary<string, string> ParseKeyValueList(string input, char delimiter, bool urlDecode, CallState callState)
+        public static Dictionary<string, string> ParseKeyValueList(string input, char delimiter, bool urlDecode, bool lowercaseKeys,
+            CallState callState)
         {
             var response = new Dictionary<string, string>();
 
@@ -93,10 +94,14 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                         value = UrlDecode(value);
                     }
 
-                    key = key.Trim().ToLower();
+                    if (lowercaseKeys)
+                    {
+                        key = key.Trim().ToLower();
+                    }
+
                     value = value.Trim().Trim(new[] { '\"' }).Trim();
 
-                    if (response.ContainsKey(key) && callState!=null)
+                    if (response.ContainsKey(key) && callState != null)
                     {
                         PlatformPlugin.Logger.Warning(callState, string.Format("Key/value pair list contains redundant key '{0}'.", key));
                     }
@@ -106,6 +111,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
 
             return response;
+        }
+
+        public static Dictionary<string, string> ParseKeyValueList(string input, char delimiter, bool urlDecode, CallState callState)
+        {
+            return ParseKeyValueList(input, delimiter, urlDecode, true, callState);
         }
 
         public static byte[] ToByteArray(this String stringInput)

--- a/tests/TestApp/TestApp.PCL/TokenBroker.cs
+++ b/tests/TestApp/TestApp.PCL/TokenBroker.cs
@@ -37,7 +37,7 @@ namespace TestApp.PCL
             this.ValidateAuthority = true;
             this.ValidExistingRedirectUri = new Uri("https://login.live.com/");
             this.ValidExpiresIn = 28800;
-            this.ValidNonExistingRedirectUri = new Uri("<REPLACE>");
+            this.ValidNonExistingRedirectUri = new Uri("urn:ietf:wg:oauth:2.0:oob");
             this.ValidLoggedInFederatedUserName = "dummy\\dummy";
             string[] segments = this.ValidLoggedInFederatedUserName.Split(new[] { '\\' });
             this.ValidLoggedInFederatedUserId = string.Format("{0}@microsoft.com", (segments.Length == 2) ? segments[1] : segments[0]);


### PR DESCRIPTION
send pkeyauth header all the time. launch intent for MAM
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/261%23discussion_r42297533%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/261%23discussion_r42298402%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%2083d98e09020c118745e0c9b4293a777738039c9f%20src/ADAL.PCL.Android/AuthenticationAgentActivity.cs%206%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/261%23discussion_r42297533%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20don%27t%20know%20why%20we%20name%20this%20as%20ClientTlsNotSupport%20instead%20of%20PkeyAuthHeader%20or%20something%20else%20to%20make%20it%20more%20clear.%20%22%2C%20%22created_at%22%3A%20%222015-10-16T22%3A38%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1166233%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/weijjia%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20a%20direct%20port%20of%20android.%20I%20mean%20DIRECT.%22%2C%20%22created_at%22%3A%20%222015-10-16T22%3A52%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20src/ADAL.PCL.Android/AuthenticationAgentActivity.cs%3AL42-53%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 83d98e09020c118745e0c9b4293a777738039c9f src/ADAL.PCL.Android/AuthenticationAgentActivity.cs 6'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/261#discussion_r42297533'>File: src/ADAL.PCL.Android/AuthenticationAgentActivity.cs:L42-53</a></b>
- <a href='https://github.com/weijjia'><img border=0 src='https://avatars.githubusercontent.com/u/1166233?v=3' height=16 width=16'></a> I don't know why we name this as ClientTlsNotSupport instead of PkeyAuthHeader or something else to make it more clear.
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> This is a direct port of android. I mean DIRECT.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/261?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/261?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/261'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>