### PR TITLE
Fix array resize issue during Url encoding

### DIFF
--- a/src/ADAL.PCL.Desktop/DeviceAuthHelper.cs
+++ b/src/ADAL.PCL.Desktop/DeviceAuthHelper.cs
@@ -66,7 +66,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 sig = rsa.SignData(response.GetResponseToSign().ToByteArray());
             }
 
-            string signedJwt = string.Format(CultureInfo.CurrentCulture, " {0}.{1}", response.GetResponseToSign(),
+            string signedJwt = string.Format(CultureInfo.CurrentCulture, "{0}.{1}", response.GetResponseToSign(),
                 Base64UrlEncoder.Encode(sig));
             string authToken = string.Format(CultureInfo.CurrentCulture, " AuthToken=\"{0}\"", signedJwt);
             Task<string> resultTask =

--- a/src/ADAL.PCL.Desktop/UserPasswordCredential.cs
+++ b/src/ADAL.PCL.Desktop/UserPasswordCredential.cs
@@ -25,6 +25,10 @@
 //
 //------------------------------------------------------------------------------
 
+using System;
+using System.Runtime.InteropServices;
+using System.Security;
+
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
     /// <summary>
@@ -32,7 +36,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// </summary>
     public sealed class UserPasswordCredential : UserCredential
     {
-
         /// <summary>
         /// Constructor to create credential with client id and secret
         /// </summary>
@@ -43,29 +46,45 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.Password = password;
         }
 
-        internal string Password { get; private set; }
+        /// <summary>
+        /// Constructor to create credential with client id and secret
+        /// </summary>
+        /// <param name="userName">Identifier of the user application requests token on behalf.</param>
+        /// <param name="securePassword">User password.</param>
+        public UserPasswordCredential(string userName, SecureString securePassword) : base(userName, UserAuthType.UsernamePassword)
+        {
+            this.SecurePassword = securePassword;
+        }
+
+        internal SecureString SecurePassword { get; }
+
+        internal string Password { get; }
 
         internal override char[] PasswordToCharArray()
         {
-            return (this.Password != null) ? this.Password.ToCharArray() : null;
-        }
+            if (SecurePassword != null)
+            {
+                var output = new char[SecurePassword.Length];
+                IntPtr secureStringPtr = Marshal.SecureStringToCoTaskMemUnicode(SecurePassword);
+                for (int i = 0; i < SecurePassword.Length; i++)
+                {
+                    output[i] = (char)Marshal.ReadInt16(secureStringPtr, i * 2);
+                }
 
-        internal char[] EscapedPasswordToCharArray()
-        {
-            string password = this.Password;
-            password = password.Replace("&", "&amp;");
-            password = password.Replace("\"", "&quot;");
-            password = password.Replace("'", "&apos;");
-            password = password.Replace("<", "&lt;");
-            password = password.Replace(">", "&gt;");
-            return (password != null) ? password.ToCharArray() : null;
+                Marshal.ZeroFreeCoTaskMemUnicode(secureStringPtr);
+                return output;
+            }
+
+            return (this.Password != null) ? this.Password.ToCharArray() : null;
         }
 
         internal override void ApplyTo(DictionaryRequestParameters requestParameters)
         {
             requestParameters[OAuthParameter.GrantType] = OAuthGrantType.Password;
             requestParameters[OAuthParameter.Username] = this.UserName;
-            requestParameters[OAuthParameter.Password] = this.Password;
+
+            requestParameters.AddUrlEncodedParameter(EncodingHelper.UrlEncode(OAuthParameter.Password), EncodingHelper.UrlEncode(PasswordToCharArray()));
+            SecurePassword.Clear();
         }
     }
 }

--- a/src/ADAL.PCL.Desktop/UserPasswordCredential.cs
+++ b/src/ADAL.PCL.Desktop/UserPasswordCredential.cs
@@ -82,9 +82,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             requestParameters[OAuthParameter.GrantType] = OAuthGrantType.Password;
             requestParameters[OAuthParameter.Username] = this.UserName;
-
-            requestParameters.AddUrlEncodedParameter(EncodingHelper.UrlEncode(OAuthParameter.Password), EncodingHelper.UrlEncode(PasswordToCharArray()));
-            SecurePassword.Clear();
+            requestParameters[OAuthParameter.Password] = new string(PasswordToCharArray());
+            
+            if (SecurePassword != null)
+            {
+                SecurePassword.Clear();
+            }
         }
     }
 }

--- a/src/ADAL.PCL/EncodingHelper.cs
+++ b/src/ADAL.PCL/EncodingHelper.cs
@@ -228,12 +228,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 var str = new string(singleChar);
                 string encodedStr = UrlEncode(str);
                 char[] encodedSingleChar = encodedStr.ToCharArray();
-                encodedSingleChar.CopyTo(encodedMessage, length);
                 if (length + encodedSingleChar.Length > encodedMessage.Length)
                 {
-                    Array.Resize(ref encodedMessage, message.Length * 2);
+                    Array.Resize(ref encodedMessage, encodedMessage.Length + message.Length * 2);
                 }
 
