### PR TITLE
sovereign clouds support for public client code flow

### DIFF
--- a/src/ADAL.PCL.iOS/BrokerHelper.cs
+++ b/src/ADAL.PCL.iOS/BrokerHelper.cs
@@ -53,7 +53,18 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 				{
 					return false;
 				}
-                return pp.UseBroker && UIApplication.SharedApplication.CanOpenUrl(new NSUrl("msauth://"));
+
+                var res = false;
+
+                if (pp.UseBroker)
+                {
+                    pp.CallerViewController.InvokeOnMainThread(() =>
+                    {
+                        res = UIApplication.SharedApplication.CanOpenUrl(new NSUrl("msauth://"));
+                    });
+                }
+
+                return res;
             }
         }
 

--- a/src/ADAL.PCL/AuthenticationResult.cs
+++ b/src/ADAL.PCL/AuthenticationResult.cs
@@ -138,5 +138,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 this.UserInfo = new UserInfo(userInfo);
             }
         }
+
+        public String Authority { get; internal set; }
     }
 }

--- a/src/ADAL.PCL/Authority/AuthorizationResult.cs
+++ b/src/ADAL.PCL/Authority/AuthorizationResult.cs
@@ -77,6 +77,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         [DataMember]
         public string ErrorDescription { get; set; }
 
+        [DataMember]
+        public string CloudInstanceName { get; set; }
+
         public void ParseAuthorizeResponse(string webAuthenticationResult)
         {
             var resultUri = new Uri(webAuthenticationResult);
@@ -110,6 +113,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     this.Error = AdalError.AuthenticationFailed;
                     this.ErrorDescription = AdalErrorMessage.AuthorizationServerInvalidResponse;
                     this.Status = AuthorizationStatus.UnknownError;
+                }
+
+                if (response.ContainsKey(TokenResponseClaim.CloudInstanceName))
+                {
+                    this.CloudInstanceName = response[TokenResponseClaim.CloudInstanceName];
                 }
             }
             else

--- a/src/ADAL.PCL/Authority/TokenResponse.cs
+++ b/src/ADAL.PCL/Authority/TokenResponse.cs
@@ -52,6 +52,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public const string ErrorDescription = "error_description";
         public const string ErrorCodes = "error_codes";
         public const string Claims = "claims";
+        public const string CloudInstanceName = "cloud_instance_name";
     }
 
     [DataContract]

--- a/src/ADAL.PCL/Flows/AcquireTokenHandlerBase.cs
+++ b/src/ADAL.PCL/Flows/AcquireTokenHandlerBase.cs
@@ -86,7 +86,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         protected bool SupportADFS { get; set; }
 
-        protected Authenticator Authenticator { get; private set; }
+        protected Authenticator Authenticator { get; set; }
 
         protected string Resource { get; set; }
 
@@ -181,6 +181,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                         this.tokenCache.StoreToCache(ResultEx, this.Authenticator.Authority, this.Resource,
                             this.ClientKey.ClientId, this.TokenSubjectType, this.CallState);
                     }
+                }
+                if (ResultEx.Result != null)
+                {
+                    ResultEx.Result.Authority = this.Authenticator.Authority;
                 }
                 await this.PostRunAsync(ResultEx.Result).ConfigureAwait(false);
                 return ResultEx.Result;
@@ -358,7 +362,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
         }
 
