### PR TITLE
Check assertion Hash when there are multiple tokens found - v2 #383

### DIFF
--- a/src/ADAL.Common/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.Common/AcquireTokenHandlerBase.cs
@@ -29,6 +29,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         protected readonly static Task CompletedTask = Task.FromResult(false);
         private readonly TokenCache tokenCache;
         protected Exception RefreshException;
+        protected readonly CacheQueryData CacheQueryData;
 
         protected AcquireTokenHandlerBase(Authenticator authenticator, TokenCache tokenCache, string resource, ClientKey clientKey, TokenSubjectType subjectType, bool callSync)
         {
@@ -56,6 +57,14 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.LoadFromCache = (tokenCache != null);
             this.StoreToCache = (tokenCache != null);
             this.SupportADFS = false;
+
+            CacheQueryData = new CacheQueryData();
+            CacheQueryData.Authority = Authenticator.Authority;
+            CacheQueryData.Resource = this.Resource;
+            CacheQueryData.ClientId = this.ClientKey.ClientId;
+            CacheQueryData.SubjectType = this.TokenSubjectType;
+            CacheQueryData.UniqueId = this.UniqueId;
+            CacheQueryData.DisplayableId = this.DisplayableId;
         }
 
         internal CallState CallState { get; set; }
@@ -94,9 +103,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     this.NotifyBeforeAccessCache();
                     notifiedBeforeAccessCache = true;
 
-                    result = this.tokenCache.LoadFromCache(this.Authenticator.Authority, this.Resource,
-                        this.ClientKey.ClientId, this.TokenSubjectType, this.UniqueId, this.DisplayableId,
-                        this.CallState);
+                    result = this.tokenCache.LoadFromCache(CacheQueryData, this.CallState);
                     result = this.ValidateResult(result);
 
                     if (result != null && result.AccessToken == null && result.RefreshToken != null)

--- a/src/ADAL.Common/AuthenticationResult.cs
+++ b/src/ADAL.Common/AuthenticationResult.cs
@@ -149,6 +149,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         [DataMember]
-        internal String UserAssertionHash { get; set; }
+        internal string UserAssertionHash { get; set; }
     }
 }

--- a/src/ADAL.Common/CacheQueryData.cs
+++ b/src/ADAL.Common/CacheQueryData.cs
@@ -16,19 +16,22 @@
 // limitations under the License.
 //----------------------------------------------------------------------
 
-using System;
-using System.Runtime.Serialization;
-
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
-    /// <summary>
-    /// Contains the results of one token acquisition operation. 
-    /// </summary>
-    [DataContract]
-    public partial class AuthenticationResult
+    class CacheQueryData
     {
-        // This is only needed for AcquireTokenByAuthorizationCode in which parameter resource is optional and we need
-        // to get it from the STS response.
-        internal string Resource { get; set; }
+        public string Authority { get; set; }
+
+        public string Resource { get; set; }
+
+        public string ClientId { get; set; }
+
+        public TokenSubjectType SubjectType { get; set; }
+
+        public string UniqueId { get; set; }
+
+        public string DisplayableId { get; set; }
+
+        public string AssertionHash { get; set; }
     }
 }

--- a/src/ADAL.Common/CommonAssemblyInfo.cs
+++ b/src/ADAL.Common/CommonAssemblyInfo.cs
@@ -27,11 +27,11 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Open Technologies. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 
-[assembly: AssemblyVersion("2.24.0.0")]
+[assembly: AssemblyVersion("2.25.0.0")]
 
 // Keep major and minor versions in AssemblyFileVersion in sync with AssemblyVersion.
 // Build and revision numbers are replaced on build machine for official builds.
-[assembly: AssemblyFileVersion("2.24.00000.0000")]
+[assembly: AssemblyFileVersion("2.25.00000.0000")]
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.
 // e.g.: [assembly: AssemblyInformationalVersionAttribute("4392c9835a38c27516fc0cd7bad7bccdcaeab161")]

--- a/src/ADAL.NET/ADAL.NET.csproj
+++ b/src/ADAL.NET/ADAL.NET.csproj
@@ -25,7 +25,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>Sdl7.0.ruleset</CodeAnalysisRuleSet>
-    
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -38,7 +37,6 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RunCodeAnalysis>true</RunCodeAnalysis>
     <CodeAnalysisRuleSet>Sdl7.0.ruleset</CodeAnalysisRuleSet>
-    
   </PropertyGroup>
   <PropertyGroup>
     <SignAssembly>true</SignAssembly>
@@ -119,6 +117,9 @@
     </Compile>
     <Compile Include="..\ADAL.Common\CallState.cs">
       <Link>Common\CallState.cs</Link>
+    </Compile>
+    <Compile Include="..\ADAL.Common\CacheQueryData.cs">
+      <Link>Common\CacheQueryData.cs</Link>
     </Compile>
     <Compile Include="..\ADAL.Common\ClientKey.cs">
       <Link>Common\ClientKey.cs</Link>

--- a/src/ADAL.NET/AcquireTokenOnBehalfHandler.cs
+++ b/src/ADAL.NET/AcquireTokenOnBehalfHandler.cs
@@ -24,7 +24,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     internal class AcquireTokenOnBehalfHandler : AcquireTokenHandlerBase
     {
         private readonly UserAssertion userAssertion;
-        private readonly string assertionHash;
 
         public AcquireTokenOnBehalfHandler(Authenticator authenticator, TokenCache tokenCache, string resource, ClientKey clientKey, UserAssertion userAssertion, bool callSync)
             : base(authenticator, tokenCache, resource, clientKey, TokenSubjectType.UserPlusClient, callSync)
@@ -36,7 +35,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
             this.userAssertion = userAssertion;
             this.DisplayableId = userAssertion.UserName;
-            this.assertionHash = PlatformSpecificHelper.CreateSha256Hash(userAssertion.Assertion);
+            CacheQueryData.AssertionHash = PlatformSpecificHelper.CreateSha256Hash(userAssertion.Assertion);
 
             this.SupportADFS = true;
         }
