### PR TITLE
Adding an optional readonly address bar in Login Dialog Box.

### DIFF
--- a/src/ADAL.PCL.Desktop/ADAL.PCL.Desktop.csproj
+++ b/src/ADAL.PCL.Desktop/ADAL.PCL.Desktop.csproj
@@ -111,6 +111,10 @@
     </Compile>
     <Compile Include="StaTaskScheduler.cs" />
     <Compile Include="TokenCachePlugin.cs" />
+    <Compile Include="UserControlWebBrowser.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="UserControlWebBrowser.Designer.cs" />
     <Compile Include="UserPasswordCredential.cs" />
     <Compile Include="WebBrowserInterfaces.cs" />
     <Compile Include="WebBrowserNavigateErrorEventArgs.cs" />
@@ -134,6 +138,9 @@
     <None Include="..\..\build\35MSSharedLib1024.snk">
       <Link>35MSSharedLib1024.snk</Link>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="UserControlWebBrowser.resx" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/src/ADAL.PCL.Desktop/InteractiveWebUI.cs
+++ b/src/ADAL.PCL.Desktop/InteractiveWebUI.cs
@@ -30,12 +30,18 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
     internal class InteractiveWebUI : WebUI
     {
         private WindowsFormsWebAuthenticationDialog dialog;
+        private readonly bool displayAddressBar;
+
+        public InteractiveWebUI(bool displayAddressBar = false)
+        {
+            this.displayAddressBar = displayAddressBar;
+        }
 
         protected override AuthorizationResult OnAuthenticate()
         {
             AuthorizationResult result;
 
-            using (this.dialog = new WindowsFormsWebAuthenticationDialog(this.OwnerWindow))
+            using (this.dialog = new WindowsFormsWebAuthenticationDialog(this.OwnerWindow, this.displayAddressBar))
             {
                 result = this.dialog.AuthenticateAAD(this.RequestUri, this.CallbackUri);
             }

--- a/src/ADAL.PCL.Desktop/PlatformParameters.cs
+++ b/src/ADAL.PCL.Desktop/PlatformParameters.cs
@@ -32,11 +32,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// </summary>
     public class PlatformParameters : IPlatformParameters
     {
-        /// <summary>
-        /// 
-        /// </summary>
-        /// <param name="promptBehavior"></param>
-        public PlatformParameters(PromptBehavior promptBehavior):this(promptBehavior, null)
+        private bool displayAdfsUrlAddressBar;
+
+        public PlatformParameters(PromptBehavior promptBehavior) : this(promptBehavior, null)
         {
         }
 
@@ -45,10 +43,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// </summary>
         /// <param name="promptBehavior"></param>
         /// <param name="ownerWindow"></param>
-        public PlatformParameters(PromptBehavior promptBehavior, object ownerWindow)
+        /// <param name="displayAdfsUrlAddressBar"></param>
+        public PlatformParameters(PromptBehavior promptBehavior, object ownerWindow, bool displayAdfsUrlAddressBar = false)
         {
             this.PromptBehavior = promptBehavior;
             this.OwnerWindow = ownerWindow;
+            this.DisplayAdfsUrlAddressBar = displayAdfsUrlAddressBar;
         }
 
         /// <summary>
@@ -57,8 +57,23 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public object OwnerWindow { get; private set; }
 
         /// <summary>
+        /// Gets whether ADFS url address bar is displayed in browser dialog box or not.
+        /// </summary>
+        public bool DisplayAdfsUrlAddressBar
+        {
+            get
+            {
+                return this.displayAdfsUrlAddressBar;
+            }
+            private set
+            {
+                this.displayAdfsUrlAddressBar = value;
+            }
+        }
+
+        /// <summary>
         /// Gets prompt behavior. If <see cref="PromptBehavior.Always"/>, asks service to show user the authentication page which gives them chance to authenticate as a different user.
         /// </summary>
-        public PromptBehavior PromptBehavior { get; internal set; } 
+        public PromptBehavior PromptBehavior { get; internal set; }
     }
 }

--- a/src/ADAL.PCL.Desktop/SilentWindowsFormsAuthenticationDialog.cs
+++ b/src/ADAL.PCL.Desktop/SilentWindowsFormsAuthenticationDialog.cs
@@ -53,7 +53,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
             : base(ownerWindow)
         {
             this.SuppressBrowserSubDialogs();
-            this.WebBrowser.DocumentCompleted += this.DocumentCompletedHandler;
+            this.WebBrowser.customWebBrowser.DocumentCompleted += this.DocumentCompletedHandler;
         }
 
         public void CloseBrowser()
@@ -67,7 +67,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         /// </summary>
         private void SuppressBrowserSubDialogs()
         {
-            var webBrowser2 = (NativeWrapper.IWebBrowser2)this.WebBrowser.ActiveXInstance;
+            var webBrowser2 = (NativeWrapper.IWebBrowser2)this.WebBrowser.customWebBrowser.ActiveXInstance;
             webBrowser2.Silent = true;
         }
 
@@ -152,7 +152,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
 
         private bool HasLoginPage()
         {
-            HtmlDocument doc = this.WebBrowser.Document;
+            HtmlDocument doc = this.WebBrowser.customWebBrowser.Document;
             HtmlElement passwordFieldElement = null;
 
             if (null != doc)

--- a/src/ADAL.PCL.Desktop/UserControlWebBrowser.Designer.cs
+++ b/src/ADAL.PCL.Desktop/UserControlWebBrowser.Designer.cs
@@ -1,0 +1,66 @@
+﻿namespace Microsoft.IdentityModel.Clients.ActiveDirectory
+{
+
+    /// <summary>
+    /// Extended web browser user control which has an address bar above its browser control
+    /// </summary>
+    partial class UserControlWebBrowser
+    {
+        /// <summary> 
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary> 
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Component Designer generated code
+
+        /// <summary> 
+        /// Required method for Designer support - do not modify 
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.TextBoxAddressBar = new System.Windows.Forms.TextBox();
+            this.SuspendLayout();
+            // 
+            // textBoxAddressBar
+            // 
+            this.TextBoxAddressBar.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.TextBoxAddressBar.Dock = System.Windows.Forms.DockStyle.Top;
+            this.TextBoxAddressBar.Location = new System.Drawing.Point(0, 0);
+            this.TextBoxAddressBar.Name = "textBoxAddressBar";
+            this.TextBoxAddressBar.ReadOnly = true;
+            this.TextBoxAddressBar.Size = new System.Drawing.Size(150, 20);
+            this.TextBoxAddressBar.TabIndex = 0;
+            // 
+            // UserControlWebBrowser
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.Controls.Add(this.TextBoxAddressBar);
+            this.Name = "UserControlWebBrowser";
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        /// <summary>
+        /// Address bar text box
+        /// </summary>
+        public System.Windows.Forms.TextBox TextBoxAddressBar;
+    }
+}

--- a/src/ADAL.PCL.Desktop/UserControlWebBrowser.cs
+++ b/src/ADAL.PCL.Desktop/UserControlWebBrowser.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Drawing;
+using System.Data;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace Microsoft.IdentityModel.Clients.ActiveDirectory
+{
+    using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
+
+    public  partial class UserControlWebBrowser : UserControl
+    {
+        internal  CustomWebBrowser customWebBrowser=new CustomWebBrowser();
+
+        /// <summary>
+        /// UserControlWebBrowser Constructor 
+        /// </summary>
+        public UserControlWebBrowser(bool displayAddressBar)
+        {
+            InitializeComponent();
+            customWebBrowser.Dock =DockStyle.Fill;
+            this.Controls.Add(this.customWebBrowser);
+            if (displayAddressBar)
+            {
+                this.TextBoxAddressBar.Height = 30;
+                this.TextBoxAddressBar.BringToFront();
+                this.TextBoxAddressBar.Visible =true;
+            }
+            else
+            {
+                this.TextBoxAddressBar.Visible = false;
+            }
+        }
+    }
+}

--- a/src/ADAL.PCL.Desktop/UserControlWebBrowser.resx
+++ b/src/ADAL.PCL.Desktop/UserControlWebBrowser.resx
@@ -1,0 +1,120 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/ADAL.PCL.Desktop/WinFormWebAuthenticationDialog.cs
+++ b/src/ADAL.PCL.Desktop/WinFormWebAuthenticationDialog.cs
@@ -25,6 +25,8 @@
 //
 //------------------------------------------------------------------------------
 
+// Changed by Riteq:  Replaced CustomWebBrowser by UserControlWebBrowser(CustomWebBrowser+AddressBar)
+
 using System;
 using System.ComponentModel;
 using System.Runtime.InteropServices;
@@ -46,12 +48,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         /// <summary>
         /// Default constructor
         /// </summary>
-        public WindowsFormsWebAuthenticationDialog(object ownerWindow)
-            : base(ownerWindow)
+        public WindowsFormsWebAuthenticationDialog(object ownerWindow, bool displayAddressBar = false)
+            : base(ownerWindow, displayAddressBar)
         {
             this.Shown += this.FormShownHandler;
-            this.WebBrowser.DocumentTitleChanged += this.WebBrowserDocumentTitleChangedHandler;
-            this.WebBrowser.ObjectForScripting = this;
+            this.WebBrowser.customWebBrowser.DocumentTitleChanged += this.WebBrowserDocumentTitleChangedHandler;
+            this.WebBrowser.customWebBrowser.ObjectForScripting = this;
         }
 
         /// <summary>
@@ -128,7 +130,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
 
         private void SetBrowserControlZoom(int zoomPercent)
         {
-            NativeWrapper.IWebBrowser2 browser2 = (NativeWrapper.IWebBrowser2)this.WebBrowser.ActiveXInstance;
+            NativeWrapper.IWebBrowser2 browser2 = (NativeWrapper.IWebBrowser2)this.WebBrowser.customWebBrowser.ActiveXInstance;
             NativeWrapper.IOleCommandTarget cmdTarget = browser2.Document as NativeWrapper.IOleCommandTarget;
             if (cmdTarget != null)
             {
@@ -155,7 +157,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
 
         private void WebBrowserDocumentTitleChangedHandler(object sender, EventArgs e)
         {
-            this.Text = this.WebBrowser.DocumentTitle;
+            this.Text = this.WebBrowser.customWebBrowser.DocumentTitle;
         }
     }
 }

--- a/src/ADAL.PCL.Desktop/WindowsFormsWebAuthenticationDialogBase.cs
+++ b/src/ADAL.PCL.Desktop/WindowsFormsWebAuthenticationDialogBase.cs
@@ -25,6 +25,8 @@
 //
 //------------------------------------------------------------------------------
 
+// Changed by Riteq:  Replaced CustomWebBrowser by UserControlWebBrowser(CustomWebBrowser+AddressBar)
+
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -48,7 +50,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         private const int UIWidth = 566;
 
         private Panel webBrowserPanel;
-        private readonly CustomWebBrowser webBrowser;
+        private readonly UserControlWebBrowser webBrowser;
 
         private Uri desiredCallbackUri;
 
@@ -66,7 +68,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         /// 
         /// </summary>
         /// <param name="ownerWindow"></param>
-        protected WindowsFormsWebAuthenticationDialogBase(object ownerWindow)
+        /// <param name="displayAddressBar"></param>
+        protected WindowsFormsWebAuthenticationDialogBase(object ownerWindow, bool displayAddressBar = false)
         {
             // From MSDN (http://msdn.microsoft.com/en-us/library/ie/dn720860(v=vs.85).aspx): 
             // The net session count tracks the number of instances of the web browser control. 
@@ -100,7 +103,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
                     "Invalid owner window type. Expected types are IWin32Window or IntPtr (for window handle).");
             }
 
-            this.webBrowser = new CustomWebBrowser();
+            this.webBrowser = new UserControlWebBrowser(displayAddressBar);
             this.webBrowser.PreviewKeyDown += webBrowser_PreviewKeyDown;
             this.InitializeComponent();
 
@@ -118,7 +121,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         /// <summary>
         /// Gets Web Browser control used by the dialog.
         /// </summary>
-        public WebBrowser WebBrowser
+        public UserControlWebBrowser WebBrowser
         {
             get { return this.webBrowser; }
         }
@@ -191,7 +194,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
                 return;
             }
 
