### PR TITLE
Fix array resize issue during Url encoding where Array.Resize call wa…

### DIFF
--- a/src/ADAL.Common/EncodingHelper.cs
+++ b/src/ADAL.Common/EncodingHelper.cs
@@ -187,12 +187,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 var str = new string(singleChar);
                 string encodedStr = UrlEncode(str);
                 char[] encodedSingleChar = encodedStr.ToCharArray();
-                encodedSingleChar.CopyTo(encodedMessage, length);
                 if (length + encodedSingleChar.Length > encodedMessage.Length)
                 {
-                    Array.Resize(ref encodedMessage, message.Length * 2);
+                    Array.Resize(ref encodedMessage, encodedMessage.Length + message.Length * 2);
                 }
 
+                encodedSingleChar.CopyTo(encodedMessage, length);
                 length += encodedSingleChar.Length;
             }
 

--- a/tests/Test.ADAL.NET.Unit/UnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/UnitTests.cs
@@ -55,6 +55,7 @@ namespace Test.ADAL.NET.Unit
             TestUrlEncoding("   ");
             TestUrlEncoding(ComplexString);
             TestUrlEncoding(ComplexString2);
+            TestUrlEncoding("@");
         }
 
         [TestMethod]


### PR DESCRIPTION
…s not being provided new size of the array and developer got index out of bound exception. CopyTo function was also being called at the wrong place. the code should resize the array (if needed) and then copy to. #405