### PR TITLE
Modified exception checking in tests

### DIFF
--- a/tests/Test.ADAL.Common/TokenCacheTests.cs
+++ b/tests/Test.ADAL.Common/TokenCacheTests.cs
@@ -164,66 +164,66 @@ namespace Test.ADAL.Common.Unit
         }
 
 
- /// <summary>
- /// Check when there are multiple users in the cache with the same
- /// authority, clientId, resource but different unique and displayId's that
- /// we can correctly get them from the cache without a multiple token 
- /// detected exception.
- /// </summary>
- /// <returns></returns>
- public static async Task TestUniqueIdDisplayableIdLookup()
- {
- 
-     string authority = "https://www.gotJwt.com/";
-     string clientId = Guid.NewGuid().ToString();
-     string resource = Guid.NewGuid().ToString();
-     string tenantId = Guid.NewGuid().ToString();
-     string uniqueId = Guid.NewGuid().ToString();
-     string displayableId = Guid.NewGuid().ToString();
-     Uri redirectUri = new Uri("https://www.GetJwt.com");
- 
-     var authenticationResult = CreateCacheValue(uniqueId, displayableId);
-     authority = authority + tenantId + "/";
-     UserCredential credential = new UserCredential(displayableId);
-     AuthenticationContext tempContext = new AuthenticationContext(authority, false);
-     var localCache = tempContext.TokenCache;
-     localCache.Clear();
- 
-     // Add first user into cache
-     resource = Guid.NewGuid().ToString();
-     clientId = Guid.NewGuid().ToString();
-     uniqueId = Guid.NewGuid().ToString();
-     displayableId = Guid.NewGuid().ToString();
-     var cacheValue = CreateCacheValue(uniqueId, displayableId);
-     AddToDictionary(localCache,
-         new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
-         cacheValue);
- 
-     //Add second user into cache
-     uniqueId = Guid.NewGuid().ToString();
-     displayableId = Guid.NewGuid().ToString();
-     cacheValue = CreateCacheValue(uniqueId, displayableId);
-     AddToDictionary(localCache,
-         new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
-         cacheValue);
- 
-     var acWithLocalCache = new AuthenticationContext(authority, false, localCache);
-     var userId = new UserIdentifier(uniqueId, UserIdentifierType.UniqueId);
-     var userIdUpper = new UserIdentifier(displayableId.ToUpper(), UserIdentifierType.RequiredDisplayableId);
+        /// <summary>
+        /// Check when there are multiple users in the cache with the same
+        /// authority, clientId, resource but different unique and displayId's that
+        /// we can correctly get them from the cache without a multiple token
+        /// detected exception.
+        /// </summary>
+        /// <returns></returns>
+        public static async Task TestUniqueIdDisplayableIdLookup()
+        {
 
-     var parameters = new PlatformParameters(PromptBehavior.Auto);
-     var authenticationResultFromCache = await acWithLocalCache.AcquireTokenAsync(resource, clientId, redirectUri, parameters, userId);
-     VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
- 
-     authenticationResultFromCache = await acWithLocalCache.AcquireTokenAsync(resource, clientId, redirectUri, parameters, userIdUpper);
-     VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
- 
-     authenticationResultFromCache = await acWithLocalCache.AcquireTokenSilentAsync(resource, clientId, userId);
-     VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
- 
-     authenticationResultFromCache = await acWithLocalCache.AcquireTokenSilentAsync(resource, clientId, userIdUpper);
-     VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
- }
+            string authority = "https://www.gotJwt.com/";
+            string clientId = Guid.NewGuid().ToString();
+            string resource = Guid.NewGuid().ToString();
+            string tenantId = Guid.NewGuid().ToString();
+            string uniqueId = Guid.NewGuid().ToString();
+            string displayableId = Guid.NewGuid().ToString();
+            Uri redirectUri = new Uri("https://www.GetJwt.com");
+
+            var authenticationResult = CreateCacheValue(uniqueId, displayableId);
+            authority = authority + tenantId + "/";
+            UserCredential credential = new UserCredential(displayableId);
+            AuthenticationContext tempContext = new AuthenticationContext(authority, false);
+            var localCache = tempContext.TokenCache;
+            localCache.Clear();
+
+            // Add first user into cache
+            resource = Guid.NewGuid().ToString();
+            clientId = Guid.NewGuid().ToString();
+            uniqueId = Guid.NewGuid().ToString();
+            displayableId = Guid.NewGuid().ToString();
+            var cacheValue = CreateCacheValue(uniqueId, displayableId);
+            AddToDictionary(localCache,
+                new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
+                cacheValue);
+
+            //Add second user into cache
+            uniqueId = Guid.NewGuid().ToString();
+            displayableId = Guid.NewGuid().ToString();
+            cacheValue = CreateCacheValue(uniqueId, displayableId);
+            AddToDictionary(localCache,
+                new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
+                cacheValue);
+
+            var acWithLocalCache = new AuthenticationContext(authority, false, localCache);
+            var userId = new UserIdentifier(uniqueId, UserIdentifierType.UniqueId);
+            var userIdUpper = new UserIdentifier(displayableId.ToUpper(), UserIdentifierType.RequiredDisplayableId);
+
+            var parameters = new PlatformParameters(PromptBehavior.Auto);
+            var authenticationResultFromCache = await acWithLocalCache.AcquireTokenAsync(resource, clientId, redirectUri, parameters, userId);
+            VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
+
+            authenticationResultFromCache = await acWithLocalCache.AcquireTokenAsync(resource, clientId, redirectUri, parameters, userIdUpper);
+            VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
+
+            authenticationResultFromCache = await acWithLocalCache.AcquireTokenSilentAsync(resource, clientId, userId);
+            VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
+
+            authenticationResultFromCache = await acWithLocalCache.AcquireTokenSilentAsync(resource, clientId, userIdUpper);
+            VerifyAuthenticationResultsAreEqual(cacheValue.Result, authenticationResultFromCache);
+        }
 
 #if TEST_ADAL_NET
     public static async Task TokenCacheKeyTestAsync(IPlatformParameters parameters)
@@ -260,28 +260,21 @@ namespace Test.ADAL.Common.Unit
                 new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, null, displayableId),
                 authenticationResult);
 
