### PR TITLE
Updating the Azure US Gov Cloud STS and adding comments

### DIFF
--- a/src/ADAL.Common/AuthenticatorTemplateList.cs
+++ b/src/ADAL.Common/AuthenticatorTemplateList.cs
@@ -27,7 +27,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     {
         public AuthenticatorTemplateList()
         {
-            string[] trustedHostList = { "login.windows.net", "login.chinacloudapi.cn", "login.cloudgovapi.us", "login.microsoftonline.com" };
+            string[] trustedHostList =
+                {
+                    "login.windows.net",            // Microsoft Azure Worldwide - Used in validation scenarios where host is not this list 
+                    "login.chinacloudapi.cn",       // Microsoft Azure China
+                    "login-us.microsoftonline.com", // Microsoft Azure US Government
+                    "login.microsoftonline.com"     // Microsoft Azure Worldwide
+                };
 
             string customAuthorityHost = PlatformSpecificHelper.GetEnvironmentVariable("customTrustedHost");
             if (string.IsNullOrWhiteSpace(customAuthorityHost))


### PR DESCRIPTION
Updating the Azure US Gov STS URL to the US Only STS that has been stood up.  The previous URL was not valid.  Also adding comments about what cloud the STS goes with. 

The same code change has been submitted to the dev branch for inclusion in MAIN.