### PR TITLE
OBO test coverage and user assertion logic update

### DIFF
--- a/src/ADAL.Common/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.Common/AcquireTokenHandlerBase.cs
@@ -35,7 +35,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             this.Authenticator = authenticator;
             this.CallState = CreateCallState(this.Authenticator.CorrelationId, callSync);
-            Logger.Information(this.CallState, 
+            Logger.Information(this.CallState,
                 string.Format(CultureInfo.InvariantCulture, "=== Token Acquisition started:\n\tAuthority: {0}\n\tResource: {1}\n\tClientId: {2}\n\tCacheType: {3}\n\tAuthentication Target: {4}\n\t",
                 authenticator.Authority, resource, clientKey.ClientId,
                 (tokenCache != null) ? tokenCache.GetType().FullName + string.Format(CultureInfo.InvariantCulture, " ({0} items)", tokenCache.Count) : "null",
@@ -78,7 +78,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         protected UserIdentifierType UserIdentifierType { get; set; }
 
         protected bool LoadFromCache { get; set; }
-        
+
         protected bool StoreToCache { get; set; }
 
         public async Task<AuthenticationResult> RunAsync()
@@ -103,8 +103,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     notifiedBeforeAccessCache = true;
 
                     result = this.tokenCache.LoadFromCache(CacheQueryData, this.CallState);
-                    result = this.ValidateResult(result);
-
                     if (result != null && result.AccessToken == null && result.RefreshToken != null)
                     {
                         result = await this.RefreshAccessTokenAsync(result);
@@ -148,11 +146,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     this.NotifyAfterAccessCache();
                 }
             }
-        }
-
-        protected virtual AuthenticationResult ValidateResult(AuthenticationResult result)
-        {
-            return result;
         }
 
         public static CallState CreateCallState(Guid correlationId, bool callSync)
@@ -299,7 +292,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 }
 
                 Logger.Information(this.CallState, "=== Token Acquisition finished successfully. An access token was retuned:\n\tAccess Token Hash: {0}\n\tRefresh Token Hash: {1}\n\tExpiration Time: {2}\n\tUser Hash: {3}\n\t",
-                    accessTokenHash, refreshTokenHash, result.ExpiresOn, 
+                    accessTokenHash, refreshTokenHash, result.ExpiresOn,
                     result.UserInfo != null ? PlatformSpecificHelper.CreateSha256Hash(result.UserInfo.UniqueId) : "null");
             }
         }

--- a/src/ADAL.Common/CommonAssemblyInfo.cs
+++ b/src/ADAL.Common/CommonAssemblyInfo.cs
@@ -30,7 +30,7 @@ using System.Reflection;
 // Allow this assembly to be serviced when run on desktop CLR
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyFileVersion("2.28.1.0")]
+[assembly: AssemblyFileVersion("2.28.2.0")]
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.
 // e.g.: [assembly: AssemblyInformationalVersionAttribute("4392c9835a38c27516fc0cd7bad7bccdcaeab161")]

