### PR TITLE
Change scope of UserAuthType from internal to public

### DIFF
--- a/src/ADAL.PCL/UserCredential.cs
+++ b/src/ADAL.PCL/UserCredential.cs
@@ -27,7 +27,7 @@
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
-    internal enum UserAuthType
+    public enum UserAuthType
     {
         IntegratedAuth,
         UsernamePassword


### PR DESCRIPTION
Hi, Team.

Regarding to the issue #482 , I changed the scope of the enum `UserAuthType` from internal to public. With this change, the `UserCredential` class can be inherited for .NET Core application, like `UserPasswordCredential`, which only supports .NET full framework.

It would be great if you review this change and accept it.


Cheers,
