### PR TITLE
AcquireTokenAsync returns null access token

### DIFF
--- a/src/ADAL.PCL/AuthenticationContext.cs
+++ b/src/ADAL.PCL/AuthenticationContext.cs
@@ -526,7 +526,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 TokenCache = this.TokenCache,
                 Resource = resource,
                 ClientKey = clientKey,
-                ExtendedLifeTimeEnabled = this.ExtendedLifeTimeEnabled
+                ExtendedLifeTimeEnabled = this.ExtendedLifeTimeEnabled,
+                SubjectType = TokenSubjectType.Client
             };
             var handler = new AcquireTokenForClientHandler(requestData);
             return await handler.RunAsync();

--- a/src/ADAL.PCL/AuthenticationResult.cs
+++ b/src/ADAL.PCL/AuthenticationResult.cs
@@ -104,7 +104,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// Gets an identifier for the tenant the token was acquired from. This property will be null if tenant information is not returned by the service.
         /// </summary>
         [DataMember]
-        public string TenantId { get; private set; }
+        public string TenantId { get; internal set; }
 
         /// <summary>
         /// Gets user information including user Id. Some elements in UserInfo might be null if not returned by the service.

--- a/src/ADAL.PCL/AuthenticationResultEx.cs
+++ b/src/ADAL.PCL/AuthenticationResultEx.cs
@@ -104,5 +104,23 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         
         [DataMember]
         public string UserAssertionHash { get; set; }
+
+        internal AuthenticationResultEx Clone()
+        {
+            return new AuthenticationResultEx
+            {
+                UserAssertionHash = this.UserAssertionHash,
+                Exception = this.Exception,
+                RefreshToken = this.RefreshToken,
+                ResourceInResponse = this.ResourceInResponse,
+                Result = new AuthenticationResult(this.Result.AccessTokenType, this.Result.AccessToken, this.Result.ExpiresOn, this.Result.ExtendedExpiresOn)
+                {
+                    ExtendedLifeTimeToken = this.Result.ExtendedLifeTimeToken,
+                    IdToken = this.Result.IdToken,
+                    TenantId = this.Result.TenantId,
+                    UserInfo = new UserInfo(this.Result.UserInfo)
+                }
+            };
+        }
     }
 }

--- a/src/ADAL.PCL/UserAssertion.cs
+++ b/src/ADAL.PCL/UserAssertion.cs
@@ -39,14 +39,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// assertion is a JWT token. For other flows, the other construction with assertionType must be used.
         /// </summary>
         /// <param name="assertion">Assertion representing the user.</param>
-        public UserAssertion(string assertion)
+        public UserAssertion(string assertion) :this(assertion, OAuthGrantType.JwtBearer)
         {
-            if (string.IsNullOrWhiteSpace(assertion))
-            {
-                throw new ArgumentNullException("assertion");
-            }
-
-            this.Assertion = assertion;
         }
 
         /// <summary>

--- a/src/ADAL.PCL/UserInfo.cs
+++ b/src/ADAL.PCL/UserInfo.cs
@@ -42,13 +42,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         internal UserInfo(UserInfo other)
         {
-            this.UniqueId = other.UniqueId;
-            this.DisplayableId = other.DisplayableId;
-            this.GivenName = other.GivenName;
-            this.FamilyName = other.FamilyName;
-            this.IdentityProvider = other.IdentityProvider;
-            this.PasswordChangeUrl = other.PasswordChangeUrl;
-            this.PasswordExpiresOn = other.PasswordExpiresOn;
+            if (other != null)
+            {
+                this.UniqueId = other.UniqueId;
+                this.DisplayableId = other.DisplayableId;
+                this.GivenName = other.GivenName;
+                this.FamilyName = other.FamilyName;
+                this.IdentityProvider = other.IdentityProvider;
+                this.PasswordChangeUrl = other.PasswordChangeUrl;
+                this.PasswordExpiresOn = other.PasswordExpiresOn;
+            }
         }
 
         /// <summary>

--- a/tests/Test.ADAL.Common/TokenCacheTests.cs
+++ b/tests/Test.ADAL.Common/TokenCacheTests.cs
@@ -520,9 +520,9 @@ namespace Test.ADAL.Common.Unit
         internal static void MultipleUserAssertionHashTest()
         {
             TokenCacheKey key = new TokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
-                TokenSubjectType.User, null, "user1");
+                TokenSubjectType.Client, null, "user1");
             TokenCacheKey key2 = new TokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
-                TokenSubjectType.User, null, "user2");
+                TokenSubjectType.Client, null, "user2");
             AuthenticationResultEx value = CreateCacheValue(null, "user1");
             value.UserAssertionHash = "hash1";
             AuthenticationResultEx value2 = CreateCacheValue(null, "user2");
@@ -537,7 +537,7 @@ namespace Test.ADAL.Common.Unit
                 Authority = "https://localhost/MockSts/",
                 Resource = "resource1",
                 ClientId = "client1",
-                SubjectType = TokenSubjectType.User,
+                SubjectType = TokenSubjectType.Client,
                 UniqueId = null,
                 DisplayableId = null
             };
@@ -554,6 +554,7 @@ namespace Test.ADAL.Common.Unit
             try
             {
                 cache.LoadFromCache(data, null);
+                Assert.Fail("multiple_tokens_detected should have been thrown");
             }
             catch (Exception exc)
             {

--- a/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
@@ -1417,9 +1417,15 @@ namespace Test.ADAL.NET.Unit
             };
 
             AcquireTokenOnBehalfHandler handler = new AcquireTokenOnBehalfHandler(data, new UserAssertion("non-existant"));
-
-            AuthenticationResult result = await handler.RunAsync();
-            Assert.IsNotNull(result);
+            try
+            {
+                await handler.RunAsync();
+                Assert.Fail("acquire token call should have failed due to hash mistmatch");
+            }
+            catch (Exception exc)
+            {
+                Assert.IsNotNull(exc);
+            }
         }
 
     }


### PR DESCRIPTION
AuthenticationContext.AcquireTokenAsync() occasionally returns null
access token from cache per #487
This PR also includes fix for https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/493