-            if (this.webBrowser.ActiveXInstance != e.WebBrowserActiveXInstance)
+            if (this.webBrowser.customWebBrowser.ActiveXInstance != e.WebBrowserActiveXInstance)
             {
                 // this event came from internal frame, ignore this.
                 return;
@@ -246,19 +249,19 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         {
             if (!this.webBrowser.IsDisposed)
             {
-                if (this.webBrowser.IsBusy)
+                if (this.webBrowser.customWebBrowser.IsBusy)
                 {
                     PlatformPlugin.Logger.Verbose(null,
                         string.Format(CultureInfo.CurrentCulture,
                             " WebBrowser state: IsBusy: {0}, ReadyState: {1}, Created: {2}, Disposing: {3}, IsDisposed: {4}, IsOffline: {5}",
-                            this.webBrowser.IsBusy, this.webBrowser.ReadyState, this.webBrowser.Created,
-                            this.webBrowser.Disposing, this.webBrowser.IsDisposed, this.webBrowser.IsOffline));
-                    this.webBrowser.Stop();
+                            this.webBrowser.customWebBrowser.IsBusy, this.webBrowser.customWebBrowser.ReadyState, this.webBrowser.customWebBrowser.Created,
+                            this.webBrowser.customWebBrowser.Disposing, this.webBrowser.customWebBrowser.IsDisposed, this.webBrowser.customWebBrowser.IsOffline));
+                    this.webBrowser.customWebBrowser.Stop();
                     PlatformPlugin.Logger.Verbose(null,
                         string.Format(CultureInfo.CurrentCulture,
                             " WebBrowser state (after Stop): IsBusy: {0}, ReadyState: {1}, Created: {2}, Disposing: {3}, IsDisposed: {4}, IsOffline: {5}",
-                            this.webBrowser.IsBusy, this.webBrowser.ReadyState, this.webBrowser.Created,
-                            this.webBrowser.Disposing, this.webBrowser.IsDisposed, this.webBrowser.IsOffline));
+                            this.webBrowser.customWebBrowser.IsBusy, this.webBrowser.customWebBrowser.ReadyState, this.webBrowser.customWebBrowser.Created,
+                            this.webBrowser.customWebBrowser.Disposing, this.webBrowser.customWebBrowser.IsDisposed, this.webBrowser.customWebBrowser.IsOffline));
                 }
             }
         }
