### PR TITLE
Add support for AcquireToken with client id, client secret, and user credential

### DIFF
--- a/src/ADAL.Common/AcquireTokenNonInteractiveHandler.cs
+++ b/src/ADAL.Common/AcquireTokenNonInteractiveHandler.cs
@@ -25,6 +25,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     internal class AcquireTokenNonInteractiveHandler : AcquireTokenHandlerBase
     {
         private readonly UserCredential userCredential;
+        private readonly string clientSecret;
         private UserAssertion userAssertion;
         
         public AcquireTokenNonInteractiveHandler(Authenticator authenticator, TokenCache tokenCache, string resource, string clientId, UserCredential userCredential, bool callSync)
@@ -36,6 +37,17 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
 
             this.userCredential = userCredential;
+        }
+
+        public AcquireTokenNonInteractiveHandler(Authenticator authenticator, TokenCache tokenCache, string resource, string clientId, string clientSecret, UserCredential userCredential, bool callSync)
+            : base(authenticator, tokenCache, resource, new ClientKey(clientId), TokenSubjectType.User, callSync)
+        {
+            if (userCredential == null)
+            {
+                throw new ArgumentNullException("userCredential");
+            }
+            this.userCredential = userCredential;
+            this.clientSecret = clientSecret;
         }
 
         public AcquireTokenNonInteractiveHandler(Authenticator authenticator, TokenCache tokenCache, string resource, string clientId, UserAssertion userAssertion, bool callSync)
@@ -128,6 +140,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         protected override void AddAditionalRequestParameters(RequestParameters requestParameters)
         {
+            if(this.clientSecret != null)
+            {
+                requestParameters[OAuthParameter.ClientSecret] = this.clientSecret;
+            }
+
             if (this.userAssertion != null)
             {
                 requestParameters[OAuthParameter.GrantType] = this.userAssertion.AssertionType;

--- a/src/ADAL.Common/AuthenticationContext.cs
+++ b/src/ADAL.Common/AuthenticationContext.cs
@@ -173,6 +173,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return await handler.RunAsync();
         }
 
+        private async Task<AuthenticationResult> AcquireTokenCommonAsync(string resource, string clientId, string clientSecret, UserCredential userCredential, bool callSync = false)
+        {
+            var handler = new AcquireTokenNonInteractiveHandler(this.Authenticator, this.TokenCache, resource, clientId, clientSecret, userCredential, callSync);
+            return await handler.RunAsync();
+        }
+
         private async Task<AuthenticationResult> AcquireTokenCommonAsync(string resource, string clientId, UserAssertion userAssertion, bool callSync = false)
         {
             var handler = new AcquireTokenNonInteractiveHandler(this.Authenticator, this.TokenCache, resource, clientId, userAssertion, callSync);

--- a/src/ADAL.NET/AuthenticationContext.cs
+++ b/src/ADAL.NET/AuthenticationContext.cs
@@ -392,6 +392,19 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
+        /// <param name="clientSecret">The client secret to use for token acquisition.</param>
+        /// <param name="userCredential">The credential to use for token acquisition.</param>
+        /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
+        public AuthenticationResult AcquireToken(string resource, string clientId, string clientSecret, UserCredential userCredential)
+        {
+            return RunAsyncTask(this.AcquireTokenCommonAsync(resource, clientId, clientSecret, userCredential, callSync: true));
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="userAssertion">The assertion to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
         public AuthenticationResult AcquireToken(string resource, string clientId, UserAssertion userAssertion)


### PR DESCRIPTION
In order to use PowerBI via Azure using non-interactive authentication a new AquireToken function signature was needed.

Fixes the error: 'AADSTS90014: The request body must contain the following parameter: 'client_secret or client_assertion' when trying to authenticate against a PowerBI web application.