### PR TITLE
UWP fails when handling WebAuthenticationStatus.ErrorHttp 

### DIFF
--- a/src/ADAL.PCL.WinRT/WebUI.cs
+++ b/src/ADAL.PCL.WinRT/WebUI.cs
@@ -116,7 +116,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     result = new AuthorizationResult(AuthorizationStatus.Success, webAuthenticationResult.ResponseData);
                     break;
                 case WebAuthenticationStatus.ErrorHttp:
-                    result = new AuthorizationResult(AuthorizationStatus.ErrorHttp, webAuthenticationResult.ResponseErrorDetail.ToString(CultureInfo.CurrentCulture));
+                    result = new AuthorizationResult(AuthorizationStatus.ErrorHttp)
+                    {
+                        Error = AdalError.Unknown,
+                        ErrorDescription =
+                            webAuthenticationResult.ResponseErrorDetail.ToString(CultureInfo.InvariantCulture)
+                    };
                     break;
                 case WebAuthenticationStatus.UserCancel:
                     result = new AuthorizationResult(AuthorizationStatus.UserCancel, null);


### PR DESCRIPTION
The problem originates in WebUI.ProcessAuthorizationResult (from src\ADAL.PCL.WinRT\WebUI.cs). In the event that the system returns WebAuthenticationStatus.ErrorHttp, it creates an AuthorizationResult with the returned HTTP status code in the returnedUriInput field.

case WebAuthenticationStatus.ErrorHttp:
    result = new AuthorizationResult(AuthorizationStatus.ErrorHttp, webAuthenticationResult.ResponseErrorDetail.ToString(CultureInfo.CurrentCulture));
However, the AuthorizationResult c’tor (in src\ADAL.PCL\AuthorizationResult.cs) only has special handling for the UserCancel and UnknownError result statuses. So, ErrorHttp results are passed off to the ParseAuthorizeResponse method which tries parsing the returnedUriInput as a Uri and throws. This exception isn’t being wrapped up in an AdalException, so it’s not processed by our auth code and eventually crashes the app. #539