### PR TITLE
Workaround for new Roslyn bug that prevented compilation in VS2017

### DIFF
--- a/src/ADAL.PCL.WinRT/DeviceAuthHelper.cs
+++ b/src/ADAL.PCL.WinRT/DeviceAuthHelper.cs
@@ -121,7 +121,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
             byte[] arr = new byte[hex.Length >> 1];
 
-            for (int i = 0; i < hex.Length >> 1; ++i)
+            for (int i = 0; i < (hex.Length >> 1); ++i)
             {
                 arr[i] = (byte)((GetHexVal(hex[i << 1]) << 4) + (GetHexVal(hex[(i << 1) + 1])));
             }


### PR DESCRIPTION
See https://github.com/dotnet/roslyn/pull/16834 - the Roslyn compiler wasn't correctly parsing >>