### PR TITLE
Check PlatformParameters in BrokerHelper.CanInvokeBroker for null

### DIFF
--- a/src/ADAL.PCL.iOS/BrokerHelper.cs
+++ b/src/ADAL.PCL.iOS/BrokerHelper.cs
@@ -49,6 +49,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             get
             {
                 PlatformParameters pp = PlatformParameters as PlatformParameters;
+				if (pp == null)
+				{
+					return false;
+				}
                 return pp.UseBroker && UIApplication.SharedApplication.CanOpenUrl(new NSUrl("msauth://"));
             }
         }


### PR DESCRIPTION
We had some exceptions while trying to silently login with an expired refresh token because `BrokerHelper.CanInvokeBroker` does not null-check `pp`.