### PR TITLE
verify certificate chain for broker app

### DIFF
--- a/src/ADAL.PCL/AdalHttpClient.cs
+++ b/src/ADAL.PCL/AdalHttpClient.cs
@@ -135,7 +135,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         private bool isDeviceAuthChallenge(string endpointType, IHttpWebResponse response, bool respondToDeviceAuthChallenge)
         {
             return PlatformPlugin.DeviceAuthHelper.CanHandleDeviceAuthChallenge &&
-                   respondToDeviceAuthChallenge &&
+                   respondToDeviceAuthChallenge && response != null && response.Headers != null &&
                    (response.Headers.ContainsKey(WwwAuthenticateHeader) &&
                     response.Headers[WwwAuthenticateHeader].StartsWith(PKeyAuthName, StringComparison.CurrentCulture)) &&
                    endpointType.Equals(ClientMetricsEndpointType.Token);


### PR DESCRIPTION
In Android API 15 and under, adal could communicate with a fake broker app where 
the attacker could take the certificate from a valid broker app and create a
fake certificate chain since the lower sdk do not perform certificate
chain validation.

The fix will create a certificate chain based on the returned signatures
from the os, and validate the certificate chain.