### PR TITLE
 Fix to allow hardware based keys to perform authentication.

### DIFF
--- a/src/ADAL.Common/CommonAssemblyInfo.cs
+++ b/src/ADAL.Common/CommonAssemblyInfo.cs
@@ -27,11 +27,11 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Open Technologies. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 
-[assembly: AssemblyVersion("2.26.0.0")]
+[assembly: AssemblyVersion("2.27.0.0")]
 
 // Keep major and minor versions in AssemblyFileVersion in sync with AssemblyVersion.
 // Build and revision numbers are replaced on build machine for official builds.
-[assembly: AssemblyFileVersion("2.26.00000.0000")]
+[assembly: AssemblyFileVersion("2.27.00000.0000")]
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.
 // e.g.: [assembly: AssemblyInformationalVersionAttribute("4392c9835a38c27516fc0cd7bad7bccdcaeab161")]

--- a/src/ADAL.NET/CryptographyHelper.cs
+++ b/src/ADAL.NET/CryptographyHelper.cs
@@ -29,7 +29,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public static byte[] SignWithCertificate(string message, X509Certificate2 x509Certificate)
         {
             X509AsymmetricSecurityKey x509Key = new X509AsymmetricSecurityKey(x509Certificate);
-            RSACryptoServiceProvider rsa = x509Key.GetAsymmetricAlgorithm(SecurityAlgorithms.RsaSha256Signature, true) as RSACryptoServiceProvider;
+            RSACryptoServiceProvider rsa =
+                x509Key.GetAsymmetricAlgorithm(SecurityAlgorithms.RsaSha256Signature, true) as RSACryptoServiceProvider;
 
             RSACryptoServiceProvider newRsa = null;
             try
@@ -62,30 +63,32 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         // This method returns an AsymmetricSignatureFormatter capable of supporting Sha256 signatures. 
         private static RSACryptoServiceProvider GetCryptoProviderForSha256(RSACryptoServiceProvider rsaProvider)
         {
-            const int PROV_RSA_AES = 24;    // CryptoApi provider type for an RSA provider supporting sha-256 digital signatures
-            if (rsaProvider.CspKeyContainerInfo.ProviderType == PROV_RSA_AES)
+            const int PROV_RSA_AES = 24;
+                // CryptoApi provider type for an RSA provider supporting sha-256 digital signatures
+            if ((rsaProvider.CspKeyContainerInfo.ProviderType == 1 || rsaProvider.CspKeyContainerInfo.ProviderType == 12) &&
+                !rsaProvider.CspKeyContainerInfo.HardwareDevice)
             {
-                return rsaProvider;
+                CspParameters csp = new CspParameters
+                {
+                    ProviderType = PROV_RSA_AES,
+                    KeyContainerName = rsaProvider.CspKeyContainerInfo.KeyContainerName,
+                    KeyNumber = (int) rsaProvider.CspKeyContainerInfo.KeyNumber
+                };
+
+                if (rsaProvider.CspKeyContainerInfo.MachineKeyStore)
+                {
+                    csp.Flags = CspProviderFlags.UseMachineKeyStore;
+                }
+
+                //
+                // If UseExistingKey is not specified, the CLR will generate a key for a non-existent group.
+                // With this flag, a CryptographicException is thrown instead.
+                //
+                csp.Flags |= CspProviderFlags.UseExistingKey;
+                return new RSACryptoServiceProvider(csp);
             }
 
-            CspParameters csp = new CspParameters
-                                {
-                                    ProviderType = PROV_RSA_AES,
-                                    KeyContainerName = rsaProvider.CspKeyContainerInfo.KeyContainerName,
-                                    KeyNumber = (int)rsaProvider.CspKeyContainerInfo.KeyNumber
-                                };
-
-            if (rsaProvider.CspKeyContainerInfo.MachineKeyStore)
-            {
-                csp.Flags = CspProviderFlags.UseMachineKeyStore;
-            }
-
-            //
-            // If UseExistingKey is not specified, the CLR will generate a key for a non-existent group.
-            // With this flag, a CryptographicException is thrown instead.
-            //
-            csp.Flags |= CspProviderFlags.UseExistingKey;
-            return new RSACryptoServiceProvider(csp);
+            return rsaProvider;
         }
     }
 }


### PR DESCRIPTION
We should only up-level software keys using the CAPI PROV_RSA_FULL and
 PROV_RSA_SCHANNEL providers and never up-level hardware based keys.