### PR TITLE
v3 - add haschrome=1 QP to all interactive requests #387

### DIFF
--- a/src/ADAL.PCL/AcquireTokenInteractiveHandler.cs
+++ b/src/ADAL.PCL/AcquireTokenInteractiveHandler.cs
@@ -168,7 +168,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             var authorizationRequestParameters = new DictionaryRequestParameters(this.Resource, this.ClientKey);
             authorizationRequestParameters[OAuthParameter.ResponseType] = OAuthResponseType.Code;
-
+            authorizationRequestParameters[OAuthParameter.HasChrome] = "1";
             authorizationRequestParameters[OAuthParameter.RedirectUri] = this.redirectUriRequestParameter;
 
             if (!string.IsNullOrWhiteSpace(loginHint))

--- a/src/ADAL.PCL/OAuthConstants.cs
+++ b/src/ADAL.PCL/OAuthConstants.cs
@@ -45,6 +45,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public const string Username = "username";
         public const string Password = "password";
 
+        public const string HasChrome = "haschrome";
         public const string LoginHint = "login_hint"; // login_hint is not standard oauth2 parameter
         public const string CorrelationId = OAuthHeader.CorrelationId; // correlation id is not standard oauth2 parameter
         public const string Prompt = "prompt"; // prompt is not standard oauth2 parameter


### PR DESCRIPTION
ADAL should send haschrome=1 QP for all interactive requests. This will
hide the back button the UI and developers will stop getting
access_denied error when it was actually user_cancel.