### PR TITLE
AcquireTokenInteractiveHandler - BUG fix - when Creating Handler with…

### DIFF
--- a/src/ADAL.PCL/AcquireTokenInteractiveHandler.cs
+++ b/src/ADAL.PCL/AcquireTokenInteractiveHandler.cs
@@ -93,7 +93,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
             this.brokerParameters["username_type"] = userId.Type.ToString();
 
-            this.brokerParameters["redirect_uri"] = redirectUri.AbsoluteUri;
+            this.brokerParameters["redirect_uri"] = this.redirectUri.AbsoluteUri;
             this.brokerParameters["extra_qp"] = extraQueryParameters;
             PlatformPlugin.BrokerHelper.PlatformParameters = authorizationParameters;
         }


### PR DESCRIPTION
Fix for: Calling AuthenticationContext.AcquireTokenAsync with Uri as null

AcquireTokenInteractiveHandler - BUG fix - when Creating Handler with redirectUri as null (happens when calling AuthenticationContext.AcquireTokenAsync)  the constructor  will throw NullReferenceException, beasue it will try to access this Uri property although, the Uri is validated (checked for null) - reason -  method paramerter is used instead of class field.