### PR TITLE
Added support for using the default IWebProxy inside ADAL.

### DIFF
--- a/src/ADAL.PCL/Http/HttpMessageHandlerFactory.cs
+++ b/src/ADAL.PCL/Http/HttpMessageHandlerFactory.cs
@@ -42,7 +42,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 return MockHandlerQueue.Dequeue();
             }
 
-            return new HttpClientHandler { UseDefaultCredentials = useDefaultCredentials };
+            return new HttpClientHandler { UseDefaultCredentials = useDefaultCredentials, Proxy = System.Net.WebRequest.DefaultWebProxy };
         }
 
         private readonly static Queue<HttpMessageHandler> MockHandlerQueue = new Queue<HttpMessageHandler>();


### PR DESCRIPTION
This is a useful change for enterprises who want to connect from their app to Azure AD from an internal network via proxy.  This is especially useful for Xamarin.Android applications since proxy settings on android usually only apply to the web browser/web-views but not HTTP calls from within 3rd party applications.  For some developers, specifying a proxy programmatically is the only answer for many scenarios and with this change, the ADAL http requests will respect the DefaultWebProxy that is set for that app.