### PR TITLE
Add new US Gov STS

### DIFF
--- a/src/ADAL.PCL/Authority/AuthenticatorTemplateList.cs
+++ b/src/ADAL.PCL/Authority/AuthenticatorTemplateList.cs
@@ -41,7 +41,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     "login.windows.net",            // Microsoft Azure Worldwide - Used in validation scenarios where host is not this list 
                     "login.chinacloudapi.cn",       // Microsoft Azure China
                     "login.microsoftonline.de",     // Microsoft Azure Blackforest
-                    "login-us.microsoftonline.com", // Microsoft Azure US Government
+                    "login-us.microsoftonline.com", // Microsoft Azure US Government - Legacy
+                    "login.microsoftonline.us",     // Microsoft Azure US Government
                     "login.microsoftonline.com"     // Microsoft Azure Worldwide
                 };
 


### PR DESCRIPTION
Adding the new STS for Azure Gov (login.microsoftonline.us). Leaving the previous URL in place for compatibility. We can remove as we wind down support in 12 to 18 months.