### PR TITLE
Support SecureString for client secrets

### DIFF
--- a/src/ADAL.Common/CommonAssemblyInfo.cs
+++ b/src/ADAL.Common/CommonAssemblyInfo.cs
@@ -37,7 +37,7 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyVersion("3.12.0.0")]
+[assembly: AssemblyFileVersion("3.13.0.0")]
 
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.

--- a/src/ADAL.PCL.Desktop/ADAL.PCL.Desktop.csproj
+++ b/src/ADAL.PCL.Desktop/ADAL.PCL.Desktop.csproj
@@ -99,12 +99,11 @@
     <Compile Include="InteractiveWebUI.cs" />
     <Compile Include="NavigateErrorStatus.cs" />
     <Compile Include="PlatformInformation.cs" />
-
     <Compile Include="..\ADAL.Common\PromptBehavior.cs">
       <Link>PromptBehavior.cs</Link>
     </Compile>
-		
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SecureClientSecret.cs" />
     <Compile Include="SilentWebUI.cs" />
     <Compile Include="SilentWebUIDoneEventArgs.cs" />
     <Compile Include="SilentWindowsFormsAuthenticationDialog.cs">

--- a/src/ADAL.PCL.Desktop/CryptographyHelper.cs
+++ b/src/ADAL.PCL.Desktop/CryptographyHelper.cs
@@ -38,6 +38,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     {
         public string CreateSha256Hash(string input)
         {
+            if (string.IsNullOrEmpty(input))
+            {
+                return null;
+            }
+
             using (SHA256Cng sha = new SHA256Cng())
             {
                 UTF8Encoding encoding = new UTF8Encoding();

--- a/src/ADAL.PCL.Desktop/SecureClientSecret.cs
+++ b/src/ADAL.PCL.Desktop/SecureClientSecret.cs
@@ -1,0 +1,76 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+using System.Security;
+
+namespace Microsoft.IdentityModel.Clients.ActiveDirectory
+{
+    /// <summary>
+    /// This class allows to pass client secret as a SecureString to the API.
+    /// </summary>
+    public class SecureClientSecret : ISecureClientSecret
+    {
+        private SecureString secureString;
+
+        /// <summary>
+        /// Required Constructor
+        /// </summary>
+        /// <param name="secret">SecureString secret. Required and cannot be null.</param>
+        public SecureClientSecret(SecureString secret)
+        {
+            if (secret == null)
+            {
+                throw new ArgumentNullException(nameof(secret));
+            }
+
+            this.secureString = secret;
+        }
+
+        public void ApplyTo(IDictionary<string, string> parameters)
+        {
+            var output = new char[secureString.Length];
+            IntPtr secureStringPtr = Marshal.SecureStringToCoTaskMemUnicode(secureString);
+            for (int i = 0; i < secureString.Length; i++)
+            {
+                output[i] = (char) Marshal.ReadInt16(secureStringPtr, i*2);
+            }
+
+            Marshal.ZeroFreeCoTaskMemUnicode(secureStringPtr);
+            parameters[OAuthParameter.ClientSecret] = new string(output);
+
+            if (secureString != null && !secureString.IsReadOnly())
+            {
+                secureString.Clear();
+            }
+
+            secureString = null;
+        }
+    }
+}

--- a/src/ADAL.PCL.Desktop/UserPasswordCredential.cs
+++ b/src/ADAL.PCL.Desktop/UserPasswordCredential.cs
@@ -56,7 +56,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.SecurePassword = securePassword;
         }
 
-        internal SecureString SecurePassword { get; }
+        internal SecureString SecurePassword { get; private set; }
 
         internal string Password { get; }
 
@@ -84,10 +84,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             requestParameters[OAuthParameter.Username] = this.UserName;
             requestParameters[OAuthParameter.Password] = new string(PasswordToCharArray());
             
-            if (SecurePassword != null)
+            if (SecurePassword != null && !SecurePassword.IsReadOnly())
             {
                 SecurePassword.Clear();
             }
+
+            SecurePassword = null;
         }
     }
 }

--- a/src/ADAL.PCL/ADAL.PCL.csproj
+++ b/src/ADAL.PCL/ADAL.PCL.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Base64UrlEncoder.cs" />
     <Compile Include="CacheQueryData.cs" />
     <Compile Include="CallState.cs" />
+    <Compile Include="ISecureClientSecret.cs" />
     <Compile Include="RequestData.cs" />
     <Compile Include="ClientAssertion.cs" />
     <Compile Include="ClientCredential.cs" />