-            try
-            {
-                await acWithLocalCache.AcquireTokenAsync(resource, clientId, credential);
-                Assert.Fail("Exception expected");
-            }
-            catch (AdalException adae)
-            {
-                Assert.IsTrue(adae.ErrorCode == "multiple_matching_tokens_detected" &&
-                              adae.Message.Contains("The cache contains multiple tokens satisfying the requirements"));
-            }
 
-            try
+            var adae = AssertException.TaskThrows<AdalException>(() =>
+                acWithLocalCache.AcquireTokenAsync(resource, clientId, credential));
+            Assert.IsTrue(adae.ErrorCode == "multiple_matching_tokens_detected" &&
+                            adae.Message.Contains("The cache contains multiple tokens satisfying the requirements"));
+
+
+            adae = AssertException.TaskThrows<AdalException>(async () =>
             {
                 AuthenticationContext acWithDefaultCache = new AuthenticationContext(authority, false);
                 await acWithDefaultCache.AcquireTokenAsync(resource, clientId, credential);
                 Assert.Fail("Exception expected");
-            }
-            catch (AdalException adae)
-            {
-                Assert.IsTrue(adae.ErrorCode == "multiple_matching_tokens_detected" &&
+            });
+            Assert.IsTrue(adae.ErrorCode == "multiple_matching_tokens_detected" &&
                               adae.Message.Contains("The cache contains multiple tokens satisfying the requirements"));
-            }
 
             // @resource && @clientId
             acWithLocalCache = new AuthenticationContext(authority, false, localCache);
@@ -371,15 +364,11 @@ namespace Test.ADAL.Common.Unit
             valueInCache = cacheDictionary[key];
             VerifyAuthenticationResultExsAreEqual(valueInCache, value2);
             VerifyAuthenticationResultExsAreNotEqual(valueInCache, value);
-            try
-            {
-                AddToDictionary(tokenCache, key, value);
-                Assert.Fail("Exception expected due to duplicate key");
-            }
-            catch (ArgumentException)
-            {
-                // Expected
-            }
+
+            // Duplicate key -> should fail to add again
+            AssertException.Throws<ArgumentException>(() =>
+                AddToDictionary(tokenCache, key, value));
+
 
             Log.Comment(
                 "====== Verifying that correct values are retrieved when requested for different tenant with user and without user");
@@ -407,25 +396,16 @@ namespace Test.ADAL.Common.Unit
             Assert.AreEqual(cacheDictionary[key], value);
             Assert.AreEqual(cacheDictionary[key2], value2);
 
-            try
-            {
-                AddToDictionary(tokenCache, null, value);
-                Assert.Fail("Exception expected due to duplicate key");
-            }
-            catch (ArgumentNullException)
-            {
-                // Expected
-            }
 
-            try
-            {
-                cacheDictionary[null] = value;
-                Assert.Fail("Exception expected due to duplicate key");
-            }
-            catch (ArgumentNullException)
-            {
-                // Expected
-            }
+            // Null key -> error
+            AssertException.Throws<ArgumentNullException>(() =>
+                AddToDictionary(tokenCache, null, value));
+
+
+            // Null key -> error
+            AssertException.Throws<ArgumentNullException>(() =>
+                AddToDictionary(tokenCache, null, value));
+
 
             Assert.IsFalse(cacheDictionary.IsReadOnly);
 
@@ -456,15 +436,11 @@ namespace Test.ADAL.Common.Unit
             Assert.IsFalse(cacheDictionary.Contains(new KeyValuePair<TokenCacheKey, AuthenticationResultEx>(key, value2)));
             Assert.IsFalse(cacheDictionary.Contains(new KeyValuePair<TokenCacheKey, AuthenticationResultEx>(key2, value)));
 
-            try
-            {
-                AddToDictionary(tokenCache, key, value);
-                Assert.Fail("Exception expected due to duplicate key");
-            }
-            catch (ArgumentException)
-            {
-                // Expected
-            }
+
+            // Duplicate key -> error
+            AssertException.Throws<ArgumentException>(() =>
+                AddToDictionary(tokenCache, key, value));
+
 
             AddToDictionary(tokenCache, key3, value);
             Assert.AreEqual(3, cacheDictionary.Keys.Count);
@@ -477,25 +453,13 @@ namespace Test.ADAL.Common.Unit
                 Assert.AreEqual(cacheItemsCopy[i + 1].Value, cacheDictionary[cacheItemsCopy[i + 1].Key]);
             }
 
-            try
-            {
-                cacheDictionary.CopyTo(cacheItemsCopy, 2);
-                Assert.Fail("Exception expected");
-            }
-            catch (ArgumentException)
-            {
-                // Expected
-            }
 
-            try
-            {
-                cacheDictionary.CopyTo(cacheItemsCopy, -1);
-                Assert.Fail("Exception expected");
-            }
-            catch (ArgumentOutOfRangeException)
-            {
-                // Expected
-            }
+            AssertException.Throws<ArgumentException>(() =>
+                cacheDictionary.CopyTo(cacheItemsCopy, 2));
+
+            AssertException.Throws<ArgumentOutOfRangeException>(() =>
+                cacheDictionary.CopyTo(cacheItemsCopy, -1));
+
 
             RemoveFromDictionary(tokenCache, key2);
             Assert.AreEqual(2, cacheDictionary.Keys.Count);
@@ -551,16 +515,10 @@ namespace Test.ADAL.Common.Unit
 
             data.AssertionHash = null;
 
-            try
-            {
-                cache.LoadFromCache(data, null);
-                Assert.Fail("multiple_tokens_detected should have been thrown");
-            }
-            catch (Exception exc)
-            {
-                Assert.IsTrue(exc is AdalException);
-                Assert.AreEqual(((AdalException) exc).ErrorCode, AdalError.MultipleTokensMatched);
-            }
+            // Multiple tokens in cache -> error
+            var exc = AssertException.Throws<AdalException>(() =>
+                cache.LoadFromCache(data, null));
+            Assert.AreEqual(exc.ErrorCode, AdalError.MultipleTokensMatched);
         }
 
         internal static void TokenCacheCapacityTest()