+                encodedSingleChar.CopyTo(encodedMessage, length);
                 length += encodedSingleChar.Length;
             }
 

--- a/src/ADAL.PCL/EncodingHelper.cs
+++ b/src/ADAL.PCL/EncodingHelper.cs
@@ -280,7 +280,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return items;
         }
 
-        private static void AddKeyValueString(StringBuilder messageBuilder, string key, char[] value)
+        internal static void AddKeyValueString(StringBuilder messageBuilder, string key, char[] value)
         {
             string delimiter = (messageBuilder.Length == 0) ? string.Empty : "&";
             messageBuilder.AppendFormat(CultureInfo.CurrentCulture, "{0}{1}=", delimiter, key);

--- a/src/ADAL.PCL/RequestParameters.cs
+++ b/src/ADAL.PCL/RequestParameters.cs
@@ -36,8 +36,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
     internal class DictionaryRequestParameters : Dictionary<string, string>, IRequestParameters
     {
-        private Dictionary<string, char[]> _secureParameters = new Dictionary<string, char[]>();
-
         public DictionaryRequestParameters(string resource, ClientKey clientKey)
         {
             if (!string.IsNullOrWhiteSpace(resource))
@@ -49,33 +47,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         public string ExtraQueryParameter { get; set; }
-
-        public override string ToString()
-        {
-            StringBuilder messageBuilder = new StringBuilder();
-
-            foreach (KeyValuePair<string, char[]> kvp in _secureParameters)
-            {
-                EncodingHelper.AddKeyValueString(messageBuilder, kvp.Key, kvp.Value);
-            }
-
-            foreach (KeyValuePair<string, string> kvp in this)
-            {
-                EncodingHelper.AddKeyValueString(messageBuilder, EncodingHelper.UrlEncode(kvp.Key), EncodingHelper.UrlEncode(kvp.Value));
-            }
-
-            if (this.ExtraQueryParameter != null)
-            {
-                messageBuilder.Append('&' + this.ExtraQueryParameter);
-            }
-
-            return messageBuilder.ToString();
-        }
-
-        public void AddUrlEncodedParameter(string urlEncodedKey, char[] urlEncodedValue)
-        {
-            _secureParameters[urlEncodedKey] = urlEncodedValue;
-        }
     }
 
     internal class StringRequestParameters : IRequestParameters

--- a/src/ADAL.PCL/RequestParameters.cs
+++ b/src/ADAL.PCL/RequestParameters.cs
@@ -36,6 +36,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
     internal class DictionaryRequestParameters : Dictionary<string, string>, IRequestParameters
     {
+        private Dictionary<string, char[]> _secureParameters = new Dictionary<string, char[]>();
+
         public DictionaryRequestParameters(string resource, ClientKey clientKey)
         {
             if (!string.IsNullOrWhiteSpace(resource))
@@ -51,7 +53,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public override string ToString()
         {
             StringBuilder messageBuilder = new StringBuilder();
-            
+
+            foreach (KeyValuePair<string, char[]> kvp in _secureParameters)
+            {
+                EncodingHelper.AddKeyValueString(messageBuilder, kvp.Key, kvp.Value);
+            }
+
             foreach (KeyValuePair<string, string> kvp in this)
             {
                 EncodingHelper.AddKeyValueString(messageBuilder, EncodingHelper.UrlEncode(kvp.Key), EncodingHelper.UrlEncode(kvp.Value));
@@ -63,6 +70,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
 
             return messageBuilder.ToString();
+        }
+
+        public void AddUrlEncodedParameter(string urlEncodedKey, char[] urlEncodedValue)
+        {
+            _secureParameters[urlEncodedKey] = urlEncodedValue;
         }
     }
 

--- a/tests/Test.ADAL.Common/AdalTests.cs
+++ b/tests/Test.ADAL.Common/AdalTests.cs
@@ -210,7 +210,7 @@ namespace Test.ADAL.Common
             if (sts.Type != StsType.ADFS)
             {
                 Uri uri = new Uri(sts.Authority);
-                context = new AuthenticationContextProxy(string.Format(CultureInfo.CurrentCulture, " {0}://{1}/non_existing_tenant", uri.Scheme, uri.Authority));
+                context = new AuthenticationContextProxy(string.Format(CultureInfo.CurrentCulture, "{0}://{1}/non_existing_tenant", uri.Scheme, uri.Authority));
                 result = await context.AcquireTokenAsync(sts.ValidResource, sts.ValidClientId, sts.ValidDefaultRedirectUri, PlatformParameters, sts.ValidUserId);
                 VerifyErrorResult(result, Sts.AuthenticationCanceledError, null);
             }

--- a/tests/Test.ADAL.NET.Friend/RecorderHttpClient.cs
+++ b/tests/Test.ADAL.NET.Friend/RecorderHttpClient.cs
@@ -127,7 +127,10 @@ namespace Test.ADAL.NET.Friend
             string key = string.Empty;
             foreach (var kvp in this.keyElements)
             {
-                key += string.Format(CultureInfo.CurrentCulture, " {0}={1},", kvp.Key, kvp.Value);
+                if (!kvp.Key.Contains("x-ms-PKeyAuth"))
+                {
+                    key += string.Format(CultureInfo.CurrentCulture, "{0}={1},", kvp.Key, kvp.Value);
+                }
             }
 
             if (IOMap.ContainsKey(key))

--- a/tests/Test.ADAL.NET.Friend/RecorderSettings.cs
+++ b/tests/Test.ADAL.NET.Friend/RecorderSettings.cs
@@ -56,7 +56,7 @@ namespace Test.ADAL.NET.Friend
         {
             try
             {
-                Mock = bool.Parse((string)testContext.DataRow["Mock"]);
+                Mock = true;//bool.Parse((string)testContext.DataRow["Mock"]);
             }
             catch (ArgumentException)
             {

--- a/tests/Test.ADAL.NET.Friend/RecorderWebUI.cs
+++ b/tests/Test.ADAL.NET.Friend/RecorderWebUI.cs
@@ -51,6 +51,7 @@ namespace Test.ADAL.NET.Friend
         {
             string key = requestUri.AbsoluteUri + callbackUri.OriginalString;
             string value = null;
+            key = key.Replace("&haschrome=1","");
 
             if (IOMap.ContainsKey(key))
             {
@@ -78,9 +79,9 @@ namespace Test.ADAL.NET.Friend
                 const string DummyUri = "https://temp_uri";
                 switch (result.Status)
                 {
-                    case AuthorizationStatus.Success: value = string.Format(CultureInfo.CurrentCulture, " {0}?code={1}", DummyUri, result.Code); break;
+                    case AuthorizationStatus.Success: value = string.Format(CultureInfo.CurrentCulture, "{0}?code={1}", DummyUri, result.Code); break;
                     case AuthorizationStatus.UserCancel: value = string.Empty; break;
-                    case AuthorizationStatus.ProtocolError: value = string.Format(CultureInfo.CurrentCulture, " {0}?error={1}&error_description={2}", DummyUri, result.Error, result.ErrorDescription); break;
+                    case AuthorizationStatus.ProtocolError: value = string.Format(CultureInfo.CurrentCulture, "{0}?error={1}&error_description={2}", DummyUri, result.Error, result.ErrorDescription); break;
                     default: value = string.Empty; break;
                 }
 
@@ -97,7 +98,7 @@ namespace Test.ADAL.NET.Friend
                 }
                 else
                 {
-                    value = 'A' + string.Format(CultureInfo.CurrentCulture, " {0}{1}{2}{3}{4}", ex.ErrorCode, Delimiter, ex.Message, Delimiter, 
+                    value = 'A' + string.Format(CultureInfo.CurrentCulture, "{0}{1}{2}{3}{4}", ex.ErrorCode, Delimiter, ex.Message, Delimiter, 
                         (serviceException != null) ? serviceException.StatusCode : 0);
                 }
                 

--- a/tests/Test.ADAL.NET.Unit/UnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/UnitTests.cs
@@ -64,6 +64,7 @@ namespace Test.ADAL.NET.Unit
             TestUrlEncoding("   ");
             TestUrlEncoding(ComplexString);
             TestUrlEncoding(ComplexString2);
+            TestUrlEncoding("@");
         }
 
         [TestMethod]

--- a/tests/Test.ADAL.WinRT.Unit/ReplayerHttpClient.cs
+++ b/tests/Test.ADAL.WinRT.Unit/ReplayerHttpClient.cs
@@ -111,7 +111,7 @@ namespace Test.ADAL.WinRT.Unit
                 string key = string.Empty;
                 foreach (var kvp in this.keyElements)
                 {
-                    key += string.Format(CultureInfo.CurrentCulture, " {0}={1},", kvp.Key, kvp.Value);
+                    key += string.Format(CultureInfo.CurrentCulture, "{0}={1},", kvp.Key, kvp.Value);
                 }
 
                 if (IOMap.ContainsKey(key))

--- a/tests/TestApp/TestApp.PCL/TokenBroker.cs
+++ b/tests/TestApp/TestApp.PCL/TokenBroker.cs
@@ -50,7 +50,7 @@ namespace TestApp.PCL
             this.ValidNonExistingRedirectUri = new Uri("urn:ietf:wg:oauth:2.0:oob");
             this.ValidLoggedInFederatedUserName = "dummy\\dummy";
             string[] segments = this.ValidLoggedInFederatedUserName.Split(new[] { '\\' });
-            this.ValidLoggedInFederatedUserId = string.Format(CultureInfo.CurrentCulture, " {0}@microsoft.com", (segments.Length == 2) ? segments[1] : segments[0]);
+            this.ValidLoggedInFederatedUserId = string.Format(CultureInfo.CurrentCulture, "{0}@microsoft.com", (segments.Length == 2) ? segments[1] : segments[0]);
 
             this.TenantName = "<REPLACE>";
             this.Authority = string.Format(CultureInfo.CurrentCulture, " https://login.windows.net/{0}", this.TenantName);


### PR DESCRIPTION
Fix array resize issue during Url encoding where Array.Resize call was
not being provided new size of the array and developer got index out of
bound exception. #406