@@ -51,7 +50,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                  if (!string.IsNullOrEmpty(result.UserAssertionHash))
                  {
                      //if user assertion hash does not match then return null
-                     if (!result.UserAssertionHash.Equals(assertionHash))
+                     if (!result.UserAssertionHash.Equals(CacheQueryData.AssertionHash))
                      {
                          result = null;
                      }
@@ -72,7 +71,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
              AuthenticationResult result = await base.SendTokenRequestAsync();
              if (result != null)
              {
-                 result.UserAssertionHash = this.assertionHash;
+                 result.UserAssertionHash = CacheQueryData.AssertionHash;
              }
  
              return result;

--- a/src/ADAL.WinPhone/ADAL.WinPhone.csproj
+++ b/src/ADAL.WinPhone/ADAL.WinPhone.csproj
@@ -153,6 +153,9 @@
     <Compile Include="..\ADAL.Common\ClientMetrics.cs">
       <Link>Common\ClientMetrics.cs</Link>
     </Compile>
+    <Compile Include="..\ADAL.Common\CacheQueryData.cs">
+      <Link>Common\CacheQueryData.cs</Link>
+    </Compile>
     <Compile Include="..\ADAL.Common\Constants.cs">
       <Link>Common\Constants.cs</Link>
     </Compile>

--- a/src/ADAL.WinPhoneSL/ADAL.WinPhoneSL.csproj
+++ b/src/ADAL.WinPhoneSL/ADAL.WinPhoneSL.csproj
@@ -168,6 +168,9 @@
     <Compile Include="..\ADAL.Common\CallState.cs">
       <Link>Common\CallState.cs</Link>
     </Compile>
+    <Compile Include="..\ADAL.Common\CacheQueryData.cs">
+      <Link>Common\CacheQueryData.cs</Link>
+    </Compile>
     <Compile Include="..\ADAL.Common\ClientKey.cs">
       <Link>Common\ClientKey.cs</Link>
     </Compile>

--- a/src/ADAL.WinRT/ADAL.WinRT.csproj
+++ b/src/ADAL.WinRT/ADAL.WinRT.csproj
@@ -165,6 +165,9 @@
     <Compile Include="..\ADAL.Common\CallState.cs">
       <Link>Common\CallState.cs</Link>
     </Compile>
+    <Compile Include="..\ADAL.Common\CacheQueryData.cs">
+      <Link>Common\CacheQueryData.cs</Link>
+    </Compile>
     <Compile Include="..\ADAL.Common\ClientKey.cs">
       <Link>Common\ClientKey.cs</Link>
     </Compile>

--- a/tests/Test.ADAL.Common/TokenCacheTests.cs
+++ b/tests/Test.ADAL.Common/TokenCacheTests.cs
@@ -457,16 +457,6 @@ namespace Test.ADAL.Common.Unit
             tokenCache.Clear();
         }
 
-        public static void TokenCacheBackCompatTest(byte[] oldcache)
-         {
-             TokenCache cache = new TokenCache(oldcache);
-             Verify.IsNotNull(cache);
-             foreach (var value in cache.tokenCacheDictionary.Values)
-             {
-                 Verify.IsNull(value.UserAssertionHash);
-             }
-         }
-
 internal static void TokenCacheValueSplitTest()
         {
             var tokenCache = new TokenCache();
@@ -587,22 +577,27 @@ internal static void TokenCacheValueSplitTest()
             return item.Match(key);
         }
 
-        private static void VerifyAuthenticationResultsAreEqual(AuthenticationResult result1, AuthenticationResult result2)
+        public static void VerifyAuthenticationResultsAreEqual(AuthenticationResult result1, AuthenticationResult result2)
         {
             Verify.IsTrue(AreAuthenticationResultsEqual(result1, result2));
         }
 
-        private static void VerifyAuthenticationResultsAreNotEqual(AuthenticationResult result1, AuthenticationResult result2)
+        public static void VerifyAuthenticationResultsAreNotEqual(AuthenticationResult result1, AuthenticationResult result2)
         {
             Verify.IsFalse(AreAuthenticationResultsEqual(result1, result2));
         }
 
-        private static bool AreAuthenticationResultsEqual(AuthenticationResult result1, AuthenticationResult result2)
+        public static bool AreAuthenticationResultsEqual(AuthenticationResult result1, AuthenticationResult result2)
         {
+#if TEST_ADAL_NET            
+            if(result1.UserAssertionHash != result2.UserAssertionHash)
+            {
+                return false;
+            }
+#endif
             return (AreStringsEqual(result1.AccessToken, result2.AccessToken)
                     && AreStringsEqual(result1.AccessTokenType, result2.AccessTokenType)
                     && AreStringsEqual(result1.IdToken, result2.IdToken)
-                    && result1.UserAssertionHash == result2.UserAssertionHash
                     && result1.IsMultipleResourceRefreshToken == result2.IsMultipleResourceRefreshToken
                     && AreStringsEqual(result1.RefreshToken, result2.RefreshToken)
                     && AreStringsEqual(result1.TenantId, result2.TenantId)


### PR DESCRIPTION
For the server side scenarios, ADAL should check user assertion Hash (if provided) when there are multiple tokens found because the developer did not supply upn. #383