### PR TITLE
Null reference exception in Device authentication flow.

### DIFF
--- a/src/ADAL.PCL/AcquireTokenByDeviceCodeHandler.cs
+++ b/src/ADAL.PCL/AcquireTokenByDeviceCodeHandler.cs
@@ -30,19 +30,13 @@ using System.Threading.Tasks;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
-    class AcquireTokenByDeviceCodeHandler : AcquireTokenHandlerBase
+    internal class AcquireTokenByDeviceCodeHandler : AcquireTokenHandlerBase
     {
         private DeviceCodeResult deviceCodeResult = null;
 
         public AcquireTokenByDeviceCodeHandler(RequestData requestData, DeviceCodeResult deviceCodeResult)
             : base(requestData)
         {
-            requestData.ClientKey = new ClientKey(deviceCodeResult.ClientId);
-            if (deviceCodeResult == null)
-            {
-                throw new ArgumentNullException("deviceCodeResult");
-            }
-            
             this.LoadFromCache = false; //no cache lookup for token
             this.StoreToCache = (requestData.TokenCache != null);
             this.SupportADFS = false;

--- a/src/ADAL.PCL/AuthenticationContext.cs
+++ b/src/ADAL.PCL/AuthenticationContext.cs
@@ -187,12 +187,20 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
         public async Task<AuthenticationResult> AcquireTokenByDeviceCodeAsync(DeviceCodeResult deviceCodeResult)
         {
+            if (deviceCodeResult == null)
+            {
+                throw new ArgumentNullException("deviceCodeResult");
+            }
+
             RequestData requestData = new RequestData
             {
                 Authenticator = this.Authenticator,
                 TokenCache = this.TokenCache,
-                ExtendedLifeTimeEnabled = this.ExtendedLifeTimeEnabled
+                ExtendedLifeTimeEnabled = this.ExtendedLifeTimeEnabled,
+                Resource = deviceCodeResult.Resource,
+                ClientKey = new ClientKey(deviceCodeResult.ClientId)
             };
+
             var handler = new AcquireTokenByDeviceCodeHandler(requestData, deviceCodeResult);
             return await handler.RunAsync();
         }

--- a/tests/Test.ADAL.NET.Unit/DeviceCodeFlowTests.cs
+++ b/tests/Test.ADAL.NET.Unit/DeviceCodeFlowTests.cs
@@ -1,0 +1,85 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Test.ADAL.NET.Unit.Mocks;
+
+namespace Test.ADAL.NET.Unit
+{
+    [TestClass]
+    public class DeviceCodeFlowTests
+    {
+        [TestMethod]
+        public async Task PositiveTest()
+        {
+            DeviceCodeResult dcr = new DeviceCodeResult()
+            {
+                ClientId = TestConstants.DefaultClientId,
+                Resource = TestConstants.DefaultResource,
+                DeviceCode = "device-code",
+                ExpiresOn = (DateTimeOffset.UtcNow + TimeSpan.FromMinutes(10)),
+                Interval = 5,
+                Message = "get token here",
+                UserCode = "user-code",
+                VerificationUrl = "https://login.microsoftonline.com/home.oauth2/token"
+            };
+
+            MockHttpMessageHandler mockMessageHandler = new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                Url = "https://login.microsoftonline.com/home/oauth2/token",
+                ResponseMessage = MockHelpers.CreateFailureResponseMessage("{\"error\":\"authorization_pending\"," +
+                                                                           "\"error_description\":\"AADSTS70016: Pending end-user authorization." +
+                                                                           "\\r\\nTrace ID: f6c2c73f-a21d-474e-a71f-d8b121a58205\\r\\nCorrelation ID: " +
+                                                                           "36fe3e82-442f-4418-b9f4-9f4b9295831d\\r\\nTimestamp: 2015-09-24 19:51:51Z\"," +
+                                                                           "\"error_codes\":[70016],\"timestamp\":\"2015-09-24 19:51:51Z\",\"trace_id\":" +
+                                                                           "\"f6c2c73f-a21d-474e-a71f-d8b121a58205\",\"correlation_id\":" +
+                                                                           "\"36fe3e82-442f-4418-b9f4-9f4b9295831d\"}")
+            };
+
+            HttpMessageHandlerFactory.AddMockHandler(mockMessageHandler);
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                Url = "https://login.microsoftonline.com/home/oauth2/token",
+                ResponseMessage =
+                    MockHelpers.CreateSuccessTokenResponseMessage(TestConstants.DefaultUniqueId,
+                        TestConstants.DefaultDisplayableId, TestConstants.DefaultResource)
+            });
+
+            TokenCache cache = new TokenCache();
+            AuthenticationContext ctx = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, cache);
+            AuthenticationResult result = await ctx.AcquireTokenByDeviceCodeAsync(dcr);
+            Assert.IsNotNull(result);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+        }
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -72,7 +72,9 @@
     </When>
     <Otherwise>
       <ItemGroup>
-        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
       </ItemGroup>
     </Otherwise>
   </Choose>
@@ -97,6 +99,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestConstants.cs" />
     <Compile Include="TokenCacheUnitTests.cs" />
+    <Compile Include="DeviceCodeFlowTests.cs" />
     <Compile Include="UnitTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
per #500, The Device authentication flow will always throw a null reference exception when attempting to acquire a token by device code. This is because the constructor for AcquireTokenHandlerBase uses requestData.ClientKey and requestData.Resource, and they are not initialized when it is called.