### PR TITLE
Add Preseve tag for dynamically loaded classes #385

### DIFF
--- a/src/ADAL.PCL.Android/BrokerHelper.cs
+++ b/src/ADAL.PCL.Android/BrokerHelper.cs
@@ -36,6 +36,7 @@ using Java.IO;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
+    [Android.Runtime.Preserve(AllMembers = true)]
     class BrokerHelper : IBrokerHelper
     {
         private static SemaphoreSlim readyForResponse = null;

--- a/src/ADAL.PCL.Android/CryptographyHelper.cs
+++ b/src/ADAL.PCL.Android/CryptographyHelper.cs
@@ -29,6 +29,7 @@ using System;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
+    [Android.Runtime.Preserve(AllMembers = true)]
     internal class CryptographyHelper : ICryptographyHelper
     {
         public string CreateSha256Hash(string input)

--- a/src/ADAL.PCL.Android/DeviceAuthHelper.cs
+++ b/src/ADAL.PCL.Android/DeviceAuthHelper.cs
@@ -25,20 +25,12 @@
 //
 //------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Android.App;
-using Android.Content;
-using Android.OS;
-using Android.Runtime;
-using Android.Views;
-using Android.Widget;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
+    [Android.Runtime.Preserve(AllMembers = true)]
     internal class DeviceAuthHelper : IDeviceAuthHelper
     {
         public bool CanHandleDeviceAuthChallenge {

--- a/src/ADAL.PCL.Android/Logger.cs
+++ b/src/ADAL.PCL.Android/Logger.cs
@@ -31,6 +31,7 @@ using Android.Util;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
+    [Android.Runtime.Preserve(AllMembers = true)]
     internal class Logger : LoggerBase
     {
         internal override void Error(CallState callState, Exception ex, [System.Runtime.CompilerServices.CallerFilePath] string callerFilePath = "")

--- a/src/ADAL.PCL.Android/PlatformInformation.cs
+++ b/src/ADAL.PCL.Android/PlatformInformation.cs
@@ -29,6 +29,7 @@ using System.Threading.Tasks;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
+    [Android.Runtime.Preserve(AllMembers = true)]
     internal class PlatformInformation : PlatformInformationBase
     {
         public override string GetProductName()

--- a/src/ADAL.PCL.Android/TokenCachePlugin.cs
+++ b/src/ADAL.PCL.Android/TokenCachePlugin.cs
@@ -31,6 +31,7 @@ using System;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
+    [Android.Runtime.Preserve(AllMembers = true)]
     internal class TokenCachePlugin : ITokenCachePlugin
     {
         private const string SharedPreferencesName = "ActiveDirectoryAuthenticationLibrary";

--- a/src/ADAL.PCL.Android/WebUIFactory.cs
+++ b/src/ADAL.PCL.Android/WebUIFactory.cs
@@ -27,6 +27,7 @@
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
+    [Android.Runtime.Preserve(AllMembers = true)]
     internal class WebUIFactory : IWebUIFactory
     {
         public IWebUI CreateAuthenticationDialog(IPlatformParameters parameters)

--- a/tests/TestApp/AdalAndroidTestApp/AdalAndroidTestApp.csproj
+++ b/tests/TestApp/AdalAndroidTestApp/AdalAndroidTestApp.csproj
@@ -20,7 +20,7 @@
     <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
@@ -28,7 +28,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
-    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+    <AndroidLinkMode>Full</AndroidLinkMode>
     <AndroidLinkSkip />
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <BundleAssemblies>False</BundleAssemblies>
@@ -49,8 +49,21 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
-    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+    <AndroidLinkMode>Full</AndroidLinkMode>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AndroidLinkSkip />
+    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+    <BundleAssemblies>False</BundleAssemblies>
+    <AndroidCreatePackagePerAbi>False</AndroidCreatePackagePerAbi>
+    <AndroidSupportedAbis />
+    <AndroidStoreUncompressedFileExtensions />
+    <MandroidI18n />
+    <Debugger>Xamarin</Debugger>
+    <AotAssemblies>False</AotAssemblies>
+    <EnableLLVM>False</EnableLLVM>
+    <AndroidEnableMultiDex>False</AndroidEnableMultiDex>
+    <EnableProguard>False</EnableProguard>
+    <DebugSymbols>False</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/tests/TestApp/XFormsApp.Droid/XFormsApp.Droid.csproj
+++ b/tests/TestApp/XFormsApp.Droid/XFormsApp.Droid.csproj
@@ -28,7 +28,7 @@
     <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
+    <DebugSymbols>True</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
@@ -36,7 +36,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
-    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+    <AndroidLinkMode>Full</AndroidLinkMode>
     <AndroidLinkSkip />
     <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
     <BundleAssemblies>False</BundleAssemblies>


### PR DESCRIPTION
When using ADAL with Xamarin.Android, if full linking is enabled, then
ADAL fails with the following exception:

System.ArgumentNullException: Value cannot be null.
Parameter name: type
at System.Activator.CreateInstance (System.Type type, Boolean nonPublic)
[0x00006] in :0
at System.Activator.CreateInstance (System.Type type) [0x00000] in :0
at
Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformPlugin.InitializeByAssemblyDynamicLinking
() [0x00011] in :0
at Microsoft.IdentityModel.Clients.ActiveDirectory.PlatformPlugin..cctor
() [0x00011] in :0

The problem appears to be that ADAL is dynamically loading types using
reflection, and the linker does not recognize this pattern so removes
them.

Linker attributes could be used to to ensure the dynamically loaded
types are preserved:
https://developer.xamarin.com/guides/android/advanced_topics/linking/

See also https://bugzilla.xamarin.com/show_bug.cgi?id=40811#c2