### PR TITLE
Address some globalisation issues in WinRT, iOS and Android platform assemblies

### DIFF
--- a/src/ADAL.PCL.Android/BrokerProxy.cs
+++ b/src/ADAL.PCL.Android/BrokerProxy.cs
@@ -107,7 +107,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 Application.Context.PackageManager.CheckPermission(permission, Application.Context.PackageName))
             {
                 PlatformPlugin.Logger.Information(null,
-                    string.Format(AdalErrorMessageAndroidEx.MissingPackagePermissionTemplate, permission));
+                    string.Format(CultureInfo.InvariantCulture, AdalErrorMessageAndroidEx.MissingPackagePermissionTemplate, permission));
                 return false;
             }
 
@@ -259,7 +259,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             string msg = bundleResult.GetString(AccountManager.KeyErrorMessage);
             if (!string.IsNullOrEmpty(msg))
             {
-                throw new AdalException(errCode.ToString(), msg);
+                throw new AdalException(errCode.ToString(CultureInfo.InvariantCulture), msg);
             }
             else
             {
@@ -372,7 +372,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             if (!string.IsNullOrEmpty(signatureDigest))
             {
                 return string.Format(CultureInfo.InvariantCulture, "{0}://{1}/{2}", RedirectUriScheme,
-                    packageName.ToLower(), signatureDigest);
+                    packageName.ToLower(CultureInfo.InvariantCulture), signatureDigest);
             }
 
             return string.Empty;

--- a/src/ADAL.PCL.WinRT/DeviceAuthHelper.cs
+++ b/src/ADAL.PCL.WinRT/DeviceAuthHelper.cs
@@ -65,7 +65,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             string signedJwt = string.Format(CultureInfo.InvariantCulture, "{0}.{1}", response.GetResponseToSign(),
                 Base64UrlEncoder.Encode(signed.ToArray()));
             string authToken = string.Format(CultureInfo.InvariantCulture, " AuthToken=\"{0}\"", signedJwt);
-            return string.Format(authHeaderTemplate, authToken, challengeData["Context"], challengeData["Version"]);
+            return string.Format(CultureInfo.InvariantCulture, authHeaderTemplate, authToken, challengeData["Context"], challengeData["Version"]);
         }
 
         private async Task<Certificate> FindCertificate(IDictionary<string, string> challengeData)
@@ -108,7 +108,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             if (certificates == null || certificates.Count == 0)
             {
                 throw new AdalException(AdalError.DeviceCertificateNotFound,
-                    string.Format(AdalErrorMessage.DeviceCertificateNotFoundTemplate, errMessage));
+                    string.Format(CultureInfo.InvariantCulture, AdalErrorMessage.DeviceCertificateNotFoundTemplate, errMessage));
             }
 
             return certificates[0];

--- a/src/ADAL.PCL.iOS/BrokerHelper.cs
+++ b/src/ADAL.PCL.iOS/BrokerHelper.cs
@@ -82,7 +82,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     string url = brokerPayload["broker_install_url"];
                     Uri uri = new Uri(url);
                     string query = uri.Query;
-                    if (query.StartsWith("?"))
+                    if (query.StartsWith("?", StringComparison.OrdinalIgnoreCase))
                     {
                         query = query.Substring(1);
                     }


### PR DESCRIPTION
There are some more FxCop violations regarding globalisation rules (use of string methods without explicit regard for culture) present in the WinRT, iOS, and Android platform assemblies.

Correcting the issues in this PR.