--- a/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
@@ -25,15 +25,14 @@
 //
 //------------------------------------------------------------------------------
 
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
-using Microsoft.IdentityModel.Clients.ActiveDirectory;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Test.ADAL.Common;
 using Test.ADAL.Common.Unit;
 using Test.ADAL.NET.Unit.Mocks;
@@ -131,7 +130,7 @@ namespace Test.ADAL.NET.Unit
             await context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,TestConstants.DefaultRedirectUri, platformParameters);
             Assert.IsNotNull(result);
             Assert.IsNotNull(result.AccessToken);
-            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(),0);     
+            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(),0);
         }
 
         [TestMethod]
@@ -198,10 +197,10 @@ namespace Test.ADAL.NET.Unit
                 ResponseMessage = MockHelpers.CreateResiliencyMessage(HttpStatusCode.GatewayTimeout),
             });
 
-                Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 2);
+            Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 2);
             context.ExtendedLifeTimeEnabled = true;
-                AuthenticationResult result =
-                     await context.AcquireTokenSilentAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId, new UserIdentifier("unique_id", UserIdentifierType.UniqueId));
+            AuthenticationResult result =
+                 await context.AcquireTokenSilentAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId, new UserIdentifier("unique_id", UserIdentifierType.UniqueId));
             Assert.IsNull(result.AccessToken);
             Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 0);
         }
@@ -228,24 +227,24 @@ namespace Test.ADAL.NET.Unit
                 Method = HttpMethod.Post,
                 ResponseMessage = MockHelpers.CreateResiliencyMessage(HttpStatusCode.GatewayTimeout),
             });
-            
+
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
             {
                 Method = HttpMethod.Post,
                 ResponseMessage = MockHelpers.CreateResiliencyMessage(HttpStatusCode.InternalServerError),
-            });            
+            });
 
             //Assert.AreEqual(HttpMessageHandlerFactory.MockHandlersCount(), 2);
             context.ExtendedLifeTimeEnabled = true;
-                AuthenticationResult result =
-                    await
-                        context.AcquireTokenSilentAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
-                            new UserIdentifier("unique_id", UserIdentifierType.UniqueId));
+            AuthenticationResult result =
+                await
+                    context.AcquireTokenSilentAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
+                        new UserIdentifier("unique_id", UserIdentifierType.UniqueId));
 
-                Assert.IsNotNull(result);
-                Assert.IsFalse(result.ExpiresOn <=
-                               DateTime.UtcNow);
-                Assert.AreEqual(result.AccessToken, "some-access-token");
+            Assert.IsNotNull(result);
+            Assert.IsFalse(result.ExpiresOn <=
+                           DateTime.UtcNow);
+            Assert.AreEqual(result.AccessToken, "some-access-token");
         }
 
         [TestMethod]
@@ -318,25 +317,16 @@ namespace Test.ADAL.NET.Unit
             var result2 = await context.AcquireTokenAsync(TestConstants.DefaultResource, credential);
             Assert.AreEqual(result.AccessToken, result2.AccessToken);
 
-            try
-            {
-                await context.AcquireTokenAsync(null, credential);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "resource");
-            }
+            // Null resource -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(null, credential));
+            Assert.AreEqual(exc.ParamName, "resource");
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCredential");
-            }
+            // Null client credential -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null));
+            Assert.AreEqual(exc.ParamName, "clientCredential");
         }
-
 
         [TestMethod]
         [Description("Test for ExtendedLifetime feature flag being not set in normal(non-outage) for Client Credentials")]
@@ -344,7 +334,7 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             var credential = new ClientCredential(TestConstants.DefaultClientId, TestConstants.DefaultClientSecret);
-          
+
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
             {
                 Method = HttpMethod.Post,
@@ -359,7 +349,7 @@ namespace Test.ADAL.NET.Unit
                     {"grant_type", "client_credentials"}
                 }
             });
-            
+
             AuthenticationResult result = await context.AcquireTokenAsync(TestConstants.DefaultResource, credential);
             Assert.IsNotNull(result.AccessToken);
 
@@ -367,23 +357,15 @@ namespace Test.ADAL.NET.Unit
             var result2 = await context.AcquireTokenAsync(TestConstants.DefaultResource, credential);
             Assert.AreEqual(result.AccessToken, result2.AccessToken);
 
-            try
-            {
-                await context.AcquireTokenAsync(null, credential);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "resource");
-            }
+            // Null resource -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(null, credential));
+            Assert.AreEqual(exc.ParamName, "resource");
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCredential");
-            }
+            // Null client credential -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null));
+            Assert.AreEqual(exc.ParamName, "clientCredential");
         }
 
         [TestMethod]
@@ -428,7 +410,7 @@ namespace Test.ADAL.NET.Unit
                     {"grant_type", "client_credentials"}
                 }
             });
-            
+
             var credential = new ClientCredential(TestConstants.DefaultClientId, TestConstants.DefaultClientSecret);
 
             context.ExtendedLifeTimeEnabled = true;
@@ -436,28 +418,20 @@ namespace Test.ADAL.NET.Unit
             var result = await context.AcquireTokenAsync(TestConstants.DefaultResource, credential);
             Assert.IsNotNull(result.AccessToken);
 
-            try
-            {
-                await context.AcquireTokenAsync(null, credential);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "resource");
-            }
+            // Null resource -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(null, credential));
+            Assert.AreEqual(exc.ParamName, "resource");
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCredential");
-            }
+            // Null client credential -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null));
+            Assert.AreEqual(exc.ParamName, "clientCredential");
         }
 
         [TestMethod]
         [Description("Test for ExtendedLifetime feature with the extendedExpiresOn being expired not returning back stale AT")]
-        public async Task ClientCredentialExtendedExpiryNegativeTest()
+        public void ClientCredentialExtendedExpiryNegativeTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
@@ -504,39 +478,24 @@ namespace Test.ADAL.NET.Unit
 
 
             // cache look up
