### PR TITLE
UserCredential.Username is not used for cache lookups.

### DIFF
--- a/src/ADAL.Common/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.Common/AcquireTokenHandlerBase.cs
@@ -84,13 +84,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public async Task<AuthenticationResult> RunAsync()
         {
             bool notifiedBeforeAccessCache = false;
-            
-            CacheQueryData.Authority = Authenticator.Authority;
-            CacheQueryData.Resource = this.Resource;
-            CacheQueryData.ClientId = this.ClientKey.ClientId;
-            CacheQueryData.SubjectType = this.TokenSubjectType;
-            CacheQueryData.UniqueId = this.UniqueId;
-            CacheQueryData.DisplayableId = this.DisplayableId;
 
             try
             {
@@ -99,6 +92,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 AuthenticationResult result = null;
                 if (this.LoadFromCache)
                 {
+                    CacheQueryData.Authority = Authenticator.Authority;
+                    CacheQueryData.Resource = this.Resource;
+                    CacheQueryData.ClientId = this.ClientKey.ClientId;
+                    CacheQueryData.SubjectType = this.TokenSubjectType;
+                    CacheQueryData.UniqueId = this.UniqueId;
+                    CacheQueryData.DisplayableId = this.DisplayableId;
+
                     this.NotifyBeforeAccessCache();
                     notifiedBeforeAccessCache = true;
 

--- a/src/ADAL.Common/CommonAssemblyInfo.cs
+++ b/src/ADAL.Common/CommonAssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Reflection;
 // Allow this assembly to be serviced when run on desktop CLR
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyVersion("2.28.0.0")]
+[assembly: AssemblyFileVersion("2.28.0.0")]
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.
 // e.g.: [assembly: AssemblyInformationalVersionAttribute("4392c9835a38c27516fc0cd7bad7bccdcaeab161")]

--- a/tests/Test.ADAL.NET.Unit/AcquireTokenSilentTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AcquireTokenSilentTests.cs
@@ -38,7 +38,29 @@ namespace Test.ADAL.NET.Unit
             {
                 Verify.Fail("AdalSilentTokenAcquisitionException was expected");
             }
+        }
 
+        [TestMethod]
+        [Description("AcquireTokenFromCacheNonInteractiveTestAsync")]
+        [TestCategory("AdalDotNet")]
+        public async Task AcquireTokenFromCacheSilentTestAsync()
+        {
+            TokenCache cache = new TokenCache();
+            cache.tokenCacheDictionary.Add(
+                new TokenCacheKey("https://login.microsoftonline.com/home/", "resource", "clientid",
+                    TokenSubjectType.User, "unique_id", "displayable_id"),
+                new AuthenticationResult("Bearer", "access-token", "refresh-token",
+                    (DateTimeOffset.UtcNow + TimeSpan.FromHours(5))));
+            AuthenticationContext ctx = new AuthenticationContext("https://login.microsoftonline.com/home", false, cache);
+            AuthenticationResult result =
+                await ctx.AcquireTokenSilentAsync("resource", "clientid", new UserIdentifier("unique_id", UserIdentifierType.UniqueId));
+            Assert.IsNotNull(result);
+            Assert.AreEqual("access-token", result.AccessToken);
+
+            result =
+                await ctx.AcquireTokenSilentAsync("resource", "clientid", new UserIdentifier("displayable_id", UserIdentifierType.RequiredDisplayableId));
+            Assert.IsNotNull(result);
+            Assert.AreEqual("access-token", result.AccessToken);
         }
     }
 }

--- a/tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs
+++ b/tests/Test.ADAL.NET.Unit/NonInteractiveTests.cs
@@ -191,7 +191,6 @@ namespace Test.ADAL.NET.Unit
             }
         }
 
-
         [TestMethod]
         [Description("WS-Trust Request Test")]
         [TestCategory("AdalDotNet")]
@@ -264,6 +263,25 @@ namespace Test.ADAL.NET.Unit
             {
                 Verify.Fail("Not expected");
             }
+        }
+
+
+        [TestMethod]
+        [Description("AcquireTokenFromCacheNonInteractiveTestAsync")]
+        [TestCategory("AdalDotNet")]
+        public async Task AcquireTokenFromCacheNonInteractiveTestAsync()
+        {
+            TokenCache cache = new TokenCache();
+            cache.tokenCacheDictionary.Add(
+                new TokenCacheKey("https://login.microsoftonline.com/home/", "resource", "clientid",
+                    TokenSubjectType.User, "unique_id", "displayable_id"),
+                new AuthenticationResult("Bearer", "access-token", "refresh-token",
+                    (DateTimeOffset.UtcNow + TimeSpan.FromHours(5))));
+            AuthenticationContext ctx = new AuthenticationContext("https://login.microsoftonline.com/home", false, cache);
+            AuthenticationResult result =
+                await ctx.AcquireTokenAsync("resource", "clientid", new UserCredential("displayable_id"));
+            Assert.IsNotNull(result);
+            Assert.AreEqual("access-token", result.AccessToken);
         }
 
         private static void VerifyUserRealmResponse(UserRealmDiscoveryResponse userRealmResponse, string expectedAccountType)

--- a/tests/Test.ADAL.NET/AdalDotNetTests.cs
+++ b/tests/Test.ADAL.NET/AdalDotNetTests.cs
@@ -430,7 +430,7 @@ namespace Test.ADAL.NET
         {
             await AdalTests.AcquireTokenFromCacheTestAsync(Sts);
         }
-
+        
         [TestMethod]
         [TestCategory("AdalDotNet")]
         [Description("Test for cache in multi user scenario")]

--- a/tests/Test.ADAL.NET/AuthenticationContextProxy.cs
+++ b/tests/Test.ADAL.NET/AuthenticationContextProxy.cs
@@ -75,6 +75,12 @@ namespace Test.ADAL.Common
             this.context.CorrelationId = new Guid(FixedCorrelationId);
         }
 
+        public AuthenticationContextProxy(string authority, bool validateAuthority, TokenCache tokenCache)
+        {
+            this.context = new AuthenticationContext(authority, validateAuthority, tokenCache);
+            this.context.CorrelationId = new Guid(FixedCorrelationId);
+        }
+
         public static bool CallSync { get; set; }
 
         public static void InitializeTest()


### PR DESCRIPTION
Per issue #499.
When using a call pattern like this:

UserCredential credential = new UserCredential(userId, password);
result = context.AcquireToken(config.ResourceClientUri, config.ClientId, credential);

If the token cache contains a token with the same Authority, Resource, and ClientId, but a different UserId, that token is incorrectly returned.