@@ -282,11 +285,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
             // The WebBrowser event handlers must not throw exceptions.
             // If they do then they may be swallowed by the native
             // browser com control.
-            this.webBrowser.Navigating += this.WebBrowserNavigatingHandler;
-            this.webBrowser.Navigated += this.WebBrowserNavigatedHandler;
-            this.webBrowser.NavigateError += this.WebBrowserNavigateErrorHandler;
-
-            this.webBrowser.Navigate(requestUri);
+            this.webBrowser.customWebBrowser.Navigating += this.WebBrowserNavigatingHandler;
+            this.webBrowser.customWebBrowser.Navigated += this.WebBrowserNavigatedHandler;
+            this.webBrowser.customWebBrowser.NavigateError += this.WebBrowserNavigateErrorHandler;
+            this.webBrowser.TextBoxAddressBar.Text = requestUri.AbsoluteUri;
+            this.webBrowser.TextBoxAddressBar.SelectionStart = 0;
+            this.webBrowser.customWebBrowser.Navigate(requestUri);
             this.OnAuthenticate();
 
             return this.Result;
@@ -320,7 +324,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
             this.webBrowser.Name = "webBrowser";
             this.webBrowser.Size = new Size(UIWidth, 565);
             this.webBrowser.TabIndex = 1;
-            this.webBrowser.IsWebBrowserContextMenuEnabled = false;
+            this.webBrowser.customWebBrowser.IsWebBrowserContextMenuEnabled = false;
 
             // 
             // webBrowserPanel


### PR DESCRIPTION
Added a new optional DiplayAddressBar property which is 'False' by default in PlatformParameter and updated all dependent classes. 
Wrapped CustomWebBrowser in UserControlWebBrowser along with a readonly TextBox that displays Adfs Address Url on top of the WebBrowser control.
It can assure the user that the login screen belongs to the ADFS.