--- a/src/ADAL.PCL/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.PCL/AcquireTokenHandlerBase.cs
@@ -110,18 +110,20 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             bool notifiedBeforeAccessCache = false;
             AuthenticationResultEx extendedLifetimeResultEx = null;
-            CacheQueryData.Authority = Authenticator.Authority;
-            CacheQueryData.Resource = this.Resource;
-            CacheQueryData.ClientId = this.ClientKey.ClientId;
-            CacheQueryData.SubjectType = this.TokenSubjectType;
-            CacheQueryData.UniqueId = this.UniqueId;
-            CacheQueryData.DisplayableId = this.DisplayableId;
 
             try
             {
                 await this.PreRunAsync();
+
                 if (this.LoadFromCache)
                 {
+                    CacheQueryData.Authority = Authenticator.Authority;
+                    CacheQueryData.Resource = this.Resource;
+                    CacheQueryData.ClientId = this.ClientKey.ClientId;
+                    CacheQueryData.SubjectType = this.TokenSubjectType;
+                    CacheQueryData.UniqueId = this.UniqueId;
+                    CacheQueryData.DisplayableId = this.DisplayableId;
+
                     this.NotifyBeforeAccessCache();
                     notifiedBeforeAccessCache = true;
                     ResultEx = this.tokenCache.LoadFromCache(CacheQueryData, this.CallState);

--- a/src/ADAL.PCL/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.PCL/AcquireTokenHandlerBase.cs
@@ -37,7 +37,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     internal abstract class AcquireTokenHandlerBase
     {
         protected const string NullResource = "null_resource_as_optional";
-        protected readonly static Task CompletedTask = Task.FromResult(false);
+        protected static readonly Task CompletedTask = Task.FromResult(false);
         private readonly TokenCache tokenCache;
         protected readonly IDictionary<string, string> brokerParameters;
         protected CacheQueryData CacheQueryData = new CacheQueryData();
@@ -49,10 +49,14 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.Authenticator = requestData.Authenticator;
             this.CallState = CreateCallState(this.Authenticator.CorrelationId);
             PlatformPlugin.Logger.Information(this.CallState,
-                string.Format(CultureInfo.CurrentCulture, "=== Token Acquisition started:\n\tAuthority: {0}\n\tResource: {1}\n\tClientId: {2}\n\tCacheType: {3}\n\tAuthentication Target: {4}\n\t",
-                requestData.Authenticator.Authority, requestData.Resource, requestData.ClientKey.ClientId,
-                (tokenCache != null) ? tokenCache.GetType().FullName + string.Format(CultureInfo.CurrentCulture, " ({0} items)", tokenCache.Count) : "null",
-                requestData.SubjectType));
+                string.Format(CultureInfo.CurrentCulture,
+                    "=== Token Acquisition started:\n\tAuthority: {0}\n\tResource: {1}\n\tClientId: {2}\n\tCacheType: {3}\n\tAuthentication Target: {4}\n\t",
+                    requestData.Authenticator.Authority, requestData.Resource, requestData.ClientKey.ClientId,
+                    (tokenCache != null)
+                        ? tokenCache.GetType().FullName +
+                          string.Format(CultureInfo.CurrentCulture, " ({0} items)", tokenCache.Count)
+                        : "null",
+                    requestData.SubjectType));
 
             this.tokenCache = requestData.TokenCache;
 
@@ -78,9 +82,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.ResultEx = null;
 
             CacheQueryData.ExtendedLifeTimeEnabled = requestData.ExtendedLifeTimeEnabled;
-
         }
-        
+
         internal CallState CallState { get; set; }
 
         protected bool SupportADFS { get; set; }
@@ -129,7 +132,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     ResultEx = this.tokenCache.LoadFromCache(CacheQueryData, this.CallState);
                     this.ValidateResult();
                     extendedLifetimeResultEx = ResultEx;
-                    if (ResultEx != null && ResultEx.Result!=null)
+
+                    if (ResultEx != null && ResultEx.Result != null)
                     {
                         if ((ResultEx.Result.AccessToken == null && ResultEx.RefreshToken != null) ||
                             (ResultEx.Result.ExtendedLifeTimeToken && ResultEx.RefreshToken != null))
@@ -143,8 +147,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                         }
                     }
                 }
+
                 if (ResultEx == null || ResultEx.Exception != null)
