### PR TITLE
Fix warnings about FILETIME struct use

### DIFF
--- a/automation/WinFormsAutomationApp/DeleteCookies.cs
+++ b/automation/WinFormsAutomationApp/DeleteCookies.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using FILETIME = System.Runtime.InteropServices.ComTypes.FILETIME;
 
 namespace WinFormsAutomationApp
 {


### PR DESCRIPTION
In the _WinFormsAutomationApp_, use `System.Runtime.InteropServices.ComTypes.FILETIME` over `System.Runtime.InteropServices.FILETIME` as per the obsolete warning suggestion.

See VSTS PRs for update to the 'headless' copy.