### PR TITLE
Bump version number to 3.14

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,26 @@
+Version 3.14.0
+==============
+This release includes
+- Add support for ClientAssertionCertificate in CoreCLR
+- Port ADAL.PCL project to .NET Standard 1.1 project (requires VS2017 to build)
+- Port ADAL.CoreCLR project to .NET Standard 1.3 project (requires VS2017 to build)
+
+Version 3.13.9
+==============
+This release includes
+- Add blackforest as a trusted authority
+- Addition of new US Gov STS as a trusted authority
+- Limit Http Response size to 1MB
+- Fix an issue where request to WS-Trust was not working when using ADAL in sovereign clouds
+- Fix to ignore all navigation events once redirect_uri is reached in the webview
+- Add support for configuring transitioning styles in iOS
+- Add support to disable logging to platform defaults.
+- Update resiliency error codes to be HTTP 500-599 (all inclusive)
+- Add support to consume developer configured Proxy in HttpMessageHandler.
+
 Version 3.13.8
 ==============
-This release inclues
+This release includes
 - update to nuget package to fix casing of NETStandard.Library nuget dependency
 - Add serialization packages to netstandard1.4 target as they are not part of netstandard.
 

--- a/src/ADAL.Common/CommonAssemblyInfo.cs
+++ b/src/ADAL.Common/CommonAssemblyInfo.cs
@@ -37,7 +37,7 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyFileVersion("3.13.9.0")]
+[assembly: AssemblyFileVersion("3.14.0.0")]
 
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.


### PR DESCRIPTION
Bump the assembly version number to 3.14.0 and update _changelog.txt_ with appropriate details.

I also noticed that the changelog had not been updated for the 3.13.9 release so I copied the notes from that GitHub release.