### PR TITLE
dereference UIViewController for iOS

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/BrokerHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/BrokerHelper.cs
@@ -115,6 +115,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
 
             await brokerResponseReady.WaitAsync().ConfigureAwait(false);
+            PlatformParameters pp = PlatformParameters as PlatformParameters;
+            pp.CallerViewController = null;
+            PlatformParameters = null;
             return ProcessBrokerResponse();
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/PlatformParameters.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/PlatformParameters.cs
@@ -79,7 +79,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Caller UIViewController
         /// </summary>
-        public UIViewController CallerViewController { get; private set; }
+        public UIViewController CallerViewController { get; internal set; }
 
         /// <summary>
         /// Skips calling to broker if broker is present. false, by default

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
@@ -35,7 +35,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     {
         private static SemaphoreSlim returnedUriReady;
         private static AuthorizationResult authorizationResult;
-        private readonly PlatformParameters parameters;
+        private PlatformParameters parameters;
 
         public WebUI(IPlatformParameters parameters)
         {
@@ -51,6 +51,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             returnedUriReady = new SemaphoreSlim(0);
             Authenticate(authorizationUri, redirectUri, callState);
             await returnedUriReady.WaitAsync().ConfigureAwait(false);
+
+            this.parameters.CallerViewController = null;
+            this.parameters = null;
             return authorizationResult;
         }
 
@@ -71,9 +74,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                             redirectUri.OriginalString, CallbackMethod, this.parameters.PreferredStatusBarStyle);
 
                     navigationController.ModalPresentationStyle = this.parameters.ModalPresentationStyle;
-
                     navigationController.ModalTransitionStyle = this.parameters.ModalTransitionStyle;
-
                     navigationController.TransitioningDelegate = this.parameters.TransitioningDelegate;
 
                     this.parameters.CallerViewController.PresentViewController(navigationController, true, null);
@@ -81,6 +82,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
             catch (Exception ex)
             {
+                this.parameters.CallerViewController = null;
+                this.parameters = null;
                 throw new AdalException(AdalError.AuthenticationUiFailed, ex);
             }
         }


### PR DESCRIPTION
dereference UIViewController instances in Xamarin.iOS upon completion of the request. not doing so causes the OS to retain the object and causes memory leak, per #534 