-                {  
+                {
                     if (PlatformPlugin.BrokerHelper.CanInvokeBroker)
                     {
                         ResultEx = await PlatformPlugin.BrokerHelper.AcquireTokenUsingBroker(brokerParameters);
@@ -175,7 +180,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                             this.NotifyBeforeAccessCache();
                             notifiedBeforeAccessCache = true;
                         }
-                        this.tokenCache.StoreToCache(ResultEx, this.Authenticator.Authority, this.Resource, this.ClientKey.ClientId, this.TokenSubjectType, this.CallState);
+                        this.tokenCache.StoreToCache(ResultEx, this.Authenticator.Authority, this.Resource,
+                            this.ClientKey.ClientId, this.TokenSubjectType, this.CallState);
                     }
                 }
                 await this.PostRunAsync(ResultEx.Result);
@@ -183,11 +189,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
             catch (Exception ex)
             {
-                
                 PlatformPlugin.Logger.Error(this.CallState, ex);
-                if (client!=null && client.Resiliency && extendedLifetimeResultEx != null)
+                if (client != null && client.Resiliency && extendedLifetimeResultEx != null)
                 {
-                    PlatformPlugin.Logger.Information(this.CallState, "Refreshing AT failed either due to one of these :- Internal Server Error,Gateway Timeout and Service Unavailable.Hence returning back stale AT");
+                    PlatformPlugin.Logger.Information(this.CallState,
+                        "Refreshing AT failed either due to one of these :- Internal Server Error,Gateway Timeout and Service Unavailable.Hence returning back stale AT");
                     return extendedLifetimeResultEx.Result;
                 }
                 throw;
@@ -204,12 +210,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         protected virtual void ValidateResult()
         {
-              
         }
 
         protected virtual void UpdateBrokerParameters(IDictionary<string, string> parameters)
         {
-            
         }
 
         protected virtual bool BrokerInvocationRequired()
@@ -267,7 +271,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             if (result.RefreshToken == null)
             {
                 result.RefreshToken = refreshToken;
-                PlatformPlugin.Logger.Verbose(this.CallState, "Refresh token was missing from the token refresh response, so the refresh token in the request is returned instead");
+                PlatformPlugin.Logger.Verbose(this.CallState,
+                    "Refresh token was missing from the token refresh response, so the refresh token in the request is returned instead");
             }
 
             return result;
@@ -289,7 +294,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     if (newResultEx.Result.IdToken == null)
                     {
                         // If Id token is not returned by token endpoint when refresh token is redeemed, we should copy tenant and user information from the cached token.
-                        newResultEx.Result.UpdateTenantAndUserInfo(result.Result.TenantId, result.Result.IdToken, result.Result.UserInfo);
+                        newResultEx.Result.UpdateTenantAndUserInfo(result.Result.TenantId, result.Result.IdToken,
+                            result.Result.UserInfo);
                     }
                 }
                 catch (AdalException ex)
@@ -303,7 +309,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                             serviceException.ServiceErrorCodes,
                             serviceException);
                     }
-                    newResultEx = new AuthenticationResultEx { Exception = ex };
+                    newResultEx = new AuthenticationResultEx {Exception = ex};
                 }
             }
 
@@ -313,7 +319,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         private async Task<AuthenticationResultEx> SendHttpMessageAsync(IRequestParameters requestParameters)
         {
             client = new AdalHttpClient(this.Authenticator.TokenUri, this.CallState)
-                    { Client = { BodyParameters = requestParameters } };
+            {Client = {BodyParameters = requestParameters}};
             TokenResponse tokenResponse = await client.GetResponseAsync<TokenResponse>();
             return tokenResponse.GetResult();
         }
@@ -348,10 +354,14 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             {
                 string accessTokenHash = PlatformPlugin.CryptographyHelper.CreateSha256Hash(result.AccessToken);
 
-                PlatformPlugin.Logger.Information(this.CallState, string.Format(CultureInfo.CurrentCulture, "=== Token Acquisition finished successfully. An access token was retuned:\n\tAccess Token Hash: {0}\n\tExpiration Time: {1}\n\tUser Hash: {2}\n\t",
-                    accessTokenHash,
-                    result.ExpiresOn,
-                    result.UserInfo != null ? PlatformPlugin.CryptographyHelper.CreateSha256Hash(result.UserInfo.UniqueId) : "null"));
+                PlatformPlugin.Logger.Information(this.CallState,
+                    string.Format(CultureInfo.CurrentCulture,
+                        "=== Token Acquisition finished successfully. An access token was retuned:\n\tAccess Token Hash: {0}\n\tExpiration Time: {1}\n\tUser Hash: {2}\n\t",
+                        accessTokenHash,
+                        result.ExpiresOn,
+                        result.UserInfo != null
+                            ? PlatformPlugin.CryptographyHelper.CreateSha256Hash(result.UserInfo.UniqueId)
+                            : "null"));
             }
         }
 
