### PR TITLE
Trwalke/retry after header #721

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AdalServiceException.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AdalServiceException.cs
@@ -29,6 +29,7 @@ using System.Globalization;
 using System;
 using System.Net;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
@@ -100,6 +101,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 }
             }
 
+            this.Headers = ((HttpRequestWrapperException)innerException).WebResponse.Headers;
             this.ServiceErrorCodes = serviceErrorCodes;
         }
 
@@ -114,6 +116,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// Gets the specific error codes that may be returned by the service.
         /// </summary>
         public string[] ServiceErrorCodes { get; set; }
+
+        /// <summary>
+        /// Contains headers from the response that indicated an error
+        /// </summary>
+        public Dictionary<string, string> Headers { get; set; }
 
         /// <summary>
         /// Creates and returns a string representation of the current exception.

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AdalServiceException.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AdalServiceException.cs
@@ -121,7 +121,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Contains headers from the response that indicated an error
         /// </summary>
-        public HttpResponseHeaders Headers { get; set; }
+        public HttpResponseHeaders Headers { get; internal set; }
 
         /// <summary>
         /// Creates and returns a string representation of the current exception.

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AdalServiceException.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AdalServiceException.cs
@@ -30,6 +30,7 @@ using System;
 using System.Net;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Net.Http.Headers;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
@@ -81,6 +82,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 if (response != null)
                 {
                     this.StatusCode = (int)response.StatusCode;
+                    this.Headers = response.Headers;
                 }
                 else if (innerException.InnerException is TaskCanceledException)
                 {
@@ -101,7 +103,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 }
             }
 
-            this.Headers = ((HttpRequestWrapperException)innerException).WebResponse.Headers;
             this.ServiceErrorCodes = serviceErrorCodes;
         }
 
@@ -120,7 +121,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Contains headers from the response that indicated an error
         /// </summary>
-        public Dictionary<string, string> Headers { get; set; }
+        public HttpResponseHeaders Headers { get; set; }
 
         /// <summary>
         /// Creates and returns a string representation of the current exception.

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationParameters.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationParameters.cs
@@ -173,9 +173,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             AuthenticationParameters authParams;
             if (response.StatusCode == HttpStatusCode.Unauthorized)
             {
-                if (response.Headers.Keys.Contains(AuthenticateHeader))
+                if (response.Headers.Contains(AuthenticateHeader))
                 {
-                    authParams = CreateFromResponseAuthenticateHeader(response.Headers[AuthenticateHeader]);
+                    authParams = CreateFromResponseAuthenticateHeader(response.Headers.GetValues(AuthenticateHeader).FirstOrDefault());
                 }
                 else
                 {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Http/AdalHttpClient.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Http/AdalHttpClient.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 
@@ -148,15 +149,15 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                    && respondToDeviceAuthChallenge
                    && response?.Headers != null
                    && response.StatusCode == HttpStatusCode.Unauthorized
-                   && response.Headers.ContainsKey(WwwAuthenticateHeader)
-                   && response.Headers[WwwAuthenticateHeader]
+                   && response.Headers.Contains(WwwAuthenticateHeader)
+                   && response.Headers.GetValues(WwwAuthenticateHeader).FirstOrDefault()
                        .StartsWith(PKeyAuthName, StringComparison.OrdinalIgnoreCase);
         }
 
         private IDictionary<string, string> ParseChallengeData(IHttpWebResponse response)
         {
             IDictionary<string, string> data = new Dictionary<string, string>();
-            string wwwAuthenticate = response.Headers[WwwAuthenticateHeader];
+            string wwwAuthenticate = response.Headers.GetValues(WwwAuthenticateHeader).FirstOrDefault();
             wwwAuthenticate = wwwAuthenticate.Substring(PKeyAuthName.Length + 1);
             List<string> headerPairs = EncodingHelper.SplitWithQuotes(wwwAuthenticate, ',');
             foreach (string pair in headerPairs)

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Http/HttpClientWrapper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Http/HttpClientWrapper.cs
@@ -158,27 +158,19 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public async static Task<IHttpWebResponse> CreateResponseAsync(HttpResponseMessage response)
         {
-            var headers = new Dictionary<string, string>();
-            if (response.Headers != null)
-            {
-                foreach (var kvp in response.Headers)
-                {
-                    headers[kvp.Key] = kvp.Value.First();
-                }
-            }
-
-            return new HttpWebResponseWrapper(await response.Content.ReadAsStringAsync().ConfigureAwait(false), headers,
+            return new HttpWebResponseWrapper(await response.Content.ReadAsStringAsync().ConfigureAwait(false), response.Headers,
                 response.StatusCode);
         }
 
-        private void VerifyCorrelationIdHeaderInReponse(Dictionary<string, string> headers)
+        private void VerifyCorrelationIdHeaderInReponse(HttpResponseHeaders headers)
         {
-            foreach (string reponseHeaderKey in headers.Keys)
+            foreach (KeyValuePair<string, IEnumerable<string>> header in headers)
             {
+                string reponseHeaderKey = header.Key;
                 string trimmedKey = reponseHeaderKey.Trim();
                 if (string.Compare(trimmedKey, OAuthHeader.CorrelationId, StringComparison.OrdinalIgnoreCase) == 0)
                 {
-                    string correlationIdHeader = headers[trimmedKey].Trim();
+                    string correlationIdHeader = headers.GetValues(trimmedKey).FirstOrDefault().Trim();
                     Guid correlationIdInResponse;
                     if (!Guid.TryParse(correlationIdHeader, out correlationIdInResponse))
                     {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Http/HttpWebResponseWrapper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Http/HttpWebResponseWrapper.cs
@@ -29,12 +29,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
     internal class HttpWebResponseWrapper : IHttpWebResponse
     {
-        public HttpWebResponseWrapper(string responseString, Dictionary<string, string> headers, HttpStatusCode statusCode)
+        public HttpWebResponseWrapper(string responseString, HttpResponseHeaders headers, HttpStatusCode statusCode)
         {
             this.ResponseString = responseString;
             this.Headers = headers;
@@ -43,7 +44,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public HttpStatusCode StatusCode { get; private set; }
 
-        public Dictionary<string, string> Headers { get; private set; }
+        public HttpResponseHeaders Headers { get; private set; }
 
         public string ResponseString { get; private set; }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Http/IHttpWebResponse.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Http/IHttpWebResponse.cs
@@ -29,6 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
@@ -36,7 +37,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     {
         HttpStatusCode StatusCode { get; }
 
-        Dictionary<string, string> Headers { get; }
+        HttpResponseHeaders Headers { get; }
 
         string ResponseString { get; }
     }

--- a/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
@@ -1386,5 +1386,46 @@ namespace Test.ADAL.NET.Unit
                 context.AcquireTokenSilentAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId, new UserIdentifier("unique_id", UserIdentifierType.UniqueId)));
             Assert.IsTrue((ex.InnerException.InnerException.InnerException).Message.Contains(TestConstants.ErrorSubCode));
         }
+
+        [TestMethod]
+        [Description("Test for ensuring ADAL returns the appropriate headers during a http failure.")]
+        public async Task HttpErrorResponseWithHeaders()
+        {
+            MockHelpers.ConfigureMockWebUI(new AuthorizationResult(AuthorizationStatus.Success,
+                                           TestConstants.DefaultRedirectUri + "?code=some-code"));
+
+            List<KeyValuePair<string, string>> HttpErrorResponseWithHeaders = new List<KeyValuePair<string, string>>();
+            HttpErrorResponseWithHeaders.Add(new KeyValuePair<string, string>("Retry-After", "120"));
+            HttpErrorResponseWithHeaders.Add(new KeyValuePair<string, string>("GatewayTimeout", "0"));
+            HttpErrorResponseWithHeaders.Add(new KeyValuePair<string, string>("Forbidden", "0"));
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateCustomHeaderFailureResponseMessage(HttpErrorResponseWithHeaders)
+            });
+
+            var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, true);
+
+            try
+            {
+                AuthenticationResult result = await context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,
+                                              TestConstants.DefaultRedirectUri, platformParameters);
+                Assert.Fail();
+            }
+            catch (Exception ex)
+            {
+                if (ex is AdalServiceException adalEx)
+                {
+                    foreach (KeyValuePair<string, string> header in adalEx.Headers)
+                    {
+                        //Find matching header
+                        var match = adalEx.Headers.Where(x => x.Key == header.Key && x.Value == header.Value);
+                        Assert.IsNotNull(match);
+                        Assert.AreEqual(match.FirstOrDefault(), header);
+                    }
+                }
+            }
+        }
     }
 }

