### PR TITLE
Workaround for passing assembly references to VSTS FxCop task

### DIFF
--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -17,19 +17,30 @@
            For .Net Core projects, you can just drop this file next to the project file: see https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build
            Alternatively, explicitly import the targets into your project.
        
-       2. Pass in the folder path the referenced binaries should be copied to
-          e.g. /p:ReferencedAsmListFolderPath=MyFolder
+       2. Pass in either the root folder path to use "$(ReferencedBinsPathRoot)" or the full folder path "$(ReferencedBinsPath)" to specify
+           where the referenced binaries should be copied.
+           If you specify the root directory then the full path will be calculated by adding the name of the current project (useful if you
+           are building a solution and don't want to have to set the output folder for each project).
+       
+          e.g. /p:ReferencedBinsPath=MyFolder
+          e.g. /p:ReferencedBinsPathRoot=MyRootFolder
           
-           The targets will not run if the property has not been set.
+           The targets will not run unless one of the properties has been set.
            You can use VSTS build variables when specifying the folder: see https://www.visualstudio.com/en-us/docs/build/define/variables
            
        3. Configure the VSTS FxCop task to look in that folder
        
     -->
-  <Target Name="CopyReferencedAssembliesToSingleFolder" AfterTargets="Build" Condition="$(ReferencedAsmListFolderPath)!=''">
-    <Message Importance="high" Text="Copying assemblies referenced during the build to: $(ReferencedAsmListFolderPath)" />
-    <MakeDir Directories="$(ReferencedAsmListFolderPath)" />
-    <Copy SourceFiles="@(ReferencePath)" DestinationFolder="$(ReferencedAsmListFolderPath)" />
+  <PropertyGroup>
+    <!-- If the caller has specified a $(ReferencedBinsPath) then use that.
+         Otherwise, if the caller has specified a $(ReferencedBinsPathRoot) then use that as the root and add the current project name as subfolder. -->
+    <ReferencedBinsPath Condition="$(ReferencedBinsPath)=='' AND $(ReferencedBinsPathRoot)!=''" >$([MSBuild]::NormalizeDirectory($(ReferencedBinsPathRoot)))$(MSBuildProjectName)</ReferencedBinsPath>
+  </PropertyGroup>
+  
+  <Target Name="CopyReferencedAssembliesToSingleFolder" AfterTargets="Build" Condition="$(ReferencedBinsPath)!=''">
+    <Message Importance="high" Text="Copying assemblies referenced during the build to: $(ReferencedBinsPath)" />
+    <MakeDir Directories="$(ReferencedBinsPath)" />
+    <Copy SourceFiles="@(ReferencePath)" DestinationFolder="$(ReferencedBinsPath)" />
   </Target>
 
 </Project>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,0 +1,35 @@
+<Project>
+  
+  <!-- This targets file works round a problem with the VSTS SDL FxCop task.
+  
+       FxCop needs to be able to find all of the referenced binaries. The VSTS task allows multiple reference folders
+       to be specified to search for referenced binaries, but the search doesn't recursive into those folders.
+       
+       This causes a problem with .Net Core projects that use NuGet to reference platform assemblies as the required
+       assemblies are not in a flat folder structure, so each package folder has to specified separately.
+       
+       This file works round the issue by copying all of the referenced binaries to a single folder. The VSTS task can
+       then be configured to search this folder.
+       
+       Using the targets as part of a VSTS build
+       =========================================
+       1. Import this target into the project being built
+           For .Net Core projects, you can just drop this file next to the project file: see https://docs.microsoft.com/en-us/visualstudio/msbuild/customize-your-build
+           Alternatively, explicitly import the targets into your project.
+       
+       2. Pass in the folder path the referenced binaries should be copied to
+          e.g. /p:ReferencedAsmListFolderPath=MyFolder
+          
+           The targets will not run if the property has not been set.
+           You can use VSTS build variables when specifying the folder: see https://www.visualstudio.com/en-us/docs/build/define/variables
+           
+       3. Configure the VSTS FxCop task to look in that folder
+       
+    -->
+  <Target Name="CopyReferencedAssembliesToSingleFolder" AfterTargets="Build" Condition="$(ReferencedAsmListFolderPath)!=''">
+    <Message Importance="high" Text="Copying assemblies referenced during the build to: $(ReferencedAsmListFolderPath)" />
+    <MakeDir Directories="$(ReferencedAsmListFolderPath)" />
+    <Copy SourceFiles="@(ReferencePath)" DestinationFolder="$(ReferencedAsmListFolderPath)" />
+  </Target>
+
+</Project>


### PR DESCRIPTION
The VSTS FxCop task can't realistically be used to analyse .Net Core projects because there isn't a way to configure it to find all of the assemblies referenced through NuGet. We could manually supply the full path to each assembly, but that is error-prone and fragile.
This task works round the problem by copy all of the referenced assemblies by a project to a single folder, which the SDL task can then be configured to search.
See the comments in the new file for more information.
