### PR TITLE
OBO test coverage and user assertion logic update

### DIFF
--- a/src/ADAL.Common/CommonAssemblyInfo.cs
+++ b/src/ADAL.Common/CommonAssemblyInfo.cs
@@ -37,7 +37,7 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyFileVersion("3.13.4.0")]
+[assembly: AssemblyFileVersion("3.13.5.0")]
 
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.

--- a/src/ADAL.PCL/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.PCL/AcquireTokenHandlerBase.cs
@@ -130,7 +130,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     this.NotifyBeforeAccessCache();
                     notifiedBeforeAccessCache = true;
                     ResultEx = this.tokenCache.LoadFromCache(CacheQueryData, this.CallState);
-                    this.ValidateResult();
                     extendedLifetimeResultEx = ResultEx;
 
                     if (ResultEx != null && ResultEx.Result != null)
@@ -205,11 +204,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     this.NotifyAfterAccessCache();
                 }
             }
-        }
-
-
-        protected virtual void ValidateResult()
-        {
         }
 
         protected virtual void UpdateBrokerParameters(IDictionary<string, string> parameters)
@@ -309,7 +303,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                             serviceException.ServiceErrorCodes,
                             serviceException);
                     }
-                    newResultEx = new AuthenticationResultEx {Exception = ex};
+                    newResultEx = new AuthenticationResultEx { Exception = ex };
                 }
             }
 
@@ -319,7 +313,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         private async Task<AuthenticationResultEx> SendHttpMessageAsync(IRequestParameters requestParameters)
         {
             client = new AdalHttpClient(this.Authenticator.TokenUri, this.CallState)
-            {Client = {BodyParameters = requestParameters}};
+            { Client = { BodyParameters = requestParameters } };
             TokenResponse tokenResponse = await client.GetResponseAsync<TokenResponse>().ConfigureAwait(false);
             return tokenResponse.GetResult();
         }

--- a/src/ADAL.PCL/AcquireTokenOnBehalfHandler.cs
+++ b/src/ADAL.PCL/AcquireTokenOnBehalfHandler.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
@@ -46,34 +47,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.DisplayableId = userAssertion.UserName;
             CacheQueryData.AssertionHash = PlatformPlugin.CryptographyHelper.CreateSha256Hash(userAssertion.Assertion);
 
+            PlatformPlugin.Logger.Verbose(CallState,
+                string.Format(CultureInfo.InvariantCulture,
+                    "Username provided in user assertion - " + string.IsNullOrEmpty(this.DisplayableId)));
             this.SupportADFS = true;
         }
