### PR TITLE
Remove Confidential Client API surface from iOS/Android

### DIFF
--- a/appveyor.vs2015.yml
+++ b/appveyor.vs2015.yml
@@ -1,0 +1,18 @@
+image: Visual Studio 2015
+
+configuration: Release
+
+before_build:
+  - '"C:/Program Files (x86)/Microsoft SDKs/Windows/v10.0A/bin/NETFX 4.6.1 Tools/sn.exe" -Vr *,31bf3856ad364e35'
+
+build:
+  project: ADAL.NET.VS2015.sln
+
+skip_commits:
+  files:
+    - '**/*.md'
+    - 'changelog.txt'
+
+on_finish:
+# Uncomment this to be able to RDP into the build agent
+# ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -210,35 +210,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         /// <summary>
-        /// Acquires an access token from the authority on behalf of a user. It requires using a user token previously received.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
-        /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
-        /// <returns>It contains Access Token and the Access Token's expiration time.</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(string resource,
-            IClientAssertionCertificate clientCertificate, UserAssertion userAssertion)
-        {
-            return await this
-                .AcquireTokenOnBehalfCommonAsync(resource, new ClientKey(clientCertificate, this.Authenticator),
-                    userAssertion).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires an access token from the authority on behalf of a user. It requires using a user token previously received.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
-        /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
-        /// <returns>It contains Access Token and the Access Token's expiration time.</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(string resource, ClientAssertion clientAssertion,
-            UserAssertion userAssertion)
-        {
-            return await this.AcquireTokenOnBehalfCommonAsync(resource, new ClientKey(clientAssertion), userAssertion)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
         /// Acquires security token without asking for user credential.
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -192,168 +192,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         /// <summary>
-        /// Acquires security token from the authority.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientId">Identifier of the client requesting the token.</param>
-        /// <param name="userAssertion">The assertion to use for token acquisition.</param>
-        /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(string resource, string clientId,
-            UserAssertion userAssertion)
-        {
-            return await this.AcquireTokenCommonAsync(resource, clientId, userAssertion).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token from the authority.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientCredential">The client credential to use for token acquisition.</param>
-        /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(string resource, ClientCredential clientCredential)
-        {
-            return await this.AcquireTokenForClientCommonAsync(resource, new ClientKey(clientCredential))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token from the authority.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
-        /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(string resource,
-            IClientAssertionCertificate clientCertificate)
-        {
-            return await this
-                .AcquireTokenForClientCommonAsync(resource, new ClientKey(clientCertificate, this.Authenticator))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token from the authority.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
-        /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(string resource, ClientAssertion clientAssertion)
-        {
-            return await this.AcquireTokenForClientCommonAsync(resource, new ClientKey(clientAssertion))
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token from the authority using authorization code previously received.
-        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
-        /// </summary>
-        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
-        /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
-        /// <param name="clientCredential">The credential to use for token acquisition.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
-        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode,
-            Uri redirectUri, ClientCredential clientCredential)
-        {
-            return await this
-                .AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
-                    new ClientKey(clientCredential), null).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token from the authority using an authorization code previously received.
-        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
-        /// </summary>
-        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
-        /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
-        /// <param name="clientCredential">The credential to use for token acquisition.</param>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
-        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode,
-            Uri redirectUri, ClientCredential clientCredential, string resource)
-        {
-            return await this
-                .AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
-                    new ClientKey(clientCredential), resource).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token from the authority using an authorization code previously received.
-        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
-        /// </summary>
-        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
-        /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
-        /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
-        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode,
-            Uri redirectUri, ClientAssertion clientAssertion)
-        {
-            return await this
-                .AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
-                    new ClientKey(clientAssertion), null).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token from the authority using an authorization code previously received.
-        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
-        /// </summary>
-        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
-        /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
-        /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
-        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode,
-            Uri redirectUri, ClientAssertion clientAssertion, string resource)
-        {
-            return await this
-                .AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
-                    new ClientKey(clientAssertion), resource).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token from the authority using an authorization code previously received.
-        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
-        /// </summary>
-        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
-        /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
-        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
-        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode,
-            Uri redirectUri, IClientAssertionCertificate clientCertificate)
-        {
-            return await this.AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
-                new ClientKey(clientCertificate, this.Authenticator), null).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token from the authority using an authorization code previously received.
-        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
-        /// </summary>
-        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
-        /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
-        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
-        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode,
-            Uri redirectUri, IClientAssertionCertificate clientCertificate, string resource)
-        {
-            return await this.AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
-                new ClientKey(clientCertificate, this.Authenticator), resource).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires an access token from the authority on behalf of a user. It requires using a user token previously received.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientCredential">The client credential to use for token acquisition.</param>
-        /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
-        /// <returns>It contains Access Token and the Access Token's expiration time.</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(string resource, ClientCredential clientCredential,
-            UserAssertion userAssertion)
-        {
-            return await this.AcquireTokenOnBehalfCommonAsync(resource, new ClientKey(clientCredential), userAssertion)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
         /// Acquires an access token from the authority on behalf of a user, passing in the necessary claims for authentication. It requires using a user token previously received.
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
@@ -437,48 +275,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             UserIdentifier userId, IPlatformParameters parameters)
         {
             return await this.AcquireTokenSilentCommonAsync(resource, new ClientKey(clientId), userId, parameters)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token without asking for user credential.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientCredential">The client credential to use for token acquisition.</param>
-        /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
-        public async Task<AuthenticationResult> AcquireTokenSilentAsync(string resource,
-            ClientCredential clientCredential, UserIdentifier userId)
-        {
-            return await this.AcquireTokenSilentCommonAsync(resource, new ClientKey(clientCredential), userId, null)
-                .ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token without asking for user credential.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
-        /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
-        public async Task<AuthenticationResult> AcquireTokenSilentAsync(string resource,
-            IClientAssertionCertificate clientCertificate, UserIdentifier userId)
-        {
-            return await this.AcquireTokenSilentCommonAsync(resource,
-                new ClientKey(clientCertificate, this.Authenticator), userId, null).ConfigureAwait(false);
-        }
-
-        /// <summary>
-        /// Acquires security token without asking for user credential.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
-        /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
-        public async Task<AuthenticationResult> AcquireTokenSilentAsync(string resource,
-            ClientAssertion clientAssertion, UserIdentifier userId)
-        {
-            return await this.AcquireTokenSilentCommonAsync(resource, new ClientKey(clientAssertion), userId, null)
                 .ConfigureAwait(false);
         }
 
@@ -575,7 +371,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 extraQueryParameters).ConfigureAwait(false);
         }
 
