### PR TITLE
Fix for :- Exception in ADAL webview on EvoSTS consent screen

### DIFF
--- a/src/ADAL.PCL.Desktop/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/ADAL.PCL.Desktop/WindowsFormsWebAuthenticationDialogBase.cs
@@ -183,6 +183,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         {
             // e.StatusCode - Contains error code which we are able to translate this error to text
             // ADAL.Native contains a code for translation.
+            if (this.DialogResult == DialogResult.OK)
+            {
+                return;
+            }
 
             if (this.webBrowser.IsDisposed)
             {

--- a/src/ADAL.PCL.Desktop/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/ADAL.PCL.Desktop/WindowsFormsWebAuthenticationDialogBase.cs
@@ -224,7 +224,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
             // and url scheme is not https then fail to load.
             if (!canClose && !whiteListedSchemes.Contains(url.Scheme.ToLower(CultureInfo.CurrentCulture)) &&
                 !url.AbsoluteUri.Equals("about:blank", StringComparison.CurrentCultureIgnoreCase)
-                && !url.Scheme.Equals("https", StringComparison.CurrentCultureIgnoreCase))
+                && !url.Scheme.Equals("https", StringComparison.CurrentCultureIgnoreCase) 
+                && !url.Scheme.Equals("javascript", StringComparison.CurrentCultureIgnoreCase))
             {
                 this.Result = new AuthorizationResult(AuthorizationStatus.ErrorHttp);
                 this.Result.Error = AdalError.NonHttpsRedirectNotSupported;


### PR DESCRIPTION
The javascript code is getting accounted as non https url in ADAL. 