### PR TITLE
Use ISO 8601 format for logger timestamps

### DIFF
--- a/src/ADAL.PCL/Platform/LoggerBase.cs
+++ b/src/ADAL.PCL/Platform/LoggerBase.cs
@@ -48,7 +48,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         internal static string PrepareLogMessage(CallState callState, string classOrComponent, string message)
         {
             string correlationId = (callState != null) ? callState.CorrelationId.ToString() : string.Empty;
-            return string.Format(CultureInfo.CurrentCulture, "{0}: {1} - {2}: {3}", DateTime.UtcNow, correlationId, classOrComponent, message);
+            return string.Format(CultureInfo.InvariantCulture, "{0:O}: {1} - {2}: {3}", DateTime.UtcNow, correlationId, classOrComponent, message);
         }
     }
 }


### PR DESCRIPTION
Explicitly use the ISO 8601 format for date/times when generating log messages. Also ensure we're using the Invariant Culture when constructing the final string (we're only using string.Format here to do concatenation).

This should hopefully also fix issue #710.