### PR TITLE
Automatically kill other WinFormsAutoApp on start

### DIFF
--- a/automation/WinFormsAutomationApp/Program.cs
+++ b/automation/WinFormsAutomationApp/Program.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace WinFormsAutomationApp
@@ -16,7 +15,33 @@ namespace WinFormsAutomationApp
         {
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
+
+            KillOtherInstances();
+
             Application.Run(new MainForm());
+        }
+
+        /// <summary>
+        /// Kill all other instances of this application.
+        /// </summary>
+        private static void KillOtherInstances()
+        {
+            var thisProcess = Process.GetCurrentProcess();
+
+            var otherProcesses = Process.GetProcessesByName(thisProcess.ProcessName)
+                                        .Where(x => x.Id != thisProcess.Id);
+
+            foreach (var otherProcess in otherProcesses)
+            {
+                try
+                {
+                    otherProcess.Kill();
+                }
+                catch
+                {
+                    // continue; not much we can do here.
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Force kill any other running WinFormsAutomationApp instances when starting a new one.

When running E2E tests this allows us ensure that the WinAppDriver is controlling the correct instance and not a stale instance from a previous test run which didn't finish gracefully.