### PR TITLE
Added CredScan exclusions

### DIFF
--- a/build/credscan-exclusion.json
+++ b/build/credscan-exclusion.json
@@ -12,6 +12,10 @@
     {
       "file": "valid_cert2.pfx",
       "_justification": "Self-signed certificate used by unit tests."
+    },
+    {
+      "file": "invalid_cert.pfx",
+      "_justification": "Self-signed certificate used by unit tests."
     }
   ]
 }

--- a/build/credscan-exclusion.json
+++ b/build/credscan-exclusion.json
@@ -1,0 +1,17 @@
+{
+  "tool": "Credential Scanner",
+  "suppressions": [
+    {
+      "file": "AdalUniversalTestApp.Windows_TemporaryKey.pfx",
+      "_justification": "Legitimate UWP app certificate file with private key required for the app to function. This is sample test app."
+    },
+    {
+      "file": "valid_cert.pfx",
+      "_justification": "Self-signed certificate used by unit tests."
+    },
+    {
+      "file": "valid_cert2.pfx",
+      "_justification": "Self-signed certificate used by unit tests."
+    }
+  ]
+}

--- a/build/credscan-exclusion.json
+++ b/build/credscan-exclusion.json
@@ -16,6 +16,11 @@
     {
       "file": "invalid_cert.pfx",
       "_justification": "Self-signed certificate used by unit tests."
+    },
+    {
+      "file": "UnitTests.cs",
+      "_justification": "Test contains password to load the two dummy valid_cert files excluded above"
     }
+
   ]
 }

--- a/tests/Test.ADAL.Common/Sts.cs
+++ b/tests/Test.ADAL.Common/Sts.cs
@@ -227,7 +227,7 @@ namespace Test.ADAL.Common
             this.ValidClientId = "oic.resource.owner.flow";
             this.ValidDefaultRedirectUri = new Uri("oic://resource-owner/flow");
             this.ValidUserName = @"somedomain\username";
-            this.ValidPassword = "Password123";
+            this.ValidPassword = "<REPLACE>";
             this.ValidResource = "https://management.core.contoso.com/";
         }
     }


### PR DESCRIPTION
Added cred scan exclusions for test certificates.
Changed the test code to remove a false-positive password detected by CredScan.

I've added a VSTS work item (190589) to review the exclusions to see if they can be avoided.