### PR TITLE
Jennyf/ws trust sovereign clouds v2

### DIFF
--- a/src/ADAL.Common/AcquireTokenNonInteractiveHandler.cs
+++ b/src/ADAL.Common/AcquireTokenNonInteractiveHandler.cs
@@ -107,7 +107,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     WsTrustAddress wsTrustAddress = await MexParser.FetchWsTrustAddressFromMexAsync(userRealmResponse.FederationMetadataUrl, this.userCredential.UserAuthType, this.CallState);
                     Logger.Information(this.CallState, "WS-Trust endpoint '{0}' fetched from MEX at '{1}'", wsTrustAddress.Uri, userRealmResponse.FederationMetadataUrl);
 
-                    WsTrustResponse wsTrustResponse = await WsTrustRequest.SendRequestAsync(wsTrustAddress, this.userCredential, this.CallState);
+                    WsTrustResponse wsTrustResponse = await WsTrustRequest.SendRequestAsync(wsTrustAddress, this.userCredential, this.CallState, userRealmResponse.CloudAudienceUrn);
                     Logger.Information(this.CallState, "Token of type '{0}' acquired from WS-Trust endpoint", wsTrustResponse.TokenType);
 
                     // We assume that if the response token type is not SAML 1.1, it is SAML 2

--- a/src/ADAL.Common/UserRealmDiscoveryResponse.cs
+++ b/src/ADAL.Common/UserRealmDiscoveryResponse.cs
@@ -40,7 +40,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         [DataMember(Name = "federation_active_auth_url")]
         public string FederationActiveAuthUrl { get; set; }
 
-        internal static async Task<UserRealmDiscoveryResponse> CreateByDiscoveryAsync(string userRealmUri, string userName, CallState callState)
+        [DataMember(Name = "cloud_audience_urn")]
+        public string CloudAudienceUrn { get; set; }
+
+        internal static async Task<UserRealmDiscoveryResponse> CreateByDiscoveryAsync(string userRealmUri,
+            string userName, CallState callState)
         {
             string userRealmEndpoint = userRealmUri;
             userRealmEndpoint += (userName + "?api-version=1.0");
@@ -71,7 +75,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             catch (WebException ex)
             {
                 var serviceException = new AdalServiceException(AdalError.UserRealmDiscoveryFailed, ex);
-                clientMetrics.SetLastError(new[] { serviceException.StatusCode.ToString() });
+                clientMetrics.SetLastError(new[] {serviceException.StatusCode.ToString()});
                 throw serviceException;
             }
             finally

--- a/src/ADAL.Common/WsTrustRequest.cs
+++ b/src/ADAL.Common/WsTrustRequest.cs
@@ -57,9 +57,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
               </s:Envelope>";
 
         // We currently send this for all requests. We may need to change it in the future.
-        private const string DefaultAppliesTo = "urn:federation:MicrosoftOnline";
+        private const string defaultAppliesTo = "urn:federation:MicrosoftOnline";
 
-        public static async Task<WsTrustResponse> SendRequestAsync(WsTrustAddress wsTrustAddress, UserCredential credential, CallState callState)
+        public static async Task<WsTrustResponse> SendRequestAsync(WsTrustAddress wsTrustAddress, UserCredential credential, CallState callState, string cloudAudience)
         {
             IHttpWebRequest request = NetworkPlugin.HttpWebRequestFactory.Create(wsTrustAddress.Uri.AbsoluteUri);
             request.ContentType = "application/soap+xml;";
@@ -68,7 +68,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 SetKerberosOption(request);
             }
 
-            StringBuilder messageBuilder = BuildMessage(DefaultAppliesTo, wsTrustAddress, credential);
+            if (string.IsNullOrEmpty(cloudAudience))
+            {
+                cloudAudience = defaultAppliesTo;
+            }
+
+            StringBuilder messageBuilder = BuildMessage(cloudAudience, wsTrustAddress, credential);
             string soapAction = XmlNamespace.Issue.ToString();
             if (wsTrustAddress.Version == WsTrustVersion.WsTrust2005)
             {

--- a/tests/Test.ADAL.Common/TestConstants.cs
+++ b/tests/Test.ADAL.Common/TestConstants.cs
@@ -55,6 +55,7 @@ namespace Test.ADAL.Common
         Null = 2,
         InMemory = 3
     }
+
     public class TestConstants
     {
         public static readonly string DefaultResource = "resource1";
@@ -73,6 +74,7 @@ namespace Test.ADAL.Common
         public static readonly bool DefaultExtendedLifeTimeEnabled = false;
         public static readonly bool PositiveExtendedLifeTimeEnabled = true;
         public static readonly string ErrorSubCode = "ErrorSubCode";
+        public static readonly string CloudAudienceUrnMicrosoft = "urn:federation:MicrosoftOnline";
+        public static readonly string CloudAudienceUrn = "urn:federation:Blackforest";
     }
-
 }


### PR DESCRIPTION
#590 When logging in as a federated user, the default audience is urn:federation:MicrosoftOnline. However, this does not work for a sovereign cloud service. Code has been changed to use the JSON property cloud_audience_urn from the HTTPS GET response as the audience value. If no value is present, a default value will be used (urn:federation:MicrosoftOnline).