### PR TITLE
Added run settings file to exclude test projects from code coverage

### DIFF
--- a/build/ADAL.CodeCoverage.runsettings
+++ b/build/ADAL.CodeCoverage.runsettings
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>  
+
+<!-- Customised run settings file to exclude test assemblies from coverage.
+    See https://msdn.microsoft.com/en-us/library/jj159530.aspx for more info. -->
+
+<!-- File name extension must be .runsettings -->  
+<RunSettings>  
+  <DataCollectionRunSettings>  
+    <DataCollectors>  
+      <DataCollector friendlyName="Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="Microsoft.VisualStudio.Coverage.DynamicCoverageDataCollector, Microsoft.VisualStudio.TraceCollector, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">  
+        <Configuration>  
+          <CodeCoverage>  
+  
+<!--  
+About include/exclude lists:  
+Empty "Include" clauses imply all; empty "Exclude" clauses imply none.  
+Each element in the list is a regular expression (ECMAScript syntax). See http://msdn.microsoft.com/library/2k3te2cs.aspx.  
+An item must first match at least one entry in the include list to be included.  
+Included items must then not match any entries in the exclude list to remain included.  
+-->  
+  
+            <!-- Match assembly file paths: -->  
+            <ModulePaths>  
+              <Include>  
+                <ModulePath>.*\microsoft.identitymodel.clients.activedirectory.dll$</ModulePath>  
+                <ModulePath>.*\microsoft.identitymodel.clients.activedirectory.platform.dll$</ModulePath>  
+              </Include>  
+              <Exclude>  
+              </Exclude>  
+            </ModulePaths>  
+    
+          </CodeCoverage>  
+        </Configuration>  
+      </DataCollector>  
+    </DataCollectors>  
+  </DataCollectionRunSettings>  
+</RunSettings>  
+  


### PR DESCRIPTION
Added a test runsettings file that excludes test assemblies and test apps from the code coverage results.

By default, code coverage is calculated on all the projects in the solution. This gives a misleading coverage number: including the sample apps pushes the coverage number down since none of the code is executed, and including the test projects tends to push the coverage number up (tests don't tend to include much branching code so most of the code is executed most of the time).