### PR TITLE
ADAL Should Use [assembly: CLSCompliant(true)]

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AdalClaimChallengeException.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AdalClaimChallengeException.cs
@@ -41,6 +41,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             Claims = claims;
         }
 
-        public string Claims { get; set; }
+        /// <summary>
+        /// Claims challenge returned from the STS. This value should be passed back to the API caller.
+        /// </summary>
+        public string Claims { get; internal set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -196,7 +196,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
+        /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
+        /// <param name="parameters">Instance of PlatformParameters containing platform specific arguments and information.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
+        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
         /// <param name="claims">Additional claims that are needed for authentication. Acquired from the AdalClaimChallengeException</param>
         /// <returns>It contains Access Token and the Access Token's expiration time.</returns>
         public async Task<AuthenticationResult> AcquireTokenAsync(string resource, string clientId, Uri redirectUri,

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
@@ -42,6 +42,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires security token without asking for user credential.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCredential">The client credential to use for token acquisition.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
@@ -56,6 +57,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires security token without asking for user credential.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
@@ -70,6 +72,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires security token without asking for user credential.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
@@ -85,6 +88,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires security token from the authority.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="userAssertion">The assertion to use for token acquisition.</param>
@@ -98,6 +102,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires security token from the authority.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCredential">The client credential to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
@@ -110,6 +115,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires security token from the authority.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
@@ -124,6 +130,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires security token from the authority.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
@@ -137,6 +144,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// Acquires security token from the authority using authorization code previously received.
         /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
         /// <param name="clientCredential">The credential to use for token acquisition.</param>
@@ -153,6 +161,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// Acquires security token from the authority using an authorization code previously received.
         /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
         /// <param name="clientCredential">The credential to use for token acquisition.</param>
@@ -170,6 +179,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// Acquires security token from the authority using an authorization code previously received.
         /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
@@ -186,6 +196,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// Acquires security token from the authority using an authorization code previously received.
         /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
@@ -203,6 +214,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// Acquires security token from the authority using an authorization code previously received.
         /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
@@ -218,6 +230,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// Acquires security token from the authority using an authorization code previously received.
         /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
@@ -233,6 +246,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires an access token from the authority on behalf of a user. It requires using a user token previously received.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCredential">The client credential to use for token acquisition.</param>
         /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
@@ -248,6 +262,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires an access token from the authority on behalf of a user. It requires using a user token previously received.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
         /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
@@ -263,6 +278,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Acquires an access token from the authority on behalf of a user. It requires using a user token previously received.
         /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AuthenticationAgentContinuationHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AuthenticationAgentContinuationHelper.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using System;
 using System.Globalization;
 using Android.App;
 using Android.Content;
@@ -34,6 +35,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// <summary>
     /// Static class that consumes the response from the Authentication flow and continues token acquisition. This class should be called in OnActivityResult() of the activity doing authentication.
     /// </summary>
+    [CLSCompliant(false)]
     public static class AuthenticationAgentContinuationHelper
     {
         /// <summary>

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/PlatformParameters.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/PlatformParameters.cs
@@ -26,12 +26,14 @@
 //------------------------------------------------------------------------------
 
 using Android.App;
+using System;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
     /// <summary>
     /// Additional parameters used in acquiring user's authorization
     /// </summary>
+    [CLSCompliant(false)]
     public class PlatformParameters : IPlatformParameters
     {
         /// <summary>

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/AuthenticationContinuationHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/AuthenticationContinuationHelper.cs
@@ -33,6 +33,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// <summary>
     /// Static class that consumes the response from the Authentication flow and continues token acquisition. This class should be called in ApplicationDelegate whenever app loads/reloads.
     /// </summary>
+    [CLSCompliant(false)]
     public static class AuthenticationContinuationHelper
     {
         /// <summary>

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/PlatformParameters.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/PlatformParameters.cs
@@ -37,6 +37,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// <summary>
     /// Additional parameters used in acquiring user's authorization
     /// </summary>
+    [CLSCompliant(false)]
     public class PlatformParameters : IPlatformParameters
     {
         private PlatformParameters()

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/InternalsVisibleTo.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/InternalsVisibleTo.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using System;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -33,7 +34,7 @@ using System.Runtime.InteropServices;
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
-
+[assembly: CLSCompliant(true)]
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("ff47962a-d498-4c63-b7e9-4db3653ad7db")]
 


### PR DESCRIPTION
ADAL Should Use [assembly: CLSCompliant(true)] and only set to false where it is needed. per #673