### PR TITLE
enable refresh_token grant for ADFS in v2. #402

### DIFF
--- a/src/ADAL.Common/AcquireTokenByRefreshTokenHandler.cs
+++ b/src/ADAL.Common/AcquireTokenByRefreshTokenHandler.cs
@@ -36,11 +36,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 throw new ArgumentNullException("refreshToken");
             }
 
-            if (!string.IsNullOrWhiteSpace(resource) && this.Authenticator.AuthorityType != AuthorityType.AAD)
-            {
-                throw new ArgumentException(AdalErrorMessage.UnsupportedMultiRefreshToken, "resource");
-            }
-
             this.refreshToken = refreshToken;
             this.LoadFromCache = false;
             this.StoreToCache = false;

--- a/src/ADAL.Common/AcquireTokenNonInteractiveHandler.cs
+++ b/src/ADAL.Common/AcquireTokenNonInteractiveHandler.cs
@@ -91,7 +91,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             await base.PreTokenRequest();
 
-            if (this.userAssertion == null)
+            //user_realm discovery should be done only for AAD
+            if (this.userAssertion == null && this.Authenticator.AuthorityType != AuthorityType.ADFS)
             { 
                 UserRealmDiscoveryResponse userRealmResponse = await UserRealmDiscoveryResponse.CreateByDiscoveryAsync(this.Authenticator.UserRealmUri, this.userCredential.UserName, this.CallState);
                 Logger.Information(this.CallState, "User with hash '{0}' detected as '{1}'", PlatformSpecificHelper.CreateSha256Hash(this.userCredential.UserName), userRealmResponse.AccountType);

--- a/src/ADAL.Common/CommonAssemblyInfo.cs
+++ b/src/ADAL.Common/CommonAssemblyInfo.cs
@@ -27,11 +27,11 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Open Technologies. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 
-[assembly: AssemblyVersion("2.25.0.0")]
+[assembly: AssemblyVersion("2.26.0.0")]
 
 // Keep major and minor versions in AssemblyFileVersion in sync with AssemblyVersion.
 // Build and revision numbers are replaced on build machine for official builds.
-[assembly: AssemblyFileVersion("2.25.00000.0000")]
+[assembly: AssemblyFileVersion("2.26.00000.0000")]
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.
 // e.g.: [assembly: AssemblyInformationalVersionAttribute("4392c9835a38c27516fc0cd7bad7bccdcaeab161")]

--- a/src/ADAL.NET/AuthenticationContext.cs
+++ b/src/ADAL.NET/AuthenticationContext.cs
@@ -49,6 +49,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires security token from the authority.
         /// </summary>
+        /// <remarks>This feature is supported only for Azure Active Directory and Active Directory Federation Services (ADFS) on Windows 10.</remarks> 
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="userCredential">The user credential to use for token acquisition.</param>
@@ -378,6 +379,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires security token from the authority.
         /// </summary>
+        /// <remarks>This feature is supported only for Azure Active Directory and Active Directory Federation Services (ADFS) on Windows 10.</remarks> 
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="userCredential">The credential to use for token acquisition.</param>


### PR DESCRIPTION
enable refresh_token grant for ADFS in v2. Remove the check where ADAL failed when authority was not ADFS.