### PR TITLE
Fix Mac test app

### DIFF
--- a/tests/TestApp/AdalMacTestApp/ViewController.cs
+++ b/tests/TestApp/AdalMacTestApp/ViewController.cs
@@ -67,14 +67,14 @@ namespace AdalMacTestApp
         async partial void AcquireInteractiveClicked(NSObject sender)
         {
             textView.Value = string.Empty;
-            string token = await CreateBrokerWithSts().GetTokenInteractiveAsync(new PlatformParameters(this.View.Window) { UseModalDialog = true });
+            string token = await CreateBrokerWithSts().GetTokenInteractiveAsync(new PlatformParameters(this.View.Window));
             textView.Value = token;
         }
 
         async partial void AcquireSilentClicked(NSObject sender)
         {
             textView.Value = string.Empty;
-            string token = await CreateBrokerWithSts ().GetTokenSilentAsync(new PlatformParameters(View.Window) { UseModalDialog = true });
+            string token = await CreateBrokerWithSts ().GetTokenSilentAsync(new PlatformParameters(View.Window));
             textView.Value = token;
         }
 

--- a/tests/TestApp/AdalMacTestApp/ViewController.cs
+++ b/tests/TestApp/AdalMacTestApp/ViewController.cs
@@ -67,14 +67,14 @@ namespace AdalMacTestApp
         async partial void AcquireInteractiveClicked(NSObject sender)
         {
             textView.Value = string.Empty;
-            string token = await CreateBrokerWithSts().GetTokenInteractiveAsync(new PlatformParameters(this.View.Window, false) { UseModalDialog = true });
+            string token = await CreateBrokerWithSts().GetTokenInteractiveAsync(new PlatformParameters(this.View.Window) { UseModalDialog = true });
             textView.Value = token;
         }
 
         async partial void AcquireSilentClicked(NSObject sender)
         {
             textView.Value = string.Empty;
-            string token = await CreateBrokerWithSts ().GetTokenSilentAsync(new PlatformParameters(View.Window, false) { UseModalDialog = true });
+            string token = await CreateBrokerWithSts ().GetTokenSilentAsync(new PlatformParameters(View.Window) { UseModalDialog = true });
             textView.Value = token;
         }
 


### PR DESCRIPTION
This PR is just to fix a couple errors in the AdalMacTestApp.

The constructor that takes the second parameter was removed in this commit: https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/commit/16268d05889f3c8a8b0883fc3ed98ce214793913

The `UseModalDialog` property was removed in this commit: https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/commit/02ba9c3ceb754b6caf49a4a5c203a6dfcce44737

/cc @mhutch