-
-        protected override void ValidateResult()
-        {
-            // cache lookup returned a token. no username provided in the assertion. 
-            // cannot deterministicly identify the user. fallback to compare hash. 
-            if (this.ResultEx != null && string.IsNullOrEmpty(userAssertion.UserName))
-            {
-                //if cache result does not contain hash then return null
-                if (!string.IsNullOrEmpty(this.ResultEx.UserAssertionHash))
-                {
-                    //if user assertion hash does not match then return null
-                    if (!this.ResultEx.UserAssertionHash.Equals(CacheQueryData.AssertionHash))
-                    {
-                        this.ResultEx = null;
-                    }
-                }
-                else
-                {
-                    this.ResultEx = null;
-                }
-            }
-
-            //return as is if it is null or provided userAssertion contains username
-           
-        }
-
 
         protected override async Task<AuthenticationResultEx> SendTokenRequestAsync()
         {

--- a/tests/Test.ADAL.NET.Unit/AcquireTokenSilentTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AcquireTokenSilentTests.cs
@@ -43,7 +43,9 @@ namespace Test.ADAL.NET.Unit
         public async Task AcquireTokenSilentServiceErrorTestAsync()
         {
             TokenCache cache = new TokenCache();
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User, "unique_id", "displayable@id.com");
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User, "unique_id",
+                "displayable@id.com");
             cache.tokenCacheDictionary[key] = new AuthenticationResultEx
             {
                 RefreshToken = "something-invalid",

--- a/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
+++ b/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
@@ -1,0 +1,950 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Test.ADAL.NET.Unit.Mocks;
+
+namespace Test.ADAL.NET.Unit
+{
+    /// <summary>
+    /// This test class executes and validates OBO scenarios where token cache may or may not 
+    /// contain entries with user assertion hash. It accounts for cases where there is
+    /// a single user and when there are multiple users in the cache.
+    /// user assertion hash exists so that the API can deterministically identify the user
+    /// in the cache when a usernae is not passed in. It also allows the API to acquire
+    /// new token when a different assertion is passed for the user. this is needed because
+    /// the user may have authenticated with updated claims like MFA/device auth on the client.
+    /// </summary>
+    [TestClass]
+    public class OboFlowTests
+    {
+        private readonly CryptographyHelper _cryptoHelper = new CryptographyHelper();
+        private readonly DateTimeOffset _expirationTime = DateTimeOffset.UtcNow + TimeSpan.FromMinutes(30);
+        private static readonly string[] _cacheNoise = { "", "different" };
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            HttpMessageHandlerFactory.ClearMockHandlers();
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserNoHashInCacheNoUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+                //cache entry has no user assertion hash
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                {
+                    RefreshToken = cachenoise + "some-rt",
+                    ResourceInResponse = TestConstants.DefaultResource,
+                    Result = new AuthenticationResult("Bearer", cachenoise + "some-token-in-cache", _expirationTime)
+                    {
+                        UserInfo =
+                            new UserInfo()
+                            {
+                                DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                                UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                            }
+                    },
+                };
+            }
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            // call acquire token with no username. this will result in a network call because cache entry with no assertion hash is
+            // treated as a cache miss.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First(x => x.UserAssertionHash != null).UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserNoHashInCacheMatchingUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+                //cache entry has no user assertion hash
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                {
+                    RefreshToken = cachenoise + "some-rt",
+                    ResourceInResponse = TestConstants.DefaultResource,
+                    Result = new AuthenticationResult("Bearer", cachenoise + "some-token-in-cache", _expirationTime)
+                    {
+                        UserInfo =
+                            new UserInfo()
+                            {
+                                DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                                UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                            }
+                    },
+                };
+            }
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            // call acquire token with matching username from cache entry. this will result in a network call 
+            // because cache entry with no assertion hash is treated as a cache miss.
+
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First(x => x.UserAssertionHash != null).UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserNoHashInCacheDifferentUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+                //cache entry has no user assertion hash
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                {
+                    RefreshToken = cachenoise + "some-rt",
+                    ResourceInResponse = TestConstants.DefaultResource,
+                    Result = new AuthenticationResult("Bearer", cachenoise + "some-token-in-cache", _expirationTime)
+                    {
+                        UserInfo =
+                            new UserInfo()
+                            {
+                                DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                                UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                            }
+                    },
+                };
+            }
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            string displayableId2 = "extra" + TestConstants.DefaultDisplayableId;
+            string uniqueId2 = "extra" + TestConstants.DefaultUniqueId;
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage =
+                    MockHelpers.CreateSuccessTokenResponseMessage(uniqueId2, displayableId2,
+                        TestConstants.DefaultResource),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            // call acquire token with diferent username from cache entry. this will result in a network call
+            // because cache lookup failed for non-existant user
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer,
+                            "non-existant" + TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(displayableId2, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(3, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First(x => x.UserAssertionHash != null)
+                    .UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserWithHashInCacheNoUsernameAndMatchingAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                {
+                    RefreshToken = cachenoise + "some-rt",
+                    ResourceInResponse = TestConstants.DefaultResource,
+                    Result =
+                        new AuthenticationResult("Bearer", cachenoise + tokenInCache, _expirationTime)
+                        {
+                            UserInfo =
+                                new UserInfo()
+                                {
+                                    DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                                    UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                                }
+                        },
+                    UserAssertionHash = _cryptoHelper.CreateSha256Hash(cachenoise + accessToken)
+                };
+            }
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with no username and matching assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual(tokenInCache, result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserWithHashInCacheNoUsernameAndDifferentAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                {
+                    RefreshToken = cachenoise + "some-rt",
+                    ResourceInResponse = TestConstants.DefaultResource,
+                    Result =
+                        new AuthenticationResult("Bearer", cachenoise + tokenInCache, _expirationTime)
+                        {
+                            UserInfo =
+                                new UserInfo()
+                                {
+                                    DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                                    UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                                }
+                        },
+                    UserAssertionHash = _cryptoHelper.CreateSha256Hash(cachenoise + accessToken)
+                };
+            }
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with no username and different assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion("non-existant" + accessToken));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+        }
+
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserWithHashInCacheMatchingUsernameAndMatchingAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                {
+                    RefreshToken = cachenoise + "some-rt",
+                    ResourceInResponse = TestConstants.DefaultResource,
+                    Result =
+                        new AuthenticationResult("Bearer", cachenoise + tokenInCache, _expirationTime)
+                        {
+                            UserInfo =
+                                new UserInfo()
+                                {
+                                    DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                                    UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                                }
+                        },
+                    UserAssertionHash = _cryptoHelper.CreateSha256Hash(cachenoise + accessToken)
+                };
+            }
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with matching username and matching assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, TestConstants.DefaultDisplayableId));
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual(tokenInCache, result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task MultiUserWithHashInCacheMatchingUsernameAndDifferentAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            foreach (var cachenoise in _cacheNoise)
+            {
+                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
+
+                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                {
+                    RefreshToken = cachenoise + "some-rt",
+                    ResourceInResponse = TestConstants.DefaultResource,
+                    Result =
+                        new AuthenticationResult("Bearer", cachenoise + tokenInCache, _expirationTime)
+                        {
+                            UserInfo =
+                                new UserInfo()
+                                {
+                                    DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
+                                    UniqueId = cachenoise + TestConstants.DefaultUniqueId
+                                }
+                        },
+                    UserAssertionHash = _cryptoHelper.CreateSha256Hash(cachenoise + accessToken)
+                };
+            }
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with matching username and different assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion("non-existant" + accessToken, OAuthGrantType.JwtBearer,
+                            TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserNoHashInCacheNoUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+            //cache entry has no user assertion hash
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            {
+                RefreshToken = "some-rt",
+                ResourceInResponse = TestConstants.DefaultResource,
+                Result = new AuthenticationResult("Bearer", "some-token-in-cache", _expirationTime)
+                {
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = TestConstants.DefaultDisplayableId,
+                            UniqueId = TestConstants.DefaultUniqueId
+                        }
+                },
+            };
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            // call acquire token with no username. this will result in a network call because cache entry with no assertion hash is
+            // treated as a cache miss.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserNoHashInCacheMatchingUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+            //cache entry has no user assertion hash
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            {
+                RefreshToken = "some-rt",
+                ResourceInResponse = TestConstants.DefaultResource,
+                Result = new AuthenticationResult("Bearer", "some-token-in-cache", _expirationTime)
+                {
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = TestConstants.DefaultDisplayableId,
+                            UniqueId = TestConstants.DefaultUniqueId
+                        }
+                },
+            };
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            // call acquire token with matching username from cache entry. this will result in a network call 
+            // because cache entry with no assertion hash is treated as a cache miss.
+
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserNoHashInCacheDifferentUsernamePassedInAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+            //cache entry has no user assertion hash
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            {
+                RefreshToken = "some-rt",
+                ResourceInResponse = TestConstants.DefaultResource,
+                Result = new AuthenticationResult("Bearer", "some-token-in-cache", _expirationTime)
+                {
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = TestConstants.DefaultDisplayableId,
+                            UniqueId = TestConstants.DefaultUniqueId
+                        }
+                },
+            };
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            string displayableId2 = "extra" + TestConstants.DefaultDisplayableId;
+            string uniqueId2 = "extra" + TestConstants.DefaultUniqueId;
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage =
+                    MockHelpers.CreateSuccessTokenResponseMessage(uniqueId2, displayableId2,
+                        TestConstants.DefaultResource),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            // call acquire token with diferent username from cache entry. this will result in a network call
+            // because cache lookup failed for non-existant user
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, displayableId2
+                            ));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(displayableId2, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First(
+                    s => s.Result.UserInfo != null && s.Result.UserInfo.DisplayableId.Equals(displayableId2))
+                    .UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserWithHashInCacheNoUsernameAndMatchingAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            {
+                RefreshToken = "some-rt",
+                ResourceInResponse = TestConstants.DefaultResource,
+                Result =
+                    new AuthenticationResult("Bearer", tokenInCache, _expirationTime)
+                    {
+                        UserInfo =
+                            new UserInfo()
+                            {
+                                DisplayableId = TestConstants.DefaultDisplayableId,
+                                UniqueId = TestConstants.DefaultUniqueId
+                            }
+                    },
+                UserAssertionHash = _cryptoHelper.CreateSha256Hash(accessToken)
+            };
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with no username and matching assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual(tokenInCache, result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserWithHashInCacheNoUsernameAndDifferentAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            {
+                RefreshToken = "some-rt",
+                ResourceInResponse = TestConstants.DefaultResource,
+                Result =
+                    new AuthenticationResult("Bearer", tokenInCache, _expirationTime)
+                    {
+                        UserInfo =
+                            new UserInfo()
+                            {
+                                DisplayableId = TestConstants.DefaultDisplayableId,
+                                UniqueId = TestConstants.DefaultUniqueId
+                            }
+                    },
+                UserAssertionHash = _cryptoHelper.CreateSha256Hash(accessToken + "different")
+            };
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with no username and different assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserWithHashInCacheMatchingUsernameAndMatchingAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            {
+                RefreshToken = "some-rt",
+                ResourceInResponse = TestConstants.DefaultResource,
+                Result =
+                    new AuthenticationResult("Bearer", tokenInCache, _expirationTime)
+                    {
+                        UserInfo =
+                            new UserInfo()
+                            {
+                                DisplayableId = TestConstants.DefaultDisplayableId,
+                                UniqueId = TestConstants.DefaultUniqueId
+                            }
+                    },
+                UserAssertionHash = _cryptoHelper.CreateSha256Hash(accessToken)
+            };
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with matching username and matching assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual(tokenInCache, result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserWithHashInCacheMatchingUsernameAndDifferentAssertionTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            {
+                RefreshToken = "some-rt",
+                ResourceInResponse = TestConstants.DefaultResource,
+                Result =
+                    new AuthenticationResult("Bearer", tokenInCache, _expirationTime)
+                    {
+                        UserInfo =
+                            new UserInfo()
+                            {
+                                DisplayableId = TestConstants.DefaultDisplayableId,
+                                UniqueId = TestConstants.DefaultUniqueId
+                            }
+                    },
+                UserAssertionHash = _cryptoHelper.CreateSha256Hash(accessToken + "different")
+            };
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with matching username and different assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential,
+                        new UserAssertion(accessToken));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(1, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken),
+                context.TokenCache.tokenCacheDictionary.Values.First().UserAssertionHash);
+        }
+
+        [TestMethod]
+        [TestCategory("OboFlowTests")]
+        public async Task SingleUserWithHashInCacheMatchingUsernameAndMatchingAssertionDifferentResourceTest()
+        {
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
+            string accessToken = "access-token";
+            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
+                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
+
+            //cache entry has user assertion hash
+            string tokenInCache = "obo-access-token";
+            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            {
+                RefreshToken = "some-rt",
+                ResourceInResponse = TestConstants.DefaultResource,
+                Result =
+                    new AuthenticationResult("Bearer", tokenInCache, _expirationTime)
+                    {
+                        UserInfo =
+                            new UserInfo()
+                            {
+                                DisplayableId = TestConstants.DefaultDisplayableId,
+                                UniqueId = TestConstants.DefaultUniqueId
+                            }
+                    },
+                UserAssertionHash = _cryptoHelper.CreateSha256Hash(accessToken)
+            };
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(TestConstants.AnotherResource,
+                    TestConstants.DefaultDisplayableId, TestConstants.DefaultUniqueId),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"client_id", TestConstants.DefaultClientId},
+                    {"grant_type", "urn:ietf:params:oauth:grant-type:jwt-bearer"}
+                }
+            });
+
+            ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
+                TestConstants.DefaultClientSecret);
+
+            // call acquire token with matching username and different assertion hash. this will result in a cache
+            // hit.
+            var result =
+                await
+                    context.AcquireTokenAsync(TestConstants.AnotherResource, clientCredential,
+                        new UserAssertion(accessToken, OAuthGrantType.JwtBearer, TestConstants.DefaultDisplayableId));
+            Assert.AreEqual(0, HttpMessageHandlerFactory.MockHandlersCount(), "all mocks should have been consumed");
+            Assert.IsNotNull(result.AccessToken);
+            Assert.AreEqual("some-access-token", result.AccessToken);
+            Assert.AreEqual(TestConstants.DefaultDisplayableId, result.UserInfo.DisplayableId);
+
+            //there should be only one cache entry.
+            Assert.AreEqual(2, context.TokenCache.Count);
+
+            //assertion hash should be stored in the cache entry.
+            foreach (var value in context.TokenCache.tokenCacheDictionary.Values)
+            {
+                Assert.AreEqual(_cryptoHelper.CreateSha256Hash(accessToken), value.UserAssertionHash);
+            }
+        }
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Mocks\MockHttpMessageHandler.cs" />
     <Compile Include="Mocks\MockWebUI.cs" />
     <Compile Include="NonInteractiveTests.cs" />
+    <Compile Include="OboFlowTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestConstants.cs" />
     <Compile Include="TokenCacheUnitTests.cs" />


### PR DESCRIPTION
add extensive OBO test coverage and add the check to always match on user assertion when provided instead of relying on cache entry. this is because the developer may pass an updated assertion with new claims like MFA etc.