-            try
-            {
-                var result =
-                    await
-                        context.AcquireTokenAsync(TestConstants.DefaultResource, credential);
-            }
-            catch (AdalServiceException ex)
-            {
-                Assert.AreEqual(ex.InnerException.Message, " Response status code does not indicate success: 504 (GatewayTimeout).");
-            }
+            var ex = AssertException.TaskThrows<AdalServiceException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, credential));
+            Assert.AreEqual(ex.InnerException.Message, " Response status code does not indicate success: 504 (GatewayTimeout).");
 
-            try
-            {
-                await context.AcquireTokenAsync(null, credential);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "resource");
-            }
+            // Null resource -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(null, credential));
+            Assert.AreEqual(exc.ParamName, "resource");
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCredential");
-            }
+            // Null client credential -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null));
+            Assert.AreEqual(exc.ParamName, "clientCredential");
         }
 
         [TestMethod]
         [Description("Test for ExtendedLifetime feature with the extendedExpiresOn being expired not returning back stale AT")]
-        public async Task ClientCredentialNegativeRequestTimeoutTest()
+        public void ClientCredentialNegativeRequestTimeoutTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
@@ -583,39 +542,25 @@ namespace Test.ADAL.NET.Unit
 
             context.ExtendedLifeTimeEnabled = true;
             // cache look up
-            try
-            {
-                var result =
-                    await
-                        context.AcquireTokenAsync(TestConstants.DefaultResource, credential);
-            }
-            catch (AdalServiceException ex)
-            {
-                Assert.AreEqual(ex.InnerException.Message, " Response status code does not indicate success: 408 (RequestTimeout).");
-            }
+            var ex = AssertException.TaskThrows<AdalServiceException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, credential));
+            Assert.AreEqual(ex.InnerException.Message, " Response status code does not indicate success: 408 (RequestTimeout).");
 
-            try
-            {
-                await context.AcquireTokenAsync(null, credential);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "resource");
-            }
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCredential");
-            }
+            // Null resource -> error
+            ArgumentNullException exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(null, credential));
+            Assert.AreEqual(exc.ParamName, "resource");
+
+            // Null client credential -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null));
+            Assert.AreEqual(exc.ParamName, "clientCredential");
         }
 
         [TestMethod]
         [Description("Test for being in outage mode and extendedExpires flag not set")]
-        public async Task ClientCredentialExtendedExpiryNoFlagSetTest()
+        public void ClientCredentialExtendedExpiryNoFlagSetTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
@@ -662,34 +607,19 @@ namespace Test.ADAL.NET.Unit
 
             context.ExtendedLifeTimeEnabled = false;
             // cache look up
-            try
-            {
-                var result =
-                    await
-                        context.AcquireTokenAsync(TestConstants.DefaultResource, credential);
-            }
-            catch (AdalServiceException ex)
-            {
-                Assert.AreEqual(ex.InnerException.Message, " Response status code does not indicate success: 504 (GatewayTimeout).");
-            }
+            var ex = AssertException.TaskThrows<AdalServiceException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, credential));
+            Assert.AreEqual(ex.InnerException.Message, " Response status code does not indicate success: 504 (GatewayTimeout).");
 
-            try
-            {
-                await context.AcquireTokenAsync(null, credential);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "resource");
-            }
+            // Null resource -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(null, credential));
+            Assert.AreEqual(exc.ParamName, "resource");
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCredential");
-            }
+            // Null client credential -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null));
+            Assert.AreEqual(exc.ParamName, "clientCredential");
         }
 
         [TestMethod]
@@ -711,17 +641,12 @@ namespace Test.ADAL.NET.Unit
                         TestConstants.DefaultRedirectUri, platformParameters);
             Assert.IsNotNull(result);
             Assert.AreEqual(result.AccessToken, "some-access-token");
-            try
-            {
-                result =
-                    await
-                        context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
-                            TestConstants.DefaultRedirectUri, platformParameters, null);
-            }
-            catch (ArgumentException exc)
-            {
-                Assert.IsTrue(exc.Message.StartsWith(AdalErrorMessage.SpecifyAnyUser));
-            }
+
+            var exc = AssertException.TaskThrows<ArgumentException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
+                    TestConstants.DefaultRedirectUri, platformParameters, null));
+            Assert.IsTrue(exc.Message.StartsWith(AdalErrorMessage.SpecifyAnyUser));
+
 
             // this should hit the cache
             result =
@@ -738,17 +663,10 @@ namespace Test.ADAL.NET.Unit
         {
             AuthenticationContext context = null;
             AuthenticationResult result = null;
-            try
-            {
-                context = new AuthenticationContext("https://login.contoso.com/adfs");
-                await
-                    context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
-                        TestConstants.DefaultRedirectUri, platformParameters);
-            }
-            catch (ArgumentException ex)
-            {
-                Assert.AreEqual(ex.ParamName, "validateAuthority");
-            }
+
+            var ex = AssertException.Throws<ArgumentException>(() => new AuthenticationContext("https://login.contoso.com/adfs"));
+            Assert.AreEqual(ex.ParamName, "validateAuthority");
+
 
             MockHelpers.ConfigureMockWebUI(new AuthorizationResult(AuthorizationStatus.Success,
                 TestConstants.DefaultRedirectUri + "?code=some-code"));
@@ -777,23 +695,17 @@ namespace Test.ADAL.NET.Unit
                         "{\"error\":\"invalid_instance\",\"error_description\":\"AADSTS70002: Error in validating authority.\"}")
             });
 
-            try
-            {
-                context = new AuthenticationContext("https://login.microsoft0nline.com/common");
-                result =
-                    await
-                        context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
-                            TestConstants.DefaultRedirectUri, platformParameters);
-            }
-            catch (AdalException ex)
-            {
-                Assert.AreEqual(ex.ErrorCode, AdalError.AuthorityNotInValidList);
-            }
+            context = new AuthenticationContext("https://login.microsoft0nline.com/common");
+            var adalEx = AssertException.TaskThrows<AdalException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
+                    TestConstants.DefaultRedirectUri, platformParameters));
+
+            Assert.AreEqual(adalEx.ErrorCode, AdalError.AuthorityNotInValidList);
         }
 
         [TestMethod]
         [Description("Negative Test for AcquireToken with invalid resource")]
