### PR TITLE
Update UserInfo class for CoreCLR 1.0.4 issues

### DIFF
--- a/src/ADAL.PCL/UserInfo.cs
+++ b/src/ADAL.PCL/UserInfo.cs
@@ -36,11 +36,17 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     [DataContract]
     public sealed class UserInfo
     {
-        internal UserInfo()
+        /// <summary>
+        /// Create user information for token cache lookup
+        /// </summary>
+        public UserInfo()
         {            
         }
 
-        internal UserInfo(UserInfo other)
+        /// <summary>
+        /// Create user information copied from another UserInfo object
+        /// </summary>
+        public UserInfo(UserInfo other)
         {
             if (other != null)
             {


### PR DESCRIPTION
In CoreCLR 1.0.4 Json serialization, it is required for constructors of serialized types to be visible to the serializer.  This causes exceptions when running in CoreCLR 1.0.4