### PR TITLE
Fix bug to consume expires_on claim from iOS broker for Issue #345

### DIFF
--- a/src/ADAL.PCL.iOS/BrokerHelper.cs
+++ b/src/ADAL.PCL.iOS/BrokerHelper.cs
@@ -140,7 +140,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 }
             }
 
-            return response.GetResult();
+            var dateTimeOffset = new DateTimeOffset(new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc));
+            dateTimeOffset = dateTimeOffset.AddSeconds(response.ExpiresOn);
+            return response.GetResult(dateTimeOffset);
         }
         
         public static void SetBrokerResponse(NSUrl brokerResponse)

--- a/src/ADAL.PCL.iOS/PlatformParameters.cs
+++ b/src/ADAL.PCL.iOS/PlatformParameters.cs
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             SkipBroker = true;
         }
 
-        public PlatformParameters(UIViewController callerViewController)
+        public PlatformParameters(UIViewController callerViewController):this()
         {
             this.CallerViewController = callerViewController;
         }

--- a/src/ADAL.PCL/TokenResponse.cs
+++ b/src/ADAL.PCL/TokenResponse.cs
@@ -168,13 +168,17 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public AuthenticationResultEx GetResult()
         {
+            return this.GetResult(DateTime.UtcNow + TimeSpan.FromSeconds(this.ExpiresIn));
+        }
+
+        public AuthenticationResultEx GetResult(DateTimeOffset expiresOn)
+        {
             AuthenticationResultEx resultEx;
 
             if (this.AccessToken != null)
             {
-                DateTimeOffset expiresOn = DateTime.UtcNow + TimeSpan.FromSeconds(this.ExpiresIn);
                 var result = new AuthenticationResult(this.TokenType, this.AccessToken, expiresOn);
-                
+
                 IdToken idToken = IdToken.Parse(this.IdTokenString);
                 if (idToken != null)
                 {
@@ -224,7 +228,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     RefreshToken = this.RefreshToken,
                     // This is only needed for AcquireTokenByAuthorizationCode in which parameter resource is optional and we need
                     // to get it from the STS response.
-                    ResourceInResponse = this.Resource                    
+                    ResourceInResponse = this.Resource
                 };
             }
             else if (this.Error != null)
@@ -238,6 +242,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
             return resultEx;
         }
+
 
         private static string ReadStreamContent(Stream stream)
         {

--- a/tests/TestApp/AdaliOSTestApp/Info.plist
+++ b/tests/TestApp/AdaliOSTestApp/Info.plist
@@ -1,37 +1,45 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-  <dict>
-    <key>CFBundleDisplayName</key>
-    <string>AdaliOSTestApp</string>
-    <key>CFBundleIdentifier</key>
-    <string>com.your-company.AdaliOSTestApp</string>
-    <key>CFBundleShortVersionString</key>
-    <string>1.0</string>
-    <key>CFBundleVersion</key>
-    <string>1.0</string>
-    <key>UISupportedInterfaceOrientations</key>
-    <array>
-      <string>UIInterfaceOrientationPortrait</string>
-      <string>UIInterfaceOrientationLandscapeLeft</string>
-      <string>UIInterfaceOrientationLandscapeRight</string>
-    </array>
-    <key>UIMainStoryboardFile</key>
-    <string>MainStoryboard</string>
-    <key>MinimumOSVersion</key>
-    <string>7.0</string>
-    	<key>CFBundleURLTypes</key>
+<dict>
+	<key>CFBundleDisplayName</key>
+	<string>AdaliOSTestApp</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.your-company.adaliostestapp</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UIMainStoryboardFile</key>
+	<string>MainStoryboard</string>
+	<key>MinimumOSVersion</key>
+	<string>9.0</string>
+  <key>LSApplicationQueriesSchemes</key>
+  <array>
+    <string>msauth</string>
+  </array>
+	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
-			<string>com.your-company.AdaliOSTestApp</string>
+			<string>com.your-company.adaliostestapp</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>AdaliOSApp</string>
+				<string>adaliosapp</string>
 			</array>
 		</dict>
 	</array>
-  </dict>
+	<key>UIDeviceFamily</key>
+	<array>
+		<integer>1</integer>
+	</array>
+</dict>
 </plist>


### PR DESCRIPTION
Xamarin iOS ignored the expires_on claim returned from the broker and used UTC.Now + expires_in to compute expiration time. This resulted in current time as expiration time for the access token.