-        public async Task AcquireTokenWithInvalidResourceTestAsync()
+        public void AcquireTokenWithInvalidResourceTestAsync()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
@@ -812,33 +724,24 @@ namespace Test.ADAL.NET.Unit
                 ResponseMessage = MockHelpers.CreateInvalidRequestTokenResponseMessage()
             });
 
-            try
-            {
-                await context.AcquireTokenSilentAsync("random-resource", TestConstants.DefaultClientId);
-            }
-            catch (AdalServiceException exc)
-            {
-                Assert.AreEqual(AdalError.FailedToRefreshToken, exc.ErrorCode);
-            }
+            var exc = AssertException.TaskThrows<AdalServiceException>(() =>
+                context.AcquireTokenSilentAsync("random-resource", TestConstants.DefaultClientId));
+            Assert.AreEqual(AdalError.FailedToRefreshToken, exc.ErrorCode);
         }
 
         [TestMethod]
         [Description("Negative Test for AcquireToken with user canceling authentication")]
-        public async Task AcquireTokenWithAuthenticationCanceledTest()
+        public void AcquireTokenWithAuthenticationCanceledTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             MockHelpers.ConfigureMockWebUI(new AuthorizationResult(AuthorizationStatus.UserCancel,
                 TestConstants.DefaultRedirectUri + "?error=user_cancelled"));
-            try
-            {
-                await
-                    context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
-                        TestConstants.DefaultRedirectUri, platformParameters);
-            }
-            catch (AdalServiceException ex)
-            {
-                Assert.AreEqual(ex.ErrorCode, AdalError.AuthenticationCanceled);
-            }
+
+            var exc = AssertException.TaskThrows<AdalServiceException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
+                        TestConstants.DefaultRedirectUri, platformParameters));
+
+            Assert.AreEqual(exc.ErrorCode, AdalError.AuthenticationCanceled);
         }
 
         [TestMethod]
@@ -866,7 +769,7 @@ namespace Test.ADAL.NET.Unit
 
         [TestMethod]
         [Description("Test for simple refresh token")]
-        public async Task SimpleRefreshTokenTest()
+        public void SimpleRefreshTokenTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAdfsAuthorityTenant, false, new TokenCache());
             //add simple RT to cache
@@ -879,14 +782,9 @@ namespace Test.ADAL.NET.Unit
             };
 
             //token request for some other resource should fail.
-            try
-            {
-                await context.AcquireTokenSilentAsync("random-resource", TestConstants.DefaultClientId);
-            }
-            catch (AdalSilentTokenAcquisitionException exc)
-            {
-                Assert.AreEqual(AdalError.FailedToAcquireTokenSilently, exc.ErrorCode);
-            }
+            var exc = AssertException.TaskThrows<AdalSilentTokenAcquisitionException>(() =>
+                context.AcquireTokenSilentAsync("random-resource", TestConstants.DefaultClientId));
+            Assert.AreEqual(AdalError.FailedToAcquireTokenSilently, exc.ErrorCode);
         }
 
         [TestMethod]
@@ -1010,7 +908,7 @@ namespace Test.ADAL.NET.Unit
             });
 
             TokenCache cache = new TokenCache();
-            
+
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, cache);
             var result =
                 await
@@ -1060,51 +958,35 @@ namespace Test.ADAL.NET.Unit
                         certificate, TestConstants.DefaultResource);
             Assert.IsNotNull(result.AccessToken);
 
-            try
-            {
-                await
-                    context.AcquireTokenByAuthorizationCodeAsync(null, TestConstants.DefaultRedirectUri, certificate,
-                        TestConstants.DefaultResource);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "authorizationCode");
-            }
 
-            try
-            {
-                await
-                    context.AcquireTokenByAuthorizationCodeAsync(string.Empty, TestConstants.DefaultRedirectUri,
-                        certificate,
-                        TestConstants.DefaultResource);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "authorizationCode");
-            }
+            // Null auth code -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenByAuthorizationCodeAsync(null, TestConstants.DefaultRedirectUri, certificate,
+                        TestConstants.DefaultResource));
 
-            try
-            {
-                // Send null for redirect
-                await
-                    context.AcquireTokenByAuthorizationCodeAsync("some-code", null, certificate,
-                        TestConstants.DefaultResource);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "redirectUri");
-            }
+            Assert.AreEqual(exc.ParamName, "authorizationCode");
 
-            try
-            {
-                await
-                    context.AcquireTokenByAuthorizationCodeAsync("some-code", TestConstants.DefaultRedirectUri,
-                        (ClientAssertionCertificate) null, TestConstants.DefaultResource);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCertificate");
-            }
+            // Empty auth code -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenByAuthorizationCodeAsync(string.Empty, TestConstants.DefaultRedirectUri,
+                certificate,
+                TestConstants.DefaultResource));
+
+            Assert.AreEqual(exc.ParamName, "authorizationCode");
+
+
+            // Null for redirect -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenByAuthorizationCodeAsync("some-code", null, certificate,
+                        TestConstants.DefaultResource));
+            Assert.AreEqual(exc.ParamName, "redirectUri");
+
+            // Null client certificate -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenByAuthorizationCodeAsync("some-code", TestConstants.DefaultRedirectUri,
+                        (ClientAssertionCertificate)null, TestConstants.DefaultResource));
+            Assert.AreEqual(exc.ParamName, "clientCertificate");
+
         }
 
         [TestMethod]
@@ -1135,14 +1017,10 @@ namespace Test.ADAL.NET.Unit
 
             context = new AuthenticationContext(TestConstants.DefaultAuthorityGuestTenant, cache);
 
-            try
-            {
-                var result2 = await context.AcquireTokenAsync(TestConstants.DefaultResource, credential);
-            }
-            catch (AdalException)
-            {
-                Assert.AreEqual(1, cache.tokenCacheDictionary.Count);
-            }
+
+            AssertException.TaskThrows<AdalException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, credential));
+            Assert.AreEqual(1, cache.tokenCacheDictionary.Count);
         }
 
         [TestMethod]
@@ -1174,23 +1052,15 @@ namespace Test.ADAL.NET.Unit
             var result2 = await context.AcquireTokenAsync(TestConstants.DefaultResource, credential);
             Assert.AreEqual(result.AccessToken, result2.AccessToken);
 
