### PR TITLE
Unexpected multiple_matching_tokens_detected

### DIFF
--- a/src/ADAL.PCL/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.PCL/AcquireTokenHandlerBase.cs
@@ -39,7 +39,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         protected readonly static Task CompletedTask = Task.FromResult(false);
         private readonly TokenCache tokenCache;
         protected readonly IDictionary<string, string> brokerParameters;
-        protected readonly CacheQueryData CacheQueryData = null;
+        protected CacheQueryData CacheQueryData = new CacheQueryData();
 
         protected AcquireTokenHandlerBase(Authenticator authenticator, TokenCache tokenCache, string resource,
             ClientKey clientKey, TokenSubjectType subjectType)
@@ -74,14 +74,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             brokerParameters["correlation_id"] = this.CallState.CorrelationId.ToString();
             brokerParameters["client_version"] = AdalIdHelper.GetAdalVersion();
             this.ResultEx = null;
-
-            CacheQueryData = new CacheQueryData();
-            CacheQueryData.Authority = Authenticator.Authority;
-            CacheQueryData.Resource = this.Resource;
-            CacheQueryData.ClientId = this.ClientKey.ClientId;
-            CacheQueryData.SubjectType = this.TokenSubjectType;
-            CacheQueryData.UniqueId = this.UniqueId;
-            CacheQueryData.DisplayableId = this.DisplayableId;
         }
 
         internal CallState CallState { get; set; }
@@ -111,6 +103,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public async Task<AuthenticationResult> RunAsync()
         {
             bool notifiedBeforeAccessCache = false;
+
+            CacheQueryData.Authority = Authenticator.Authority;
+            CacheQueryData.Resource = this.Resource;
+            CacheQueryData.ClientId = this.ClientKey.ClientId;
+            CacheQueryData.SubjectType = this.TokenSubjectType;
+            CacheQueryData.UniqueId = this.UniqueId;
+            CacheQueryData.DisplayableId = this.DisplayableId;
 
             try
             {

--- a/src/ADAL.PCL/AcquireTokenNonInteractiveHandler.cs
+++ b/src/ADAL.PCL/AcquireTokenNonInteractiveHandler.cs
@@ -54,7 +54,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
             this.userCredential = userCredential;
             this.DisplayableId = this.userCredential.UserName;
-            this.CacheQueryData.DisplayableId = this.DisplayableId;
         }
 
         public AcquireTokenNonInteractiveHandler(Authenticator authenticator, TokenCache tokenCache, string resource, string clientId, UserAssertion userAssertion)

--- a/src/ADAL.PCL/AcquireTokenOnBehalfHandler.cs
+++ b/src/ADAL.PCL/AcquireTokenOnBehalfHandler.cs
@@ -26,8 +26,6 @@
 //------------------------------------------------------------------------------
 
 using System;
-using System.ServiceModel;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory

--- a/tests/Test.ADAL.Common/TokenCacheTests.cs
+++ b/tests/Test.ADAL.Common/TokenCacheTests.cs
@@ -163,8 +163,70 @@ namespace Test.ADAL.Common.Unit
             VerifyCacheItemCount(cache, 0);
         }
 
+
+ /// <summary>
+ /// Check when there are multiple users in the cache with the same
+ /// authority, clientId, resource but different unique and displayId's that
+ /// we can correctly get them from the cache without a multiple token 
+ /// detected exception.
+ /// </summary>
+ /// <returns></returns>
+ public static async Task TestUniqueIdDisplayableIdLookup()
+ {
+ 
+     string authority = "https://www.gotJwt.com/";
+     string clientId = Guid.NewGuid().ToString();
+     string resource = Guid.NewGuid().ToString();
+     string tenantId = Guid.NewGuid().ToString();
+     string uniqueId = Guid.NewGuid().ToString();
+     string displayableId = Guid.NewGuid().ToString();
+     Uri redirectUri = new Uri("https://www.GetJwt.com");
+ 
+     var authenticationResult = CreateCacheValue(uniqueId, displayableId);
+     authority = authority + tenantId + "/";
+     UserCredential credential = new UserCredential(displayableId);
+     AuthenticationContext tempContext = new AuthenticationContext(authority, false);
+     var localCache = tempContext.TokenCache;
+     localCache.Clear();
+ 
+     // Add first user into cache
+     resource = Guid.NewGuid().ToString();
+     clientId = Guid.NewGuid().ToString();
+     uniqueId = Guid.NewGuid().ToString();
+     displayableId = Guid.NewGuid().ToString();
+     var cacheValue = CreateCacheValue(uniqueId, displayableId);
+     AddToDictionary(localCache,
+         new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
+         cacheValue);
+ 
+     //Add second user into cache
+     uniqueId = Guid.NewGuid().ToString();
+     displayableId = Guid.NewGuid().ToString();
+     cacheValue = CreateCacheValue(uniqueId, displayableId);
+     AddToDictionary(localCache,
+         new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
+         cacheValue);
+ 
+     var acWithLocalCache = new AuthenticationContext(authority, false, localCache);
+     var userId = new UserIdentifier(uniqueId, UserIdentifierType.UniqueId);
+     var userIdUpper = new UserIdentifier(displayableId.ToUpper(), UserIdentifierType.RequiredDisplayableId);
+
+     var parameters = new PlatformParameters(PromptBehavior.Auto);
+     var authenticationResultFromCache = await acWithLocalCache.AcquireTokenAsync(resource, clientId, redirectUri, parameters, userId);
+     VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
+ 
+     authenticationResultFromCache = await acWithLocalCache.AcquireTokenAsync(resource, clientId, redirectUri, parameters, userIdUpper);
+     VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
+ 
+     authenticationResultFromCache = await acWithLocalCache.AcquireTokenSilentAsync(resource, clientId, userId);
+     VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
+ 
+     authenticationResultFromCache = await acWithLocalCache.AcquireTokenSilentAsync(resource, clientId, userIdUpper);
+     VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
+ }
+
 #if TEST_ADAL_NET
-        public static async Task TokenCacheKeyTestAsync(IPlatformParameters parameters)
+    public static async Task TokenCacheKeyTestAsync(IPlatformParameters parameters)
         {
             CheckPublicGetSets();
 

--- a/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
@@ -46,6 +46,13 @@ namespace Test.ADAL.NET.Unit
         }
 
         [TestMethod]
+        [TestCategory("AdalDotNetUnit")]
+        public async Task TestUniqueIdDisplayableIdLookup()
+        {
+            await TokenCacheTests.TestUniqueIdDisplayableIdLookup();
+        }
+
+        [TestMethod]
         [Description("Test for TokenCache")]
         [TestCategory("AdalDotNetUnit")]
         public async Task TokenCacheKeyTestAsync()


### PR DESCRIPTION
Unexpected multiple_matching_tokens_detected even when User has been
provided. The problem occurs because AcquireTokenHandlerBase initializes
CacheQueryData in its constructor and it uses fields such as
this.UniqueId and this.DisplayableId that have not been initialized yet.
They get initialized by subclasses such as AcquireTokenSilentHandler or
AcquireTokenInteractiveHandler after the base class constructor exits.