-        private void ValidateAuthorityType()
+        protected void ValidateAuthorityType()
         {
             if (!this.SupportADFS && this.Authenticator.AuthorityType == AuthorityType.ADFS)
             {

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
@@ -19,16 +19,18 @@ namespace Test.ADAL.NET.Unit.Mocks
             ConfigureMockWebUI(authorizationResult, new Dictionary<string, string>());
         }
 
-        public static void ConfigureMockWebUI(AuthorizationResult authorizationResult, Dictionary<string, string> headersToValidate)
+        public static void ConfigureMockWebUI(AuthorizationResult authorizationResult,
+            Dictionary<string, string> queryParamsToValidate)
         {
             MockWebUI webUi = new MockWebUI();
-            webUi.HeadersToValidate = headersToValidate;
+            webUi.QueryParams = queryParamsToValidate;
             webUi.MockResult = authorizationResult;
 
             IWebUIFactory mockFactory = Substitute.For<IWebUIFactory>();
             mockFactory.CreateAuthenticationDialog(Arg.Any<IPlatformParameters>()).Returns(webUi);
             PlatformPlugin.WebUIFactory = mockFactory;
         }
+
 
         public static Stream GenerateStreamFromString(string s)
         {

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockWebUI.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockWebUI.cs
@@ -13,8 +13,6 @@ namespace Test.ADAL.NET.Unit.Mocks
     {
         internal AuthorizationResult MockResult { get; set; }
 
-        internal IDictionary<string, string> HeadersToValidate { get; set; }
-
         internal IDictionary<string, string> QueryParams { get; set; }
         
         public async Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri, CallState callState)

--- a/tests/Test.ADAL.NET.Unit/SovereignCloudsTests.cs
+++ b/tests/Test.ADAL.NET.Unit/SovereignCloudsTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Test.ADAL.NET.Unit.Mocks;
+
+namespace Test.ADAL.NET.Unit
+{
+    [TestClass]
+    public class SovereignCloudsTests
+    {
+        private PlatformParameters platformParameters;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            HttpMessageHandlerFactory.ClearMockHandlers();
+            platformParameters = new PlatformParameters(PromptBehavior.Auto);
+        }
+
+        [TestMethod]
+        [Description("Sovereign user use world wide authority")]
+        public async Task SovereignUserWorldWideAuthorityIntegrationTest()
+        {
+            const string testCloudInstanceName = "some-sovereign-cloud";
+            const string sovereignAuthorityHostPrefix = "login.";
+            const string sovereignAuthorityHost = sovereignAuthorityHostPrefix + testCloudInstanceName;
+
+            var sovereignAuthority =
+                new UriBuilder(TestConstants.DefaultAuthorityCommonTenant) {Host = sovereignAuthorityHost}.Uri
+                    .ToString();
+
+            // creating AuthenticationContext with common Authority
+            var authenticationContext =
+                new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, false, new TokenCache());
+
+            // mock value for authentication returnedUriInput, with cloud_instance_name claim
+            var authReturnedUriInputMock = TestConstants.DefaultRedirectUri + "?code=some-code" + "&" +
+                                           TokenResponseClaim.CloudInstanceName + "=" + testCloudInstanceName;
+
+            MockHelpers.ConfigureMockWebUI(
+                new AuthorizationResult(AuthorizationStatus.Success, authReturnedUriInputMock),
+                // validate that authorizationUri passed to WebUi contains instance_aware query parameter
+                new Dictionary<string, string> {{"instance_aware", "true"}});
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(
+                        "{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"access_token\":\"some-access-token\"}")
+                },
+
+                AdditionalRequestValidation = request =>
+                {
+                    // make sure that Sovereign authority was used for Authorization request
+                    Assert.AreEqual(sovereignAuthorityHost, request.RequestUri.Authority);
+                }
+            });
+
+            var authenticationResult = await authenticationContext.AcquireTokenAsync(TestConstants.DefaultResource,
+                TestConstants.DefaultClientId,
+                TestConstants.DefaultRedirectUri, platformParameters, UserIdentifier.AnyUser, "instance_aware=true");
+
+            // make sure that sovereign Authority returned to the app in AuthenticationResult
+            Assert.AreEqual(sovereignAuthorityHost, new Uri(authenticationResult.Authority).Host);
+
+            // make sure that AuthenticationContext Authority was not changed
+            Assert.AreEqual(TestConstants.DefaultAuthorityCommonTenant, authenticationContext.Authority);
+
+            // make sure AT was stored in the cache with Sovereign Authority in the key
+            Assert.AreEqual(1, authenticationContext.TokenCache.tokenCacheDictionary.Count);
+            Assert.AreEqual(sovereignAuthority,
+                authenticationContext.TokenCache.tokenCacheDictionary.Keys.FirstOrDefault().Authority);
+        }
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -97,6 +97,7 @@
     <Compile Include="NonInteractiveTests.cs" />
     <Compile Include="OboFlowTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SovereignCloudsTests.cs" />
     <Compile Include="TestConstants.cs" />
     <Compile Include="TokenCacheKeyTests.cs" />
     <Compile Include="TokenCacheUnitTests.cs" />


### PR DESCRIPTION
Sovereign clouds support for public client code flow https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/746

+ fixing "UIKitThreadAccessException"  - calling canOpenUrl() on UIThread

