### PR TITLE
Fixed automation app not parsing snake_cased user_identifier_type.

### DIFF
--- a/automation/WinFormsAutomationApp/AuthenticationHelper.cs
+++ b/automation/WinFormsAutomationApp/AuthenticationHelper.cs
@@ -33,8 +33,23 @@ namespace WinFormsAutomationApp
                 }
                 else if (input.ContainsKey("user_identifier") && input.ContainsKey("user_identifier_type"))
                 {
-                    UserIdentifierType userIdentifierType;
-                    UserIdentifierType.TryParse(input["user_identifier_type"], out userIdentifierType);
+                    // user identifier type defaults to RequiredDisplayableId 
+                    UserIdentifierType userIdentifierType = UserIdentifierType.RequiredDisplayableId;
+                    if (string.Equals(input["user_identifier_type"], "unique_id",
+                        StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        userIdentifierType = UserIdentifierType.UniqueId;
+                    }
+                     else if (string.Equals(input["user_identifier_type"], "optional_displayable",
+                        StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        userIdentifierType = UserIdentifierType.OptionalDisplayableId;
+                    }
+                    else if (string.Equals(input["user_identifier_type"], "required_displayable",
+                        StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        userIdentifierType = UserIdentifierType.RequiredDisplayableId;
+                    }
                     string prompt = input.ContainsKey("prompt_behavior") ? input["prompt_behavior"] : null;
                     result = await ctx.AcquireTokenAsync(input["resource"], input["client_id"], new Uri(input["redirect_uri"]),
                         GetPlatformParametersInstance(prompt), 


### PR DESCRIPTION
Example implementation on Objective C, which matches the snake_case system seen in all other values:
https://github.com/AzureAD/azure-activedirectory-library-for-objc/blob/61e6a751fe390f2cf4cab64e17c84a6139378042/ADAL/ADALAutomation/ADAutoMainViewController.m#L158

As `UserIdentifierType.TryParse(...)` was expecting `"OptionalDisplayableId"`, `"optional_displayable"` wasn't being recognised. Because C#'s enum parsing is pretty bad, I'm just using some if/then statements with `string.Equals(...)` calls. We could also have tried platform-specific strings, but this way seems neater.