### PR TITLE
Integrated auth support for client credentials

### DIFF
--- a/src/ADAL.PCL/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.PCL/AcquireTokenHandlerBase.cs
@@ -312,8 +312,15 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         private async Task<AuthenticationResultEx> SendHttpMessageAsync(IRequestParameters requestParameters)
         {
+            var isIntegratedAuth = this.ClientKey?.Credential != null && this.ClientKey.Credential.IsIntegratedAuth;
+
+            if (isIntegratedAuth && this.Authenticator.AuthorityType != AuthorityType.ADFS)
+            {
+                throw new NotSupportedException(AdalErrorMessage.UnsupportedIntegratedAuthentication);
+            }
+
             client = new AdalHttpClient(this.Authenticator.TokenUri, this.CallState)
-            { Client = { BodyParameters = requestParameters } };
+            { Client = { BodyParameters = requestParameters, UseDefaultCredentials = isIntegratedAuth } };
             TokenResponse tokenResponse = await client.GetResponseAsync<TokenResponse>().ConfigureAwait(false);
             return tokenResponse.GetResult();
         }

--- a/src/ADAL.PCL/ClientCredential.cs
+++ b/src/ADAL.PCL/ClientCredential.cs
@@ -35,6 +35,20 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     public sealed class ClientCredential
     {
         /// <summary>
+        /// Constructor to create credential with client id and integrated authentication.
+        /// </summary>
+        /// <param name="clientId">Identifier of the client requesting the token.</param>
+        public ClientCredential(string clientId)
+        {
+            if (string.IsNullOrWhiteSpace(clientId))
+            {
+                throw new ArgumentNullException("clientId");
+            }
+
+            this.ClientId = clientId;
+        }
+
+        /// <summary>
         /// Constructor to create credential with client id and secret
         /// </summary>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
@@ -84,5 +98,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         internal string ClientSecret { get; private set; }
 
         internal ISecureClientSecret SecureClientSecret { get; private set; }
+
+        /// <summary>
+        /// Indicates whether or not this credential uses integrated authentication on domain-joined machines.
+        /// </summary>
+        public bool IsIntegratedAuth
+        {
+            get { return this.SecureClientSecret == null && string.IsNullOrEmpty(ClientSecret); }
+        }
     }
 }

--- a/src/ADAL.PCL/ClientKey.cs
+++ b/src/ADAL.PCL/ClientKey.cs
@@ -107,6 +107,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 {
                     this.Credential.SecureClientSecret.ApplyTo(parameters);
                 }
+                else if (this.Credential.IsIntegratedAuth)
+                {
+                    parameters[OAuthParameter.UseWindowsClientAuthentication] = "true";
+                }
                 else
                 {
                     parameters[OAuthParameter.ClientSecret] = this.Credential.ClientSecret;

--- a/src/ADAL.PCL/Constants.cs
+++ b/src/ADAL.PCL/Constants.cs
@@ -376,6 +376,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public const string UnsupportedAuthorityValidation =
             "Authority validation is not supported for this type of authority";
 
+        public const string UnsupportedIntegratedAuthentication =
+    "Integrated authentication is not supported for this type of authority";
+
         public const string UnsupportedMultiRefreshToken =
             "This authority does not support refresh token for multiple resources. Pass null as a resource";
 
@@ -407,7 +410,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             "Integrated authentication failed. You may try an alternative authentication method";
 
         public const string DuplicateQueryParameterTemplate = "Duplicate query parameter '{0}' in extraQueryParameters";
-        
+
         public const string DeviceCertificateNotFoundTemplate = "Device Certificate was not found for {0}";
     }
 
@@ -430,5 +433,5 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public static readonly XNamespace Issue2005 = "http://schemas.xmlsoap.org/ws/2005/02/trust/RST/Issue";
         public static readonly XNamespace SoapEnvelope = "http://www.w3.org/2003/05/soap-envelope";
     }
-    
+
 }

--- a/src/ADAL.PCL/HttpClientFactory.cs
+++ b/src/ADAL.PCL/HttpClientFactory.cs
@@ -26,6 +26,8 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Collections.Generic;
+using System.Net.Http;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
@@ -38,7 +40,24 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public IHttpClient Create(string uri, CallState callState)
         {
+            if (MockHandlerQueue.Count > 0)
+            {
+                return MockHandlerQueue.Dequeue();
+            }
+
             return new HttpClientWrapper(uri, callState);
+        }
+
+        private readonly static Queue<IHttpClient> MockHandlerQueue = new Queue<IHttpClient>();
+
+        public static void AddMockHandler(IHttpClient mockHandler)
+        {
+            MockHandlerQueue.Enqueue(mockHandler);
+        }
+
+        public static void ClearMockHandlers()
+        {
+            MockHandlerQueue.Clear();
         }
     }
 }

--- a/src/ADAL.PCL/OAuthConstants.cs
+++ b/src/ADAL.PCL/OAuthConstants.cs
@@ -44,6 +44,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public const string RequestedTokenUse = "requested_token_use";
         public const string Username = "username";
         public const string Password = "password";
+        public const string UseWindowsClientAuthentication = "use_windows_client_authentication";
 
         public const string HasChrome = "haschrome";
         public const string LoginHint = "login_hint"; // login_hint is not standard oauth2 parameter
@@ -101,6 +102,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         // The behavior of this value is identical to prompt=none for managed users; However, for federated users, AAD
         // redirects to ADFS as it cannot determine in advance whether ADFS can login user silently (e.g. via WIA) or not.
-        public const string AttemptNone = "attempt_none";        
+        public const string AttemptNone = "attempt_none";
     }
 }

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHttpClient.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHttpClient.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Test.ADAL.NET.Unit.Mocks
+{
+    internal class MockHttpClient : IHttpClient
+    {
+        public MockHttpClient()
+        {
+            this.Headers = new Dictionary<string, string>();
+        }
+
+        public IRequestParameters BodyParameters { get; set; }
+        public string Accept { get; set; }
+        public string ContentType { get; set; }
+        public bool UseDefaultCredentials { get; set; }
+        public Dictionary<string, string> Headers { get; }
+
+        public IHttpWebResponse Response { get; set; }
+        public bool ExpectedUseOfDefaultCredentials { get; set; }
+
+        public Task<IHttpWebResponse> GetResponseAsync()
+        {
+            Assert.AreEqual(this.ExpectedUseOfDefaultCredentials, this.UseDefaultCredentials);
+
+            return new TaskFactory().StartNew(() => Response);
+        }
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -93,6 +93,7 @@
     <Compile Include="AuthenticationParametersTests.cs" />
     <Compile Include="LoggerCallbackTests.cs" />
     <Compile Include="Mocks\MockHelpers.cs" />
+    <Compile Include="Mocks\MockHttpClient.cs" />
     <Compile Include="Mocks\MockHttpMessageHandler.cs" />
     <Compile Include="Mocks\MockWebUI.cs" />
     <Compile Include="NonInteractiveTests.cs" />


### PR DESCRIPTION
ADFS supports authentication of a client by means of an AD account
instead of a client secret. This commit adds support for integrated
authentication to client credentials.

The changes consist of sending an additional oauth parameter
(use_windows_client_authentication=true) and using default credentials
when requesting an oauth token with client credentials without a
client secret.