-            try
-            {
-                await context.AcquireTokenAsync(null, credential);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "resource");
-            }
+            // Null resource -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(null, credential));
+            Assert.AreEqual(exc.ParamName, "resource");
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCredential");
-            }
+            // Null client credential -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null));
+            Assert.AreEqual(exc.ParamName, "clientCredential");
         }
 
         [TestMethod]
@@ -1217,33 +1087,26 @@ namespace Test.ADAL.NET.Unit
             AuthenticationResult result = await context.AcquireTokenAsync(TestConstants.DefaultResource, certificate);
             Assert.IsNotNull(result.AccessToken);
 
-            try
-            {
-                await context.AcquireTokenAsync(null, certificate);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "resource");
-            }
 
+            // Null resource -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(null, certificate));
+            Assert.AreEqual(exc.ParamName, "resource");
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientAssertionCertificate)null);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCertificate");
-            }
+            // Null client credential -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null));
+
+            Assert.AreEqual(exc.ParamName, "clientCredential");
         }
 
-        
+
         [TestMethod]
         [Description("Test for Confidential Client with self signed jwt")]
         public async Task ConfidentialClientWithJwtTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
-            
+
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
             {
                 Method = HttpMethod.Post,
@@ -1270,42 +1133,29 @@ namespace Test.ADAL.NET.Unit
 
             result = await context.AcquireTokenByAuthorizationCodeAsync("some-code", TestConstants.DefaultRedirectUri, assertion, null);
             Assert.IsNotNull(result.AccessToken);
-            
-            try
-            {
-                await context.AcquireTokenByAuthorizationCodeAsync(string.Empty, TestConstants.DefaultRedirectUri, assertion, TestConstants.DefaultResource);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "authorizationCode");
-            }
 
-            try
-            {
-                await context.AcquireTokenByAuthorizationCodeAsync(null, TestConstants.DefaultRedirectUri, assertion, TestConstants.DefaultResource);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "authorizationCode");
-            }
+            // Empty authorization code -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenByAuthorizationCodeAsync(string.Empty, TestConstants.DefaultRedirectUri, assertion, TestConstants.DefaultResource));
+            Assert.AreEqual(exc.ParamName, "authorizationCode");
 
-            try
-            {
-                await context.AcquireTokenByAuthorizationCodeAsync("some-code", null, assertion, TestConstants.DefaultResource);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "redirectUri");
-            }
 
-            try
-            {
-                await context.AcquireTokenByAuthorizationCodeAsync("some-code", TestConstants.DefaultRedirectUri, (ClientAssertion)null, TestConstants.DefaultResource);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientAssertion");
-            }
+            // Null authorization code -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenByAuthorizationCodeAsync(null, TestConstants.DefaultRedirectUri, assertion, TestConstants.DefaultResource));
+            Assert.AreEqual(exc.ParamName, "authorizationCode");
+
+
+            // Null redirectUri -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenByAuthorizationCodeAsync("some-code", null, assertion, TestConstants.DefaultResource));
+            Assert.AreEqual(exc.ParamName, "redirectUri");
+
+
+            // Null client assertion -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenByAuthorizationCodeAsync("some-code", TestConstants.DefaultRedirectUri, (ClientAssertion)null, TestConstants.DefaultResource));
+            Assert.AreEqual(exc.ParamName, "clientAssertion");
         }
 
         [TestMethod]
@@ -1325,33 +1175,26 @@ namespace Test.ADAL.NET.Unit
             };
 
             ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId, TestConstants.DefaultClientSecret);
-            try
-            {
-                await context.AcquireTokenAsync(null, clientCredential, new UserAssertion(accessToken));
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "resource");
-            }
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential, null);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "userAssertion");
-            }
+            // Null resource -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(null, clientCredential, new UserAssertion(accessToken)));
+            Assert.AreEqual(exc.ParamName, "resource");
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null, new UserAssertion(accessToken));
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCredential");
-            }
 
+            // Null user assertion -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential, null));
+            Assert.AreEqual(exc.ParamName, "userAssertion");
+
+
+            // Null client credential -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientCredential)null, new UserAssertion(accessToken)));
+            Assert.AreEqual(exc.ParamName, "clientCredential");
+
+
+            // Valid input -> no error
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
             {
                 Method = HttpMethod.Post,
@@ -1387,33 +1230,26 @@ namespace Test.ADAL.NET.Unit
             };
 
             ClientAssertionCertificate clientCredential = new ClientAssertionCertificate(TestConstants.DefaultClientId, new X509Certificate2("valid_cert.pfx", TestConstants.DefaultPassword));
-            try
-            {
-                await context.AcquireTokenAsync(null, clientCredential, new UserAssertion(accessToken));
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "resource");
-            }
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential, null);
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "userAssertion");
-            }
+            // Null resource -> error
+            var exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(null, clientCredential, new UserAssertion(accessToken)));
+            Assert.AreEqual(exc.ParamName, "resource");
 
-            try
-            {
-                await context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientAssertionCertificate)null, new UserAssertion(accessToken));
-            }
-            catch (ArgumentNullException exc)
-            {
-                Assert.AreEqual(exc.ParamName, "clientCertificate");
-            }
 
+            // Null user assertion -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, clientCredential, null));
+            Assert.AreEqual(exc.ParamName, "userAssertion");
+
+
+            // Null client cert -> error
+            exc = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.AcquireTokenAsync(TestConstants.DefaultResource, (ClientAssertionCertificate)null, new UserAssertion(accessToken)));
+            Assert.AreEqual(exc.ParamName, "clientCertificate");
+
+
+            // Valid input -> no error
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
             {
                 Method = HttpMethod.Post,
@@ -1439,15 +1275,10 @@ namespace Test.ADAL.NET.Unit
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant);
             Uri uri = null;
 