--- a/src/ADAL.NET/AcquireTokenOnBehalfHandler.cs
+++ b/src/ADAL.NET/AcquireTokenOnBehalfHandler.cs
@@ -25,7 +25,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     {
         private readonly UserAssertion userAssertion;
 
-        public AcquireTokenOnBehalfHandler(Authenticator authenticator, TokenCache tokenCache, string resource, ClientKey clientKey, UserAssertion userAssertion, bool callSync)
+        public AcquireTokenOnBehalfHandler(Authenticator authenticator, TokenCache tokenCache, string resource,
+            ClientKey clientKey, UserAssertion userAssertion, bool callSync)
             : base(authenticator, tokenCache, resource, clientKey, TokenSubjectType.UserPlusClient, callSync)
         {
             if (userAssertion == null)
@@ -40,42 +41,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.SupportADFS = true;
         }
 
-                protected override AuthenticationResult ValidateResult(AuthenticationResult result)
-         {
-             // cache lookup returned a token. no username provided in the assertion. 
-             // cannot deterministicly identify the user. fallback to compare hash. 
-             if (result != null && string.IsNullOrEmpty(userAssertion.UserName))
-             {
-                 //if cache result does not contain hash then return null
-                 if (!string.IsNullOrEmpty(result.UserAssertionHash))
-                 {
-                     //if user assertion hash does not match then return null
-                     if (!result.UserAssertionHash.Equals(CacheQueryData.AssertionHash))
-                     {
-                         result = null;
-                     }
-                 }
-                 else
-                 {
-                     result = null;
-                 }
-             }
- 
-             //return as is if it is null or provided userAssertion contains username
-             return result;
-         }
- 
- 
-         protected override async Task<AuthenticationResult> SendTokenRequestAsync()
-         {
-             AuthenticationResult result = await base.SendTokenRequestAsync();
-             if (result != null)
-             {
-                 result.UserAssertionHash = CacheQueryData.AssertionHash;
-             }
- 
-             return result;
-         }
+        protected override async Task<AuthenticationResult> SendTokenRequestAsync()
+        {
+            AuthenticationResult result = await base.SendTokenRequestAsync();
+            if (result != null)
+            {
+                result.UserAssertionHash = CacheQueryData.AssertionHash;
+            }
+
+            return result;
+        }
 
         protected override void AddAditionalRequestParameters(RequestParameters requestParameters)
         {

--- a/tests/Test.ADAL.Common/TestConstants.cs
+++ b/tests/Test.ADAL.Common/TestConstants.cs
@@ -16,6 +16,8 @@
 // limitations under the License.
 //----------------------------------------------------------------------
 
+using System;
+
 namespace Test.ADAL.Common
 {
     public static class StringValue
@@ -53,4 +55,24 @@ namespace Test.ADAL.Common
         Null = 2,
         InMemory = 3
     }
+    public class TestConstants
+    {
+        public static readonly string DefaultResource = "resource1";
+        public static readonly string AnotherResource = "resource2";
+        public static readonly string DefaultAdfsAuthorityTenant = "https://login.contoso.com/adfs/";
+        public static readonly string DefaultAuthorityHomeTenant = "https://login.microsoftonline.com/home/";
+        public static readonly string DefaultAuthorityGuestTenant = "https://login.microsoftonline.com/guest/";
+        public static readonly string DefaultAuthorityCommonTenant = "https://login.microsoftonline.com/common/";
+        public static readonly string DefaultClientId = "client_id";
+        public static readonly string DefaultUniqueId = "unique_id";
+        public static readonly string DefaultDisplayableId = "displayable@id.com";
+        public static readonly Uri DefaultRedirectUri = new Uri("urn:ietf:wg:oauth:2.0:oob");
+        public static readonly bool DefaultRestrictToSingleUser = false;
+        public static readonly string DefaultClientSecret = "client_secret";
+        public static readonly string DefaultPassword = "password";
+        public static readonly bool DefaultExtendedLifeTimeEnabled = false;
+        public static readonly bool PositiveExtendedLifeTimeEnabled = true;
+        public static readonly string ErrorSubCode = "ErrorSubCode";
+    }
+
 }

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
@@ -1,0 +1,128 @@
+﻿//----------------------------------------------------------------------
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+// Apache License 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------
+
+using System.Globalization;
+using System.IO;
+using System.Net;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Test.ADAL.Common;
+
+namespace Test.ADAL.NET.Unit.Mocks
+{
+    internal static class MockHelpers
+    {
+        public static Stream GenerateStreamFromString(string s)
+        {
+            MemoryStream stream = new MemoryStream();
+            StreamWriter writer = new StreamWriter(stream);
+            writer.Write(s);
+            writer.Flush();
+            stream.Position = 0;
+            return stream;
+        }
+
+        public static IHttpWebResponse CreateInvalidRequestTokenResponseMessage()
+        {
+            return
+                CreateFailureResponseMessage(
+                    "{\"error\":\"invalid_request\",\"error_description\":\"AADSTS70002: Some error message. Trace ID: f7ec686c-9196-4220-a754-cd9197de44e9 Correlation ID: 04bb0cae-580b-49ac-9a10-b6c3316b1eaa Timestamp: 2015-09-16 07:24:55Z\",\"error_codes\":[70002,70008],\"timestamp\":\"2015-09-16 07:24:55Z\",\"trace_id\":\"f7ec686c-9196-4220-a754-cd9197de44e9\",\"correlation_id\":\"04bb0cae-580b-49ac-9a10-b6c3316b1eaa\"}");
+        }
+
+        public static IHttpWebResponse CreateInvalidGrantTokenResponseMessage()
+        {
+            return
+                CreateFailureResponseMessage(
+                    "{\"error\":\"invalid_grant\",\"error_description\":\"AADSTS70002: Error validating credentials.AADSTS70008: The provided access grant is expired or revoked.Trace ID: f7ec686c-9196-4220-a754-cd9197de44e9Correlation ID: 04bb0cae-580b-49ac-9a10-b6c3316b1eaaTimestamp: 2015-09-16 07:24:55Z\",\"error_codes\":[70002,70008],\"timestamp\":\"2015-09-16 07:24:55Z\",\"trace_id\":\"f7ec686c-9196-4220-a754-cd9197de44e9\",\"correlation_id\":\"04bb0cae-580b-49ac-9a10-b6c3316b1eaa\"}");
+        }
+        
+        public static IHttpWebResponse CreateFailureResponseMessage(string message)
+        {
+            IHttpWebResponse responseMessage = new MockHttpWebResponse()
+            {
+                Stream =
+                    GenerateStreamFromString(message),
+                StatusCode = HttpStatusCode.BadRequest
+            };
+
+            return responseMessage;
+        }
+
+
+        public static IHttpWebResponse CreateSuccessTokenResponseMessage()
+        {
+            return CreateSuccessTokenResponseMessage("{\"token_type\":\"Bearer\",\"expires_in\":\"3600\"," +
+                                                     "\"resource\":\"resource1\",\"access_token\":\"some-access-token\"," +
+                                                     "\"refresh_token\":\"something-encrypted\",\"id_token\":\"" +
+                                                     CreateIdToken(TestConstants.DefaultUniqueId,
+                                                         TestConstants.DefaultDisplayableId) +
+                                                     "\"}");
+        }
+
+        public static IHttpWebResponse CreateSuccessTokenResponseMessage(string message)
+        {
+            IHttpWebResponse responseMessage = new MockHttpWebResponse()
+            {
+                Stream =
+                    GenerateStreamFromString(message),
+                StatusCode = HttpStatusCode.OK
+            };
+
+            return responseMessage;
+        }
+
+        public static IHttpWebResponse CreateSuccessfulClientCredentialTokenResponseMessage()
+        {
+            return
+                CreateSuccessTokenResponseMessage(
+                    "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"access_token\":\"header.payload.signature\"}");
+        }
+
+        public static IHttpWebResponse CreateSuccessTokenResponseMessage(string uniqueId, string displayableId, string resource)
+        {
+            string idToken = CreateIdToken(uniqueId, displayableId);
+            return
+                CreateSuccessTokenResponseMessage("{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"resource\":\"" +
+                                                  resource +
+                                                  "\",\"access_token\":\"some-access-token\",\"refresh_token\"" +
+                                                  ":\"OAAsomethingencryptedQwgAA\",\"id_token\":\"" +
+                                                  idToken +
+                                                  "\"}");
+        }
+
+        private static string CreateIdToken(string uniqueId, string displayableId)
+        {
+            string header = "{alg: \"none\"," +
+                             "typ:\"JWT\"" +
+                             "}";
+            string payload = "{\"aud\": \"e854a4a7-6c34-449c-b237-fc7a28093d84\"," +
+                        "\"iss\": \"https://login.microsoftonline.com/6c3d51dd-f0e5-4959-b4ea-a80c4e36fe5e/\"," +
+                        "\"iat\": 1455833828," +
+                        "\"nbf\": 1455833828," +
+                        "\"exp\": 1455837728," +
+                        "\"ipaddr\": \"131.107.159.117\"," +
+                        "\"name\": \"Mario Rossi\"," +
+                        "\"oid\": \"" + uniqueId + "\"," +
+                        "\"upn\": \"" + displayableId + "\"," +
+                        "\"sub\": \"werwerewrewrew-Qd80ehIEdFus\"," +
+                        "\"tid\": \"some-tenant-id\"," +
+                        "\"ver\": \"2.0\"}";
+
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}.signature", Base64UrlEncoder.Encode(header), Base64UrlEncoder.Encode(payload));
+        }
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHttpWebRequest.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHttpWebRequest.cs
@@ -1,0 +1,45 @@
+﻿//----------------------------------------------------------------------
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+// Apache License 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------
+
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+namespace Test.ADAL.NET.Unit.Mocks
+{
+    internal class MockHttpWebRequest : IHttpWebRequest
+    {
+        private readonly IHttpWebResponse _response;
+        public MockHttpWebRequest(IHttpWebResponse response)
+        {
+            this._response = response;
+            Headers = new WebHeaderCollection();
+        }
+
+        public RequestParameters BodyParameters { get; set; }
+        public string Accept { get; set; }
+        public string ContentType { get; set; }
+        public string Method { get; set; }
+        public bool UseDefaultCredentials { get; set; }
+        public WebHeaderCollection Headers { get; }
+        public Task<IHttpWebResponse> GetResponseSyncOrAsync(CallState callState)
+        {
+            return Task.Run(()=>_response);
+        }
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHttpWebRequestFactory.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHttpWebRequestFactory.cs
@@ -1,0 +1,40 @@
+﻿//----------------------------------------------------------------------
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+// Apache License 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.Net;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+namespace Test.ADAL.NET.Unit.Mocks
+{
+    internal class MockHttpWebRequestFactory : IHttpWebRequestFactory
+    {
+        public readonly Queue<IHttpWebRequest> MockHttpWebRequestQueue = new Queue<IHttpWebRequest>();
+        public readonly Queue<IHttpWebResponse> MockHttpWebResponseQueue = new Queue<IHttpWebResponse>();
+
+        public IHttpWebRequest Create(string uri)
+        {
+            return MockHttpWebRequestQueue.Dequeue();
+        }
+
+        public IHttpWebResponse CreateResponse(WebResponse response)
+        {
+            return MockHttpWebResponseQueue.Dequeue();
+        }
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHttpWebResponse.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHttpWebResponse.cs
@@ -1,0 +1,55 @@
+﻿//----------------------------------------------------------------------
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+// Apache License 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------
+
+using System.IO;
+using System.Net;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+
+namespace Test.ADAL.NET.Unit.Mocks
+{
+    internal class MockHttpWebResponse : IHttpWebResponse
+    {
+        public MockHttpWebResponse()
+        {
+            Headers = new WebHeaderCollection();    
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public Stream Stream { get; set; }
+
+        public HttpStatusCode StatusCode { get; internal set; }
+
+        public WebHeaderCollection Headers { get; internal set; }
+
+        public Stream GetResponseStream()
+        {
+            return Stream;
+        }
+
+        public void Close()
+        {
+            if (Stream != null)
+            {
+                Stream.Close();
+            }
+        }
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
+++ b/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
@@ -1,0 +1,790 @@
+﻿//----------------------------------------------------------------------
+// Copyright (c) Microsoft Open Technologies, Inc.
+// All Rights Reserved
+// Apache License 2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+// http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//----------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Test.ADAL.Common;
+using Test.ADAL.NET.Unit.Mocks;
+
+namespace Test.ADAL.NET.Unit
+{
+    /// <summary>
+    /// This test class executes and validates OBO scenarios where token cache may or may not 
+    /// contain entries with user assertion hash. It accounts for cases where there is
+    /// a single user and when there are multiple users in the cache.
+    /// user assertion hash exists so that the API can deterministically identify the user
+    /// in the cache when a usernae is not passed in. It also allows the API to acquire
+    /// new token when a different assertion is passed for the user. this is needed because
+    /// the user may have authenticated with updated claims like MFA/device auth on the client.
+    /// </summary>
+    [TestClass]
+    public class OboFlowTests
+    {
+        private readonly DateTimeOffset _expirationTime = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(30);
+        private readonly MockHttpWebRequestFactory _mockFactory = new MockHttpWebRequestFactory();
+
+        private static readonly string[] _cacheNoise = { "", "different" };
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            NetworkPlugin.HttpWebRequestFactory = _mockFactory;
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            NetworkPlugin.SetToDefault();
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserNoHashInCacheNoUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+                //cache entry has no user assertion hash
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer",
+                    cachenoise + "some-token-in-cache", cachenoise + "some-rt", _expirationTime)
+                {
+                    Resource = TestConstants.DefaultResource,
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                            UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                        },
+                };
+            }
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage()));
+
+            // call acquire token with no username. multiple results will be found.
+            // this will result in a network call because cache entry with no assertion hash is
+            // treated as a cache miss.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be 2 cache entries.
+            Assert.AreEqual(2, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First(x => x.UserAssertionHash != null).UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserNoHashInCacheMatchingUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+                //cache entry has no user assertion hash
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer",
+                    cachenoise + "some-token-in-cache",
+                    cachenoise + "some-rt", _expirationTime)
+                {
+                    Resource = TestConstants.DefaultResource,
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                            UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                        },
+                };
+            }
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage()));
+
+            // call acquire token with matching username from cache entry. 1 result will be found
+            // this will result in a network call because cache entry with no assertion 
+            // hash is treated as a cache miss.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First(x => x.UserAssertionHash != null).UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserNoHashInCacheDifferentUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+                //cache entry has no user assertion hash
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer",
+                    cachenoise + "some-token-in-cache",
+                    cachenoise + "some-rt", _expirationTime)
+                {
+                    Resource = TestConstants.DefaultResource,
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                            UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                        },
+                };
+            }
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            string displayableId2 = "extra" + TestConstants.DefaultDisplayableId;
+            string uniqueId2 = "extra" + TestConstants.DefaultUniqueId;
+
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage(uniqueId2, displayableId2,
+                    TestConstants.DefaultResource)));
+
+            // call acquire token with different username than from cache entry. this will result in a network call 
+            // because cache entry with no assertion hash is treated as a cache miss.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer,
+                            "non-existant" + TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(displayableId2, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(3, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First(x => x.UserAssertionHash != null).UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserWithHashInCacheNoUsernameAndMatchingAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer",
+                    cachenoise + tokenInCache,
+                    cachenoise + "some-rt", _expirationTime)
+                {
+                    Resource = TestConstants.DefaultResource,
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                            UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                        },
+                    UserAssertionHash = PlatformSpecificHelper.CreateSha256Hash(cachenoise + accessToken)
+                };
+            }
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with no username and matching assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual(tokenInCache, result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserWithHashInCacheNoUsernameAndDifferentAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer",
+                    cachenoise + tokenInCache,
+                    cachenoise + "some-rt", _expirationTime)
+                {
+                    Resource = TestConstants.DefaultResource,
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                            UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                        },
+                    UserAssertionHash = PlatformSpecificHelper.CreateSha256Hash(cachenoise + accessToken)
+                };
+            }
+
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage()));
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with no username and different assertion hash. this will result in a 
+            // network call.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion("non-existant" + accessToken));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+        }
+
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserWithHashInCacheMatchingUsernameAndMatchingAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer",
+                    cachenoise + tokenInCache,
+                    cachenoise + "some-rt", _expirationTime)
+                {
+                    Resource = TestConstants.DefaultResource,
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                            UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                        },
+                    UserAssertionHash = PlatformSpecificHelper.CreateSha256Hash(cachenoise + accessToken)
+                };
+            }
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with matching username and matching assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, TestConstants.DefaultDisplayableId));
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual(tokenInCache, result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserWithHashInCacheMatchingUsernameAndDifferentAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer",
+                    cachenoise + tokenInCache,
+                    cachenoise + "some-rt", _expirationTime)
+                {
+                    Resource = TestConstants.DefaultResource,
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                            UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                        },
+                    UserAssertionHash = PlatformSpecificHelper.CreateSha256Hash(cachenoise + accessToken)
+                };
+            }
+
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage()));
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with matching username and different assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion("non-existant" + accessToken, OAuthGrantType.JwtBearer,
+                            TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserNoHashInCacheNoUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+            //cache entry has no user assertion hash
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer", "some-token-in-cache",
+                "some-rt", _expirationTime)
+            {
+                Resource = TestConstants.DefaultResource,
+                UserInfo =
+                    new UserInfo()
+                    {
+                        DisplayableId = TestConstants.DefaultDisplayableId,
+                        UniqueId = TestConstants.DefaultUniqueId
+                    },
+            };
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage()));
+
+            // call acquire token with no username. this will result in a network call because cache entry with no assertion hash is
+            // treated as a cache miss.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserNoHashInCacheMatchingUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+            //cache entry has no user assertion hash
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer", "some-token-in-cache",
+                "some-rt", _expirationTime)
+            {
+                Resource = TestConstants.DefaultResource,
+                UserInfo =
+                    new UserInfo()
+                    {
+                        DisplayableId = TestConstants.DefaultDisplayableId,
+                        UniqueId = TestConstants.DefaultUniqueId
+                    },
+            };
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage()));
+
+            // call acquire token with matching username from cache entry. this will result in a network call 
+            // because cache entry with no assertion hash is treated as a cache miss.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserNoHashInCacheDifferentUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+            //cache entry has no user assertion hash
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer", "some-token-in-cache",
+                "some-rt", _expirationTime)
+            {
+                Resource = TestConstants.DefaultResource,
+                UserInfo =
+                    new UserInfo()
+                    {
+                        DisplayableId = TestConstants.DefaultDisplayableId,
+                        UniqueId = TestConstants.DefaultUniqueId
+                    },
+            };
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage()));
+
+            // call acquire token with different username than from cache entry. this will result in a network call 
+            // because cache entry with no assertion hash is treated as a cache miss.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer,
+                            "extra" + TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserWithHashInCacheNoUsernameAndMatchingAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer", tokenInCache, "some-rt",
+                _expirationTime)
+            {
+                Resource = TestConstants.DefaultResource,
+                UserInfo =
+                    new UserInfo()
+                    {
+                        DisplayableId = TestConstants.DefaultDisplayableId,
+                        UniqueId = TestConstants.DefaultUniqueId
+                    },
+                UserAssertionHash = PlatformSpecificHelper.CreateSha256Hash(accessToken)
+            };
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with no username and matching assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual(tokenInCache, result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserWithHashInCacheNoUsernameAndDifferentAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer", tokenInCache, "some-rt",
+                _expirationTime)
+            {
+                Resource = TestConstants.DefaultResource,
+                UserInfo =
+                    new UserInfo()
+                    {
+                        DisplayableId = TestConstants.DefaultDisplayableId,
+                        UniqueId = TestConstants.DefaultUniqueId
+                    },
+                UserAssertionHash = PlatformSpecificHelper.CreateSha256Hash(accessToken + "different")
+            };
+
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage()));
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with no username and different assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserWithHashInCacheMatchingUsernameAndMatchingAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer", tokenInCache, "some-rt",
+                _expirationTime)
+            {
+                Resource = TestConstants.DefaultResource,
+                UserInfo =
+                    new UserInfo()
+                    {
+                        DisplayableId = TestConstants.DefaultDisplayableId,
+                        UniqueId = TestConstants.DefaultUniqueId
+                    },
+                UserAssertionHash = PlatformSpecificHelper.CreateSha256Hash(accessToken)
+            };
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with matching username and matching assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, TestConstants.DefaultDisplayableId));
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual(tokenInCache, result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserWithHashInCacheMatchingUsernameAndDifferentAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer", tokenInCache, "some-rt",
+                _expirationTime)
+            {
+                Resource = TestConstants.DefaultResource,
+                UserInfo =
+                    new UserInfo()
+                    {
+                        DisplayableId = TestConstants.DefaultDisplayableId,
+                        UniqueId = TestConstants.DefaultUniqueId
+                    },
+                UserAssertionHash = PlatformSpecificHelper.CreateSha256Hash(accessToken + "different")
+            };
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage()));
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with matching username and different assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserWithHashInCacheMatchingUsernameAndMatchingAssertionDifferentResourceTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResult("Bearer", tokenInCache, "some-rt",
+                _expirationTime)
+            {
+                Resource = TestConstants.DefaultResource,
+                UserInfo =
+                    new UserInfo()
+                    {
+                        DisplayableId = TestConstants.DefaultDisplayableId,
+                        UniqueId = TestConstants.DefaultUniqueId
+                    },
+                UserAssertionHash = PlatformSpecificHelper.CreateSha256Hash(accessToken)
+            };
+            _mockFactory.MockHttpWebRequestQueue.Enqueue(
+                new MockHttpWebRequest(MockHelpers.CreateSuccessTokenResponseMessage(TestConstants.AnotherResource,
+                    TestConstants.DefaultDisplayableId, TestConstants.DefaultUniqueId)));
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with matching username and different assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.AnotherResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, _mockFactory.MockHttpWebRequestQueue.Count, "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            foreach (var value in context.TokenCache.tokenCacheDictionary.Values)
+            {
+                Assert.AreEqual(PlatformSpecificHelper.CreateSha256Hash(accessToken), value.UserAssertionHash);
+            }
+        }
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -114,7 +114,12 @@
     </Compile>
     <Compile Include="AcquireTokenSilentTests.cs" />
     <Compile Include="AuthenticationParametersTests.cs" />
+    <Compile Include="Mocks\MockHelpers.cs" />
+    <Compile Include="Mocks\MockHttpWebRequest.cs" />
+    <Compile Include="Mocks\MockHttpWebRequestFactory.cs" />
+    <Compile Include="Mocks\MockHttpWebResponse.cs" />
     <Compile Include="NonInteractiveTests.cs" />
+    <Compile Include="OboFlowTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TokenCacheUnitTests.cs" />
     <Compile Include="UnitTests.cs" />


### PR DESCRIPTION
The PR adds extensive OBO test coverage. It also adds the check to always match on user assertion when provided instead of relying on cache entry. this is because the developer may pass an updated assertion with new claims like MFA etc.