### PR TITLE
Use JSON.NET in automation test app (device code)

### DIFF
--- a/automation/WinFormsAutomationApp/AuthenticationHelper.cs
+++ b/automation/WinFormsAutomationApp/AuthenticationHelper.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Runtime.Serialization.Json;
 using System.Threading.Tasks;
 using System.Web.Script.Serialization;
+using Newtonsoft.Json;
 
 namespace WinFormsAutomationApp
 {
@@ -174,13 +175,13 @@ namespace WinFormsAutomationApp
                 deviceCodeResult.DeviceCode = input["device_code"];
                 deviceCodeResult.ClientId = input["client_id"];
                 deviceCodeResult.Resource = input["resource"];
-                deviceCodeResult.ExpiresOn = Convert.ToDateTime(input["expires_on"]);
+                deviceCodeResult.ExpiresOn = DateTime.Parse(input["expires_on"]);
 
                 //Try to get access token form given device code.
                 AuthenticationResult result = await ctx.AcquireTokenByDeviceCodeAsync(deviceCodeResult);
                 res.Add("unique_id", result.UserInfo.UniqueId);
                 res.Add("access_token", result.AccessToken);
-                res.Add("tenant_id", result.TenantId);               
+                res.Add("tenant_id", result.TenantId);
             }
             catch (Exception exc)
             {
@@ -202,7 +203,7 @@ namespace WinFormsAutomationApp
                 res.Add("user_code", result.UserCode);
                 res.Add("client_id", result.ClientId);
                 res.Add("resource", result.Resource);
-                res.Add("expires_on", result.ExpiresOn.DateTime);
+                res.Add("expires_on", result.ExpiresOn.UtcDateTime);
             }
             catch (Exception exc)
             {
@@ -294,8 +295,7 @@ namespace WinFormsAutomationApp
 
         private static string FromDictionaryToJson(this Dictionary<string, object> dictionary)
         {
-            var jss = new JavaScriptSerializer();
-            return jss.Serialize(dictionary);
+            return JsonConvert.SerializeObject(dictionary);
         }
 
         private static Dictionary<string, object> ProcessResult(AuthenticationResult result, Dictionary<string, string> input)

--- a/automation/WinFormsAutomationApp/WinFormsAutomationApp.csproj
+++ b/automation/WinFormsAutomationApp/WinFormsAutomationApp.csproj
@@ -44,6 +44,10 @@
     <DelaySign>true</DelaySign>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Runtime.Serialization" />
@@ -88,6 +92,7 @@
       <DependentUpon>Resources.resx</DependentUpon>
     </Compile>
     <None Include="35MSSharedLib1024.snk" />
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/automation/WinFormsAutomationApp/packages.config
+++ b/automation/WinFormsAutomationApp/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Replace `JavaScriptSerializer` with JSON.NET, at least for the device code flows, in the WinForms automation test app. The way JSS serialises dates is not compliant with ISO 8601.
Change the test app to return UTC dates formatted in ISO 8601 format.

OSS Usage Request ID is 32438.