### PR TITLE
set displayableId as the username for cache lookup

### DIFF
--- a/src/ADAL.PCL/AcquireTokenNonInteractiveHandler.cs
+++ b/src/ADAL.PCL/AcquireTokenNonInteractiveHandler.cs
@@ -53,6 +53,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
 
             this.userCredential = userCredential;
+            this.DisplayableId = this.userCredential.UserName;
+            this.CacheQueryData.DisplayableId = this.DisplayableId;
         }
 
         public AcquireTokenNonInteractiveHandler(Authenticator authenticator, TokenCache tokenCache, string resource, string clientId, UserAssertion userAssertion)

--- a/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
@@ -369,8 +369,36 @@ namespace Test.ADAL.NET.Unit
                 }
             });
 
-            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true);
-            AuthenticationResult result =
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Get,
+                ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content =
+            new StringContent("{\"ver\":\"1.0\",\"account_type\":\"Managed\",\"domain_name\":\"id.com\"}")
+                },
+                QueryParams = new Dictionary<string, string>()
+                {
+                    {"api-version", "1.0"}
+                }
+            });
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(TestConstants.DefaultUniqueId, "user2@id.com", TestConstants.DefaultResource),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"grant_type", "password"},
+                    {"username", "user2@id.com"},
+                    {"password", TestConstants.DefaultPassword}
+                }
+            });
+
+            TokenCache cache = new TokenCache();
+            
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, cache);
+            var result =
                 await
                     context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
                         new UserPasswordCredential(TestConstants.DefaultDisplayableId, TestConstants.DefaultPassword));
@@ -379,6 +407,18 @@ namespace Test.ADAL.NET.Unit
             Assert.AreEqual(result.AccessToken, "some-access-token");
             Assert.IsNotNull(result.UserInfo);
             Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+            Assert.AreEqual(TestConstants.DefaultUniqueId, result.UserInfo.UniqueId);
+
+            context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, cache);
+            result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
+                        new UserPasswordCredential("user2@id.com", TestConstants.DefaultPassword));
+            Assert.IsNotNull(result);
+            Assert.AreEqual(TestConstants.DefaultAuthorityHomeTenant, context.Authenticator.Authority);
+            Assert.AreEqual(result.AccessToken, "some-access-token");
+            Assert.IsNotNull(result.UserInfo);
+            Assert.AreEqual("user2@id.com", result.UserInfo.DisplayableId);
             Assert.AreEqual(TestConstants.DefaultUniqueId, result.UserInfo.UniqueId);
         }
 

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
@@ -84,7 +84,7 @@ namespace Test.ADAL.NET.Unit.Mocks
 
         public static HttpResponseMessage CreateSuccessTokenResponseMessage(string uniqueId, string displayableId, string resource)
         {
-            string idToken = string.Format(CultureInfo.InvariantCulture, "someheader.{0}.somesignature", CreateIdToken(uniqueId, displayableId));
+            string idToken = string.Format(CultureInfo.InvariantCulture, "{0}", CreateIdToken(uniqueId, displayableId));
             HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
             HttpContent content =
                 new StringContent("{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"resource\":\"" +
@@ -114,7 +114,7 @@ namespace Test.ADAL.NET.Unit.Mocks
                         "\"tid\": \"some-tenant-id\"," +
                         "\"ver\": \"2.0\"}";
 
-            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}.", Base64UrlEncoder.Encode(header), Base64UrlEncoder.Encode(payload));
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}.signature", Base64UrlEncoder.Encode(header), Base64UrlEncoder.Encode(payload));
         }
     }
 }


### PR DESCRIPTION
per #460, set displayableId as the username for cache lookup. This will
make sure that when user2 creds are passed to the API, it does not
return the token for user1.