@@ -360,7 +370,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             if (!this.SupportADFS && this.Authenticator.AuthorityType == AuthorityType.ADFS)
             {
                 throw new AdalException(AdalError.InvalidAuthorityType,
-                    string.Format(CultureInfo.InvariantCulture, AdalErrorMessage.InvalidAuthorityTypeTemplate, this.Authenticator.Authority));
+                    string.Format(CultureInfo.InvariantCulture, AdalErrorMessage.InvalidAuthorityTypeTemplate,
+                        this.Authenticator.Authority));
             }
         }
     }

--- a/src/ADAL.PCL/ClientCredential.cs
+++ b/src/ADAL.PCL/ClientCredential.cs
@@ -56,10 +56,33 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         /// <summary>
+        /// Constructor to create credential with client id and secret
+        /// </summary>
+        /// <param name="clientId">Identifier of the client requesting the token.</param>
+        /// <param name="secureClientSecret">Secure secret of the client requesting the token.</param>
+        public ClientCredential(string clientId, ISecureClientSecret secureClientSecret)
+        {
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentNullException("clientId");
+            }
+
+            if (secureClientSecret == null)
+            {
+                throw new ArgumentNullException("clientSecret");
+            }
+
+            this.ClientId = clientId;
+            this.SecureClientSecret = secureClientSecret;
+        }
+
+        /// <summary>
         /// Gets the identifier of the client requesting the token.
         /// </summary>
         public string ClientId { get; private set; }
 
         internal string ClientSecret { get; private set; }
+
+        internal ISecureClientSecret SecureClientSecret { get; private set; }
     }
 }

--- a/src/ADAL.PCL/ClientKey.cs
+++ b/src/ADAL.PCL/ClientKey.cs
@@ -103,7 +103,14 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
             if (this.Credential != null)
             {
-                parameters[OAuthParameter.ClientSecret] = this.Credential.ClientSecret;
+                if (this.Credential.SecureClientSecret != null)
+                {
+                    this.Credential.SecureClientSecret.ApplyTo(parameters);
+                }
+                else
+                {
+                    parameters[OAuthParameter.ClientSecret] = this.Credential.ClientSecret;
+                }
             }
             else if (this.Assertion != null)
             {

--- a/src/ADAL.PCL/HttpMessageHandlerFactory.cs
+++ b/src/ADAL.PCL/HttpMessageHandlerFactory.cs
@@ -57,7 +57,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             MockHandlerQueue.Clear();
         }
 
-        public static int CountMockHandlers()
+        public static int MockHandlersCount()
         {
             return MockHandlerQueue.Count;
         }

--- a/src/ADAL.PCL/ISecureClientSecret.cs
+++ b/src/ADAL.PCL/ISecureClientSecret.cs
@@ -1,0 +1,43 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace Microsoft.IdentityModel.Clients.ActiveDirectory
+{
+    /// <summary>
+    /// Interface to allow for client secret to be passed in as a SecureString
+    /// </summary>
+    public interface ISecureClientSecret
+    {
+        /// <summary>
+        /// Writes SecureString to the dictionary.
+        /// </summary>
+        /// <param name="parameters"></param>
+        void ApplyTo(IDictionary<string, string> parameters);
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
@@ -125,13 +125,13 @@ namespace Test.ADAL.NET.Unit
                 Method = HttpMethod.Post,
                 ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
             });
-            Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(), 2);
+            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 2);
             context.ExtendedLifeTimeEnabled = true;
             AuthenticationResult result =
             await context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,TestConstants.DefaultRedirectUri, platformParameters);
             Assert.IsNotNull(result);
             Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(),0);     
+            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(),0);     
         }
 
         [TestMethod]
@@ -161,12 +161,12 @@ namespace Test.ADAL.NET.Unit
                 Method = HttpMethod.Post,
                 ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
             });
-            Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(), 2);
+            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 2);
             context.ExtendedLifeTimeEnabled = true;
             AuthenticationResult result =
                     await context.AcquireTokenSilentAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId, new UserIdentifier("unique_id", UserIdentifierType.UniqueId));
             Assert.IsNotNull(result);
-            Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(), 0);
+            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 0);
             Assert.AreEqual(result.AccessToken, "some-access-token");
         }
 
@@ -198,12 +198,12 @@ namespace Test.ADAL.NET.Unit
                 ResponseMessage = MockHelpers.CreateResiliencyMessage(HttpStatusCode.GatewayTimeout),
             });
 
