### PR TITLE
Fixed WinRT failure when logging an empty UserInfo object.

### DIFF
--- a/src/ADAL.PCL.Android/CryptographyHelper.cs
+++ b/src/ADAL.PCL.Android/CryptographyHelper.cs
@@ -34,6 +34,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     {
         public string CreateSha256Hash(string input)
         {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return null;
+            }
+
             return string.Empty;    // TODO: Update
         }
         

--- a/src/ADAL.PCL.WinRT/CryptographyHelper.cs
+++ b/src/ADAL.PCL.WinRT/CryptographyHelper.cs
@@ -43,6 +43,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public string CreateSha256Hash(string input)
         {
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return null;
+            }
+            
             IBuffer inputBuffer = CryptographicBuffer.ConvertStringToBinary(input, BinaryStringEncoding.Utf8);
 
             var hasher = HashAlgorithmProvider.OpenAlgorithm("SHA256");

--- a/src/ADAL.PCL.iOS/CryptographyHelper.cs
+++ b/src/ADAL.PCL.iOS/CryptographyHelper.cs
@@ -35,16 +35,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     {
         public string CreateSha256Hash(string input)
         {
-            if (input != null)
+            if (string.IsNullOrWhiteSpace(input))
             {
-                using (SHA256Managed sha = new SHA256Managed())
-                {
-                    UTF8Encoding encoding = new UTF8Encoding();
-                    return Convert.ToBase64String(sha.ComputeHash(encoding.GetBytes(input)));
-                }
+                return null;
             }
 
-            return null;
+            using (SHA256Managed sha = new SHA256Managed())
+            {
+                UTF8Encoding encoding = new UTF8Encoding();
+                return Convert.ToBase64String(sha.ComputeHash(encoding.GetBytes(input)));
+            }
         }
     }
 }


### PR DESCRIPTION
In `AcquireTokenHandlerBase.cs` line 355, the following line appears:

`result.UserInfo != null
                            ? PlatformPlugin.CryptographyHelper.CreateSha256Hash(result.UserInfo.UniqueId)
                            : "null"`

When the token is first returned from the server, the UserInfo object is null and `CreateSha256Hash()` is not called. However, on subsequent returns the UserInfo object is no longer null, but it is empty (`result.UserInfo.UniqueId == null`). Thus `CreateSha256Hash()` is called with a null argument whenever a token is returned from cache.

`CreateSha256Hash()` is a platform-specific method which is implemented in `CryptographyHelper.cs`. The Desktop, CoreCLR and iOS platform libraries have defensive coding that checks for null strings, but the WinRT and Android libraries do not. Most of the other methods in the WinRT implementation of CryptographyHelper have null checks, but this one does not, and causes an exception to be thrown.

Side note: The above method appears to be not implemented on Android (!!!)

To fix the issue, this PR brings the WinRT CryptographyHelper in line with its other methods and the other implementations by adding the same `string.IsNullOrWhiteSpace(...)` check. In the interest of standardisation, I changed the iOS check to this statement, and added it to the Android implementation too.

This should fix #727.