-            try
-            {
-                uri = await context.GetAuthorizationRequestUrlAsync(null, TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, new UserIdentifier(TestConstants.DefaultDisplayableId, UserIdentifierType.RequiredDisplayableId), "extra=123");
-            }
-            catch (ArgumentNullException ex)
-            {
-                Assert.AreEqual(ex.ParamName, "resource");
-            }
-            
+            var ex = AssertException.TaskThrows<ArgumentNullException>(() =>
+                context.GetAuthorizationRequestUrlAsync(null, TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, new UserIdentifier(TestConstants.DefaultDisplayableId, UserIdentifierType.RequiredDisplayableId), "extra=123"));
+            Assert.AreEqual(ex.ParamName, "resource");
+
             uri = await context.GetAuthorizationRequestUrlAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId, TestConstants.DefaultRedirectUri, new UserIdentifier(TestConstants.DefaultDisplayableId, UserIdentifierType.RequiredDisplayableId), "extra=123");
             Assert.IsNotNull(uri);
             Assert.IsTrue(uri.AbsoluteUri.Contains("login_hint"));
@@ -1461,10 +1292,11 @@ namespace Test.ADAL.NET.Unit
             Assert.IsNotNull(uri);
             Assert.IsTrue(uri.AbsoluteUri.Contains("client-request-id="));
         }
+        
 
         [TestMethod]
         [Description("Positive Test for AcquireTokenOnBehalf with client credential")]
-        public async Task UserAssertionValidationTest()
+        public void UserAssertionValidationTest()
         {
             TokenCache cache = new TokenCache();
             AuthenticationResultEx resultEx = TokenCacheTests.CreateCacheValue("id", "user1");
@@ -1482,21 +1314,15 @@ namespace Test.ADAL.NET.Unit
                 ExtendedLifeTimeEnabled = false
             };
 
-            AcquireTokenOnBehalfHandler handler = new AcquireTokenOnBehalfHandler(data, new UserAssertion("non-existant"));
-            try
-            {
-                await handler.RunAsync();
-                Assert.Fail("acquire token call should have failed due to hash mistmatch");
-            }
-            catch (Exception exc)
-            {
-                Assert.IsNotNull(exc);
-            }
+
+            AssertException.TaskThrows<HttpRequestException>(() =>
+                    new AcquireTokenOnBehalfHandler(data, new UserAssertion("non-existant")).RunAsync()
+                );
         }
 
         [TestMethod]
         [Description("Test for returning entire HttpResponse as inner exception")]
-        public async Task HttpErrorResponseAsInnerException()
+        public void HttpErrorResponseAsInnerException()
         {
             TokenCache cache = new TokenCache();
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User, "unique_id", "displayable@id.com");
@@ -1509,19 +1335,15 @@ namespace Test.ADAL.NET.Unit
 
             AuthenticationContext context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, cache);
 
-            try
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
             {
-                HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
-                {
-                    Method = HttpMethod.Post,
-                    ResponseMessage = MockHelpers.CreateHttpErrorResponse()
-                });
-                await context.AcquireTokenSilentAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId, new UserIdentifier("unique_id", UserIdentifierType.UniqueId));
-            }
-            catch (AdalSilentTokenAcquisitionException ex)
-            {
-                Assert.IsTrue((ex.InnerException.InnerException.InnerException).Message.Contains(TestConstants.ErrorSubCode));
-            }
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateHttpErrorResponse()
+            });
+
+            var ex = AssertException.TaskThrows<AdalSilentTokenAcquisitionException>(() =>
+                context.AcquireTokenSilentAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId, new UserIdentifier("unique_id", UserIdentifierType.UniqueId)));
+            Assert.IsTrue((ex.InnerException.InnerException.InnerException).Message.Contains(TestConstants.ErrorSubCode));
         }
     }
 }

--- a/tests/Test.ADAL.NET.Unit/AuthenticationParametersTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AuthenticationParametersTests.cs
@@ -59,24 +59,17 @@ namespace Test.ADAL.NET.Unit
             Assert.AreEqual(Resource, authParams.Resource);
             Assert.IsNull(authParams.Authority);
 
-            try
-            {
-                AuthenticationParameters.CreateFromResponseAuthenticateHeader(null);
-            }
-            catch(ArgumentNullException ex)
-            {
-                Assert.AreEqual(ex.ParamName, "authenticateHeader");
-            }
+            // Null parameter -> error
+            var ex = AssertException.Throws<ArgumentNullException>(() =>
+                AuthenticationParameters.CreateFromResponseAuthenticateHeader(null));
+            Assert.AreEqual(ex.ParamName, "authenticateHeader");
 
-            try
-            {
-                AuthenticationParameters.CreateFromResponseAuthenticateHeader(string.Format(CultureInfo.InvariantCulture, @"authorization_uri=""{0}"",Resource_id=""{1}""", authority, Resource));
-            }
-            catch (ArgumentException ex)
-            {
-                Assert.AreEqual(ex.ParamName, "authenticateHeader");
-                Assert.IsTrue(ex.Message.Contains("format"));
-            }
+
+            // Invalid format -> error
+            var argEx = AssertException.Throws<ArgumentException>(() =>
+                AuthenticationParameters.CreateFromResponseAuthenticateHeader(string.Format(CultureInfo.InvariantCulture, @"authorization_uri=""{0}"",Resource_id=""{1}""", authority, Resource)));
+            Assert.AreEqual(argEx.ParamName, "authenticateHeader");
+            Assert.IsTrue(argEx.Message.Contains("format"));
         }
     }
 }

