### PR TITLE
Adding missing culture info to string format operations

### DIFF
--- a/src/ADAL.PCL.Android/DeviceAuthHelper.cs
+++ b/src/ADAL.PCL.Android/DeviceAuthHelper.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
@@ -39,7 +40,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public Task<string> CreateDeviceAuthChallengeResponse(IDictionary<string, string> challengeData)
         {
-            return Task.FromResult(string.Format(@"PKeyAuth Context=""{0}"",Version=""{1}""", challengeData[BrokerConstants.ChallangeResponseContext], challengeData[BrokerConstants.ChallangeResponseVersion]));
+            return Task.FromResult(string.Format(CultureInfo.InvariantCulture, @"PKeyAuth Context=""{0}"",Version=""{1}""", challengeData[BrokerConstants.ChallangeResponseContext], challengeData[BrokerConstants.ChallangeResponseVersion]));
         }
     }
 }

--- a/src/ADAL.PCL/Flows/NonInteractive/WsTrustRequest.cs
+++ b/src/ADAL.PCL/Flows/NonInteractive/WsTrustRequest.cs
@@ -117,7 +117,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
                 throw new AdalServiceException(
                     AdalError.FederatedServiceReturnedError,
-                    string.Format(AdalErrorMessage.FederatedServiceReturnedErrorTemplate, wsTrustAddress.Uri, errorMessage),
+                    string.Format(CultureInfo.CurrentCulture, AdalErrorMessage.FederatedServiceReturnedErrorTemplate, wsTrustAddress.Uri, errorMessage),
                     null,
                     ex);
             }


### PR DESCRIPTION
Fix two instances reported by the SDL FxCop task