### PR TITLE
Unexpected multiple_matching_tokens_detected even when User has been …

### DIFF
--- a/src/ADAL.Common/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.Common/AcquireTokenHandlerBase.cs
@@ -29,7 +29,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         protected readonly static Task CompletedTask = Task.FromResult(false);
         private readonly TokenCache tokenCache;
         protected Exception RefreshException;
-        protected readonly CacheQueryData CacheQueryData;
+        protected CacheQueryData CacheQueryData = new CacheQueryData();
 
         protected AcquireTokenHandlerBase(Authenticator authenticator, TokenCache tokenCache, string resource, ClientKey clientKey, TokenSubjectType subjectType, bool callSync)
         {
@@ -57,14 +57,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.LoadFromCache = (tokenCache != null);
             this.StoreToCache = (tokenCache != null);
             this.SupportADFS = false;
-
-            CacheQueryData = new CacheQueryData();
-            CacheQueryData.Authority = Authenticator.Authority;
-            CacheQueryData.Resource = this.Resource;
-            CacheQueryData.ClientId = this.ClientKey.ClientId;
-            CacheQueryData.SubjectType = this.TokenSubjectType;
-            CacheQueryData.UniqueId = this.UniqueId;
-            CacheQueryData.DisplayableId = this.DisplayableId;
         }
 
         internal CallState CallState { get; set; }
@@ -92,6 +84,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public async Task<AuthenticationResult> RunAsync()
         {
             bool notifiedBeforeAccessCache = false;
+            
+            CacheQueryData.Authority = Authenticator.Authority;
+            CacheQueryData.Resource = this.Resource;
+            CacheQueryData.ClientId = this.ClientKey.ClientId;
+            CacheQueryData.SubjectType = this.TokenSubjectType;
+            CacheQueryData.UniqueId = this.UniqueId;
+            CacheQueryData.DisplayableId = this.DisplayableId;
 
             try
             {

--- a/src/ADAL.Common/CommonAssemblyInfo.cs
+++ b/src/ADAL.Common/CommonAssemblyInfo.cs
@@ -27,11 +27,11 @@ using System.Reflection;
 [assembly: AssemblyCopyright("Copyright (c) Microsoft Open Technologies. All rights reserved.")]
 [assembly: AssemblyTrademark("")]
 
-[assembly: AssemblyVersion("2.27.0.0")]
+[assembly: AssemblyVersion("2.28.0.0")]
 
 // Keep major and minor versions in AssemblyFileVersion in sync with AssemblyVersion.
 // Build and revision numbers are replaced on build machine for official builds.
-[assembly: AssemblyFileVersion("2.27.00000.0000")]
+[assembly: AssemblyFileVersion("2.28.00000.0000")]
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.
 // e.g.: [assembly: AssemblyInformationalVersionAttribute("4392c9835a38c27516fc0cd7bad7bccdcaeab161")]

--- a/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
@@ -48,6 +48,14 @@ namespace Test.ADAL.NET.Unit
         }
 
         [TestMethod]
+        [Description("Test for TokenCache")]
+        [TestCategory("AdalDotNetUnit")]
+        public async Task TestUniqueIdDisplayableIdLookup()
+        {
+            await TokenCacheTests.TestUniqueIdDisplayableIdLookup();
+        }
+
+        [TestMethod]
         [Description("Test for Token Cache Operations")]
         [TestCategory("AdalDotNetUnit")]
         public void TokenCacheOperationsTest()

--- a/tests/Test.ADAL.NET/AdalDotNetTests.cs
+++ b/tests/Test.ADAL.NET/AdalDotNetTests.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Diagnostics;
 using System.Threading.Tasks;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Test.ADAL.Common;
 using Test.ADAL.NET.Friend;


### PR DESCRIPTION
…provided. The problem occurs because AcquireTokenHandlerBase initializes CacheQueryData in its constructor and it uses fields such as this.UniqueId and this.DisplayableId that have not been initialized yet. They get initialized by subclasses such as AcquireTokenSilentHandler or AcquireTokenInteractiveHandler after the base class constructor exits.

Thus, search by user id or displayable name never works and we get this error about duplicates.