--- a/tests/Test.ADAL.NET.Unit/Common/AssertException.cs
+++ b/tests/Test.ADAL.NET.Unit/Common/AssertException.cs
@@ -1,0 +1,223 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Test.ADAL.Common
+{
+    public static class AssertException
+    {
+        [DebuggerStepThrough]
+        public static void DoesNotThrow(Action testCode)
+        {
+            var ex = Recorder.Exception<Exception>(testCode);
+            if (ex != null)
+            {
+                throw new AssertFailedException("DoesNotThrow failed.", ex);
+            }
+        }
+
+        [DebuggerStepThrough]
+        public static void DoesNotThrow(Func<object> testCode)
+        {
+            var ex = Recorder.Exception<Exception>(testCode);
+            if (ex != null)
+            {
+                throw new AssertFailedException("DoesNotThrow failed.", ex);
+            }
+        }
+
+        [DebuggerStepThrough]
+        public static TException Throws<TException>(Action testCode)
+             where TException : Exception
+        {
+            return Throws<TException>(testCode, false);
+        }
+
+        [DebuggerStepThrough]
+        public static TException Throws<TException>(Action testCode, bool allowDerived)
+             where TException : Exception
+        {
+            var exception = Recorder.Exception<TException>(testCode);
+
+            if (exception == null)
+            {
+                throw new AssertFailedException("AssertExtensions.Throws failed. No exception occurred.");
+            }
+
+            CheckExceptionType<TException>(exception, allowDerived);
+
+            return exception;
+        }
+
+        [DebuggerStepThrough]
+        public static TException Throws<TException>(Func<object> testCode)
+            where TException : Exception
+        {
+            return Throws<TException>(testCode, false);
+        }
+
+        [DebuggerStepThrough]
+        public static TException Throws<TException>(Func<object> testCode, bool allowDerived)
+            where TException : Exception
+        {
+            var exception = Recorder.Exception<TException>(testCode);
+
+            if (exception == null)
+            {
+                throw new AssertFailedException("AssertExtensions.Throws failed. No exception occurred.");
+            }
+
+            CheckExceptionType<TException>(exception, allowDerived);
+
+            return exception;
+        }
+
+        [DebuggerStepThrough]
+        public static T TaskThrows<T>(Func<Task> testCode)
+            where T : Exception
+        {
+            var exception = Recorder.Exception<AggregateException>(() => testCode().Wait());
+
+            if (exception == null)
+            {
+                throw new AssertFailedException("AssertExtensions.Throws failed. No exception occurred.");
+            }
+
+            var exceptionsMatching = exception.InnerExceptions.OfType<T>().ToList();
+
+            if (!exceptionsMatching.Any())
+            {
+                throw new AssertFailedException(string.Format(CultureInfo.CurrentCulture, "AssertExtensions.Throws failed. Incorrect exception {0} occurred.", exception.GetType().Name), exception);
+            }
+
+            return exceptionsMatching.First();
+        }
+
+        [DebuggerStepThrough]
+        public static void TaskDoesNotThrow(Func<Task> testCode)
+        {
+            var exception = Recorder.Exception<AggregateException>(() => testCode().Wait());
+
+            if (exception == null)
+            {
+                return;
+            }
+
+            throw new AssertFailedException(string.Format(CultureInfo.CurrentCulture, "AssertExtensions.TaskDoesNotThrow failed. Incorrect exception {0} occurred.", exception.GetType().Name), exception);
+        }
+
+        [DebuggerStepThrough]
+        public static void TaskDoesNotThrow<T>(Func<Task> testCode) where T : Exception
+        {
+            var exception = Recorder.Exception<AggregateException>(() => testCode().Wait());
+
+            if (exception == null)
+            {
+                return;
+            }
+
+            var exceptionsMatching = exception.InnerExceptions.OfType<T>().ToList();
+
+            if (!exceptionsMatching.Any())
+            {
+                return;
+            }
+
+            throw new AssertFailedException(string.Format(CultureInfo.CurrentCulture, "AssertExtensions.Throws failed. Incorrect exception {0} occurred.", exception.GetType().Name), exception);
+        }
+
+        [DebuggerStepThrough]
+        private static void CheckExceptionType<TException>(Exception actualException, bool allowDerived)
+        {
+            Type expectedType = typeof(TException);
+
+            string message = string.Format(System.Globalization.CultureInfo.CurrentCulture,
+                "Checking exception:{0}\tType:{1}{0}\tToString: {2}{0}",
+                Environment.NewLine,
+                actualException.GetType().FullName,
+                actualException.ToString());
+            Debug.WriteLine(message);
+
+            if (allowDerived)
+            {
+                if (!(actualException is TException))
+                {
+                    throw new AssertFailedException(string.Format(CultureInfo.CurrentCulture, "AssertExtensions.Throws failed. Incorrect exception {0} occurred.", expectedType.Name),
+                        actualException);
+                }
+            }
+            else
+            {
+                if (!expectedType.Equals(actualException.GetType()))
+                {
+                    throw new AssertFailedException(string.Format(CultureInfo.CurrentCulture, "AssertExtensions.Throws failed. Incorrect exception {0} occurred.", expectedType.Name),
+                        actualException);
+                }
+            }
+        }
+
+        private static class Recorder
+        {
+            [DebuggerStepThrough]
+            public static TException Exception<TException>(Action code)
+                where TException : Exception
+            {
+                try
+                {
+                    code();
+                    return null;
+                }
+                catch (TException ex)
+                {
+                    return ex;
+                }
+            }
+
+            [DebuggerStepThrough]
+            public static TException Exception<TException>(Func<object> code)
+                where TException : Exception
+            {
+                try
+                {
+                    code();
+                    return null;
+                }
+                catch (TException ex)
+                {
+                    return ex;
+                }
+            }
+        }
+    }
+}
+

--- a/tests/Test.ADAL.NET.Unit/DeviceCodeFlowTests.cs
+++ b/tests/Test.ADAL.NET.Unit/DeviceCodeFlowTests.cs
@@ -37,6 +37,12 @@ namespace Test.ADAL.NET.Unit
     [TestClass]
     public class DeviceCodeFlowTests
     {
+        [TestInitialize]
+        public void Initialize()
+        {
+            HttpMessageHandlerFactory.ClearMockHandlers();
+        }
+
         [TestMethod]
         public async Task PositiveTest()
         {

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -91,6 +91,7 @@
     <Compile Include="AcquireTokenSilentTests.cs" />
     <Compile Include="AdalDotNetTests.cs" />
     <Compile Include="AuthenticationParametersTests.cs" />
+    <Compile Include="Common\AssertException.cs" />
     <Compile Include="LoggerCallbackTests.cs" />
     <Compile Include="Mocks\MockHelpers.cs" />
     <Compile Include="Mocks\MockHttpMessageHandler.cs" />


### PR DESCRIPTION
Added a helper method to check that the expected exceptions are being thrown and modified all of the tests to use the new helper (for consistency, I've changed all of the tests, including those that were correctly implemented before)
Using the helper method is simpler and less error-prone; previously
some of the tests were not correctly checking for error and could have
been passing even if the expected exception was not thrown.
There are two cases in AuthenticationParametersTests where this is
happening (issue #611)