### PR TITLE
Fix the readme to point to your samples and documentation if they exist.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,7 @@ Here you can find the source code for the library. You can find the correspondin
 - 
 - The next version of the library in prerelease form is also avialable on the NuGet gallery.
 - 
-## Samples and Documentation
 
-[We provide a full suite of sample applications and documentation on GitHub](https://github.com/AzureADSamples) to help you get started with learning the Azure Identity system. This includes tutorials for native clients such as Windows, Windows Phone, iOS, OSX, Android, and Linux. We also provide full walkthroughs for authentication flows such as OAuth2, OpenID Connect, Graph API, and other awesome features. 
 
 ## Community Help and Support
 


### PR DESCRIPTION
The link (https://github.com/AzureADSamples) returns 404, so your samples and documentation are not discoverable. I found this repo (https://github.com/nhwilly/AzureADSamples) which suggests that content has been migrated to (https://github.com/azure-samples?query=active-directory) but this doesn't seem to include any documentation. 

So if the link is dead and documentation is not discoverable, you might as well remove the whole paragraph. But I'd actually prefer that you update it with accurate information.