--- a/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
@@ -1417,12 +1417,10 @@ namespace Test.ADAL.NET.Unit
             {
                 if (ex is AdalServiceException adalEx)
                 {
-                    foreach (KeyValuePair<string, string> header in adalEx.Headers)
+                    foreach (KeyValuePair<string, string> header in HttpErrorResponseWithHeaders)
                     {
-                        //Find matching header
-                        var match = adalEx.Headers.Where(x => x.Key == header.Key && x.Value == header.Value);
+                        var match = adalEx.Headers.Where(x => x.Key == header.Key && x.Value.Contains(header.Value)).FirstOrDefault();
                         Assert.IsNotNull(match);
-                        Assert.AreEqual(match.FirstOrDefault(), header);
                     }
                 }
             }

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
@@ -97,9 +97,9 @@ namespace Test.ADAL.NET.Unit.Mocks
             HttpResponseMessage responseMessage = CreateHttpErrorResponse();
 
             foreach (KeyValuePair<string, string> header in headers)
+            {
                 responseMessage.Headers.Add(header.Key, header.Value);
-
-            //var resp = responseMessage.Content.Headers.TryAddWithoutValidation("retry-after", "120");
+            }
 
             return responseMessage;
         }

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
@@ -92,6 +92,18 @@ namespace Test.ADAL.NET.Unit.Mocks
             return responseMessage;
         }
 
+        public static HttpResponseMessage CreateCustomHeaderFailureResponseMessage(IEnumerable<KeyValuePair<string, string>> headers)
+        {
+            HttpResponseMessage responseMessage = CreateHttpErrorResponse();
+
+            foreach (KeyValuePair<string, string> header in headers)
+                responseMessage.Headers.Add(header.Key, header.Value);
+
+            //var resp = responseMessage.Content.Headers.TryAddWithoutValidation("retry-after", "120");
+
+            return responseMessage;
+        }
+
         public static HttpResponseMessage CreateResiliencyMessage(HttpStatusCode statusCode)
         {
             HttpResponseMessage responseMessage = null;


### PR DESCRIPTION
Added HttpResponseHeaders to the AdalServiceException that contains all headers returned in the web response. #721