### PR TITLE
OnResume throws nullpointerexception in client app

### DIFF
--- a/src/ADAL.PCL.Android/AuthenticationAgentContinuationHelper.cs
+++ b/src/ADAL.PCL.Android/AuthenticationAgentContinuationHelper.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using System.Globalization;
 using Android.App;
 using Android.Content;
 
@@ -44,6 +45,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public static void SetAuthenticationAgentContinuationEventArgs(int requestCode, Result resultCode, Intent data)
         {
             AuthorizationResult authorizationResult = null;
+            PlatformPlugin.Logger.Information(null, string.Format(CultureInfo.InvariantCulture,"Received Activity Result({0})", (int)resultCode));
             switch ((int)resultCode)
             {
                 case (int)Result.Ok:
@@ -65,7 +67,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     break;
             }
 
-            if (authorizationResult!=null)
+            if (authorizationResult != null)
             {
                 WebUI.SetAuthorizationResult(authorizationResult);
             }

--- a/src/ADAL.PCL.Android/WebUI.cs
+++ b/src/ADAL.PCL.Android/WebUI.cs
@@ -78,8 +78,15 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public static void SetAuthorizationResult(AuthorizationResult authorizationResultInput)
         {
-            authorizationResult = authorizationResultInput;
-            returnedUriReady.Release();
+            if (returnedUriReady != null)
+            {
+                authorizationResult = authorizationResultInput;
+                returnedUriReady.Release();
+            }
+            else
+            {
+                PlatformPlugin.Logger.Information(null, "No pending request for response from web ui.");
+            }
         }
     }
 }


### PR DESCRIPTION
AuthenticationAgentContinuationHelper throws null pointer exception when
there is no ADAL call pending. ADAL should check if there is a call
pending, then only save the response from activity result. #490