-                Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(), 2);
+                Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 2);
             context.ExtendedLifeTimeEnabled = true;
                 AuthenticationResult result =
                      await context.AcquireTokenSilentAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId, new UserIdentifier("unique_id", UserIdentifierType.UniqueId));
             Assert.IsNull(result.AccessToken);
-            Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(), 0);
+            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 0);
         }
 
 
@@ -235,7 +235,7 @@ namespace Test.ADAL.NET.Unit
                 ResponseMessage = MockHelpers.CreateResiliencyMessage(HttpStatusCode.InternalServerError),
             });            
 
-            //Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(), 2);
+            //Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 2);
             context.ExtendedLifeTimeEnabled = true;
                 AuthenticationResult result =
                     await
@@ -267,7 +267,7 @@ namespace Test.ADAL.NET.Unit
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
             {
                 Method = HttpMethod.Post,
-                ResponseMessage = MockHelpers.CreateResiliencyMessage(HttpStatusCode.GatewayTimeout),
+                ExceptionToThrow = new TaskCanceledException("request timed out")
             });
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
@@ -285,6 +285,8 @@ namespace Test.ADAL.NET.Unit
             Assert.IsFalse(result.ExpiresOn <=
                            DateTime.UtcNow);
             Assert.AreEqual(result.AccessToken, "some-access-token");
+
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount());
         }
 
         [TestMethod]
@@ -496,7 +498,7 @@ namespace Test.ADAL.NET.Unit
                 }
             });
 
-            Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(), 2);
+            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 2);
 
             var credential = new ClientCredential(TestConstants.DefaultClientId, TestConstants.DefaultClientSecret);
 
@@ -575,7 +577,7 @@ namespace Test.ADAL.NET.Unit
                 }
             });
 
-            Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(), 2);
+            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 2);
 
             var credential = new ClientCredential(TestConstants.DefaultClientId, TestConstants.DefaultClientSecret);
 
@@ -654,7 +656,7 @@ namespace Test.ADAL.NET.Unit
                 }
             });
 
-            Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(), 2);
+            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 2);
 
             var credential = new ClientCredential(TestConstants.DefaultClientId, TestConstants.DefaultClientSecret);
 

--- a/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
@@ -388,9 +388,9 @@ namespace Test.ADAL.NET.Unit
         [Description("Test for getting back access token when the extendedExpiresOn flag is set")]
         public async Task ClientCredentialExtendedExpiryPositiveTest()
         {
-            var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
-                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.Client,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
             {
@@ -426,9 +426,7 @@ namespace Test.ADAL.NET.Unit
                     {"grant_type", "client_credentials"}
                 }
             });
-
-            Assert.AreEqual(HttpMessageHandlerFactory.CountMockHandlers(), 2);
-
+            
             var credential = new ClientCredential(TestConstants.DefaultClientId, TestConstants.DefaultClientSecret);
 
             context.ExtendedLifeTimeEnabled = true;

--- a/tests/Test.ADAL.NET.Unit/UnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/UnitTests.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
@@ -45,6 +46,28 @@ namespace Test.ADAL.NET.Unit
     {
         private const string ComplexString = "asdfk+j0a-=skjwe43;1l234 1#$!$#%345903485qrq@#$!@#$!(rekr341!#$%Ekfaآزمايشsdsdfsddfdgsfgjsglk==CVADS";
         private const string ComplexString2 = @"a\u0304\u0308"" = ""ā̈";
+
+        [TestMethod]
+        [Description("Tests for SecureClientSecret")]
+        public void SecureClientSecretTest()
+        {
+            SecureString str = new SecureString();
+            str.AppendChar('x');
+            str.MakeReadOnly();
+            SecureClientSecret secret = new SecureClientSecret(str);
+            IDictionary<string, string> paramStr = new Dictionary<string, string>();
+            secret.ApplyTo(paramStr);
+            Assert.IsTrue(paramStr.ContainsKey("client_secret"));
+            Assert.AreEqual("x", paramStr["client_secret"]);
+
+            str = new SecureString();
+            str.AppendChar('x');
+            secret = new SecureClientSecret(str);
+            paramStr = new Dictionary<string, string>();
+            secret.ApplyTo(paramStr);
+            Assert.IsTrue(paramStr.ContainsKey("client_secret"));
+            Assert.AreEqual("x", paramStr["client_secret"]);
+        }
 
         [TestMethod]
         [Description("Positive Test for UrlEncoding")]


### PR DESCRIPTION
Added support for SecureString as client secret per #470.
Fixed SecureString.Clear issue where ADAL was not checking if string was
readonly per #458.
Client Resiliency did no retry on connection timeouts.