-        private async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeCommonAsync(string authorizationCode,
+        internal async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeCommonAsync(string authorizationCode,
             Uri redirectUri, ClientKey clientKey, string resource)
         {
             const string nullResource = "null_resource_as_optional";
@@ -595,7 +391,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        private async Task<AuthenticationResult> AcquireTokenForClientCommonAsync(string resource, ClientKey clientKey)
+        internal async Task<AuthenticationResult> AcquireTokenForClientCommonAsync(string resource, ClientKey clientKey)
         {
             RequestData requestData = new RequestData
             {
@@ -610,7 +406,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        private async Task<AuthenticationResult> AcquireTokenOnBehalfCommonAsync(string resource, ClientKey clientKey,
+        internal async Task<AuthenticationResult> AcquireTokenOnBehalfCommonAsync(string resource, ClientKey clientKey,
             UserAssertion userAssertion)
         {
             RequestData requestData = new RequestData
@@ -665,7 +461,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        private async Task<AuthenticationResult> AcquireTokenCommonAsync(string resource, string clientId,
+        internal async Task<AuthenticationResult> AcquireTokenCommonAsync(string resource, string clientId,
             UserAssertion userAssertion)
         {
             RequestData requestData = new RequestData
@@ -697,7 +493,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        private async Task<AuthenticationResult> AcquireTokenSilentCommonAsync(string resource, ClientKey clientKey,
+        internal async Task<AuthenticationResult> AcquireTokenSilentCommonAsync(string resource, ClientKey clientKey,
             UserIdentifier userId, IPlatformParameters parameters)
         {
             RequestData requestData = new RequestData

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
@@ -1,4 +1,31 @@
-﻿using System;
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
@@ -1,0 +1,221 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Features.WinCommon
+{
+    /// <summary>
+    /// Extension class to support confidential client flows.
+    /// </summary>
+    public static class AuthenticationContextConfidentialClientExtensions
+    {
+
+        /// <summary>
+        /// Acquires security token without asking for user credential.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientCredential">The client credential to use for token acquisition.</param>
+        /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
+        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx, string resource,
+            ClientCredential clientCredential, UserIdentifier userId)
+        {
+            return await ctx.AcquireTokenSilentCommonAsync(resource, new ClientKey(clientCredential), userId, null)
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token without asking for user credential.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
+        /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
+        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx, string resource,
+            IClientAssertionCertificate clientCertificate, UserIdentifier userId)
+        {
+            return await ctx.AcquireTokenSilentCommonAsync(resource,
+                new ClientKey(clientCertificate, ctx.Authenticator), userId, null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token without asking for user credential.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
+        /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
+        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx, string resource,
+            ClientAssertion clientAssertion, UserIdentifier userId)
+        {
+            return await ctx.AcquireTokenSilentCommonAsync(resource, new ClientKey(clientAssertion), userId, null)
+                .ConfigureAwait(false);
+        }
+
+
+        /// <summary>
+        /// Acquires security token from the authority.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientId">Identifier of the client requesting the token.</param>
+        /// <param name="userAssertion">The assertion to use for token acquisition.</param>
+        /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, string clientId,
+            UserAssertion userAssertion)
+        {
+            return await ctx.AcquireTokenCommonAsync(resource, clientId, userAssertion).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientCredential">The client credential to use for token acquisition.</param>
+        /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, ClientCredential clientCredential)
+        {
+            return await ctx.AcquireTokenForClientCommonAsync(resource, new ClientKey(clientCredential))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
+        /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource,
+            IClientAssertionCertificate clientCertificate)
+        {
+            return await ctx
+                .AcquireTokenForClientCommonAsync(resource, new ClientKey(clientCertificate, ctx.Authenticator))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
+        /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, ClientAssertion clientAssertion)
+        {
+            return await ctx.AcquireTokenForClientCommonAsync(resource, new ClientKey(clientAssertion))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority using authorization code previously received.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
+        /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
+        /// <param name="clientCredential">The credential to use for token acquisition.</param>
+        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+            Uri redirectUri, ClientCredential clientCredential)
+        {
+            return await ctx
+                .AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
+                    new ClientKey(clientCredential), null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority using an authorization code previously received.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
+        /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
+        /// <param name="clientCredential">The credential to use for token acquisition.</param>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
+        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+            Uri redirectUri, ClientCredential clientCredential, string resource)
+        {
+            return await ctx
+                .AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
+                    new ClientKey(clientCredential), resource).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority using an authorization code previously received.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
+        /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
+        /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
+        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+            Uri redirectUri, ClientAssertion clientAssertion)
+        {
+            return await ctx
+                .AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
+                    new ClientKey(clientAssertion), null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority using an authorization code previously received.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
+        /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
+        /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
+        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+            Uri redirectUri, ClientAssertion clientAssertion, string resource)
+        {
+            return await ctx
+                .AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
+                    new ClientKey(clientAssertion), resource).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority using an authorization code previously received.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
+        /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
+        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
+        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+            Uri redirectUri, IClientAssertionCertificate clientCertificate)
+        {
+            return await ctx.AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
+                new ClientKey(clientCertificate, ctx.Authenticator), null).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority using an authorization code previously received.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
+        /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
+        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
+        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+            Uri redirectUri, IClientAssertionCertificate clientCertificate, string resource)
+        {
+            return await ctx.AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
+                new ClientKey(clientCertificate, ctx.Authenticator), resource).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires an access token from the authority on behalf of a user. It requires using a user token previously received.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientCredential">The client credential to use for token acquisition.</param>
+        /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
+        /// <returns>It contains Access Token and the Access Token's expiration time.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, ClientCredential clientCredential,
+            UserAssertion userAssertion)
+        {
+            return await ctx.AcquireTokenOnBehalfCommonAsync(resource, new ClientKey(clientCredential), userAssertion)
+                .ConfigureAwait(false);
+        }
+
+    }
+}

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
@@ -217,5 +217,36 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Features.WinCommon
                 .ConfigureAwait(false);
         }
 
+
+        /// <summary>
+        /// Acquires an access token from the authority on behalf of a user. It requires using a user token previously received.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
+        /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
+        /// <returns>It contains Access Token and the Access Token's expiration time.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource,
+            IClientAssertionCertificate clientCertificate, UserAssertion userAssertion)
+        {
+            return await ctx
+                .AcquireTokenOnBehalfCommonAsync(resource, new ClientKey(clientCertificate, ctx.Authenticator),
+                    userAssertion).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires an access token from the authority on behalf of a user. It requires using a user token previously received.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
+        /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
+        /// <returns>It contains Access Token and the Access Token's expiration time.</returns>
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, ClientAssertion clientAssertion,
+            UserAssertion userAssertion)
+        {
+            return await ctx.AcquireTokenOnBehalfCommonAsync(resource, new ClientKey(clientAssertion), userAssertion)
+                .ConfigureAwait(false);
+        }
+
+
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Features.WinCommon
+namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
     /// <summary>
     /// Extension class to support confidential client flows.

--- a/tests/Test.ADAL.NET.Integration/Test.ADAL.NET.Integration.csproj
+++ b/tests/Test.ADAL.NET.Integration/Test.ADAL.NET.Integration.csproj
@@ -11,7 +11,6 @@
     <!-- These properties have no effect on how the project is built. -->
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
-  <Import Project="..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -58,25 +57,32 @@
     <DelaySign>true</DelaySign>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\MSTest.TestFramework.1.1.11\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.ServiceModel" />
   </ItemGroup>
+    <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
   <ItemGroup>
     <Compile Include="SovereignCloudsTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="35MSSharedLib1024.snk" />
-    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Clients.ActiveDirectory\Microsoft.IdentityModel.Clients.ActiveDirectory.csproj">
@@ -88,14 +94,38 @@
       <Name>Test.ADAL.NET.Unit</Name>
     </ProjectReference>
   </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.props'))" />
-    <Error Condition="!Exists('..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
-  <Import Project="..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\..\packages\MSTest.TestAdapter.1.1.11\build\net45\MSTest.TestAdapter.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
 </Project>

--- a/tests/Test.ADAL.NET.Integration/packages.config
+++ b/tests/Test.ADAL.NET.Integration/packages.config
@@ -1,5 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="MSTest.TestAdapter" version="1.1.11" targetFramework="net452" />
-  <package id="MSTest.TestFramework" version="1.1.11" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
Remove Confidential Client API surface from iOS/Android. per #759 