### PR TITLE
Adding the US Only STS and comments.

### DIFF
--- a/src/ADAL.PCL/AuthenticatorTemplateList.cs
+++ b/src/ADAL.PCL/AuthenticatorTemplateList.cs
@@ -27,7 +27,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     {
         public AuthenticatorTemplateList()
         {
-            string[] trustedHostList = { "login.windows.net", "login.chinacloudapi.cn", "login.cloudgovapi.us", "login.microsoftonline.com" };
+            string[] trustedHostList = 
+                {
+                    "login.windows.net",            // Microsoft Azure Worldwide - Used in validation scenarios where host is not this list 
+                    "login.chinacloudapi.cn",       // Microsoft Azure China
+                    "login-us.microsoftonline.com", // Microsoft Azure US Government
+                    "login.microsoftonline.com"     // Microsoft Azure Worldwide
+                };
 
             string customAuthorityHost = PlatformPlugin.PlatformInformation.GetEnvironmentVariable("customTrustedHost");
             if (string.IsNullOrWhiteSpace(customAuthorityHost))

--- a/tests/Test.ADAL.Common/Sts.cs
+++ b/tests/Test.ADAL.Common/Sts.cs
@@ -239,7 +239,7 @@ namespace Test.ADAL.Common
             this.ValidLoggedInFederatedUserId = string.Format(CultureInfo.CurrentCulture, " {0}@microsoft.com", (segments.Length == 2) ? segments[1] : segments[0]);
 
             this.TenantName = "aadadfs.onmicrosoft.com";
-            this.Authority = string.Format(CultureInfo.CurrentCulture, " https://login.windows.net/{0}/", this.TenantName);
+            this.Authority = string.Format(CultureInfo.CurrentCulture, "https://login.windows.net/{0}/", this.TenantName);
             this.TenantlessAuthority = "https://login.windows.net/Common";
             this.Type = StsType.AAD;
             this.ValidClientId = "4b8d1b32-ee16-4b30-9b5d-e374c43deb31";

--- a/tests/Test.ADAL.NET.Unit/UnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/UnitTests.cs
@@ -65,7 +65,7 @@ namespace Test.ADAL.NET.Unit
             const string ClientId = "client_id";
             const string AdditionalParameter = "additional_parameter";
             const string AdditionalParameter2 = "additional_parameter2";
-            string expectedString = string.Format(CultureInfo.CurrentCulture, " client_id=client_id&{0}={1}&{2}={3}", AdditionalParameter, EncodingHelper.UrlEncode(ComplexString), AdditionalParameter2, EncodingHelper.UrlEncode(ComplexString2));
+            string expectedString = string.Format(CultureInfo.CurrentCulture, "client_id=client_id&{0}={1}&{2}={3}", AdditionalParameter, EncodingHelper.UrlEncode(ComplexString), AdditionalParameter2, EncodingHelper.UrlEncode(ComplexString2));
 
             var param = new DictionaryRequestParameters(null, new ClientKey(ClientId));
             param[AdditionalParameter] = ComplexString;


### PR DESCRIPTION
Replace the Azure US Gov STS with the actual STS so that requests for that STS do not need to be validated.  Added comments to identify the source of the STS servers.  

NOTE: had to remove 2 spaces in the UT constants to get the UTs to run correctly.  I can submit that separately if needed.

I did not write specific UTs for the Authenticator classes because they would need to be mocked to avoid the web calls and that would require refactoring.

Side note - I was thinking that it might be good to move login.microsoftonline.com to the front of the list since that is most common one these days and the STS team is working to reduce usage of login.windows.net. Would be a VERY minor optimization in the lookup.  Was not sure of possible side effects so I did not do that.