### PR TITLE
Fix to use RSACng when RSA CSP is not resolved

### DIFF
--- a/build/prepare-versioning.ps1
+++ b/build/prepare-versioning.ps1
@@ -33,6 +33,11 @@ Write-Host "Setting assembly version attribute:" $assemblyVersion;
 
 $nugetVersion = "{0}.{1}.{2}" -f ($versionTokens[0], $versionTokens[1], $versionTokens[2]);
 
+if ($env:BUILD_SOURCEBRANCHNAME -ne "master")
+{
+	$nugetVersion = $nugetVersion + "-alpha" + $env:BUILD_BUILDNUMBER;
+}
+
 Write-Host "=========================="
 Write-Host "Versioning .nuspec file..."
 $filename = "build\Microsoft.IdentityModel.Clients.ActiveDirectory.nuspec"

--- a/src/ADAL.Common/CommonAssemblyInfo.cs
+++ b/src/ADAL.Common/CommonAssemblyInfo.cs
@@ -37,7 +37,7 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyFileVersion("3.16.0.0")]
+[assembly: AssemblyFileVersion("3.16.1.0")]
 
 // On official build, attribute AssemblyInformationalVersionAttribute is added as well
 // with its value equal to the hash of the last commit to the git branch.

--- a/src/ADAL.PCL.Desktop/CryptographyHelper.cs
+++ b/src/ADAL.PCL.Desktop/CryptographyHelper.cs
@@ -31,6 +31,13 @@ using System.IdentityModel.Tokens;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using Microsoft.Win32.SafeHandles;
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.Permissions;
+using Microsoft.IdentityModel.Clients.ActiveDirectory.Native;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
@@ -72,20 +79,20 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     // For .NET 4.6 and below we get the old RSACryptoServiceProvider implementation as the default.
                     // Try and get an instance of RSACryptoServiceProvider which supports SHA256
                     newRsa = GetCryptoProviderForSha256(cspRsa);
+
+                    using (var sha = new SHA256Cng())
+                    {
+                        return newRsa.SignData(messageBytes, sha);
+                    }
                 }
                 else
                 {
-                    // For .NET Framework 4.7 and onwards the RSACng implementation is the default.
-                    // Since we're targeting .NET Framework 4.5, we cannot actually use this type as it was
-                    // only introduced with .NET Framework 4.6.
-                    // Instead we try and create an RSACryptoServiceProvider based on the private key from the
-                    // certificate.
-                    newRsa = GetCryptoProviderForSha256(certificate);
-                }
-
-                using (var sha = new SHA256Cng())
-                {
-                    return newRsa.SignData(messageBytes, sha);
+                    CngKey key = GetCngPrivateKey(certificate);
+                    using (RSACng rsaCng = new RSACng(key))
+                    {
+                        rsaCng.SignatureHashAlgorithm = CngAlgorithm.Sha256;
+                        return rsaCng.SignData(messageBytes);
+                    }
                 }
             }
             finally
@@ -97,19 +104,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     newRsa.Dispose();
                 }
             }
-        }
-
-        /// <summary>
-        /// Create a <see cref="RSACryptoServiceProvider"/> using the private key from the given <see cref="X509Certificate2"/>.
-        /// </summary>
-        /// <param name="certificate">Certificate including private key with which to initialize the <see cref="RSACryptoServiceProvider"/> with</param>
-        /// <returns><see cref="RSACryptoServiceProvider"/> initialized with private key from <paramref name="certificate"/></returns>
-        private static RSACryptoServiceProvider GetCryptoProviderForSha256(X509Certificate2 certificate)
-        {
-            var privateKeyXmlParams = certificate.PrivateKey.ToXmlString(true);
-            var rsa = new RSACryptoServiceProvider();
-            rsa.FromXmlString(privateKeyXmlParams);
-            return rsa;
         }
 
         // Copied from ACS code
@@ -144,6 +138,91 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
 
             return rsaProvider;
+        }
+
+
+        /// <summary>
+        ///     <para>
+        ///         The GetCngPrivateKey method will return a <see cref="CngKey"/> representing the private
+        ///         key of an X.509 certificate which has its private key stored with NCrypt rather than with
+        ///         CAPI. If the key is not stored with NCrypt or if there is no private key available,
+        ///         GetCngPrivateKey returns null.
+        ///     </para>
+        ///     <para>
+        ///         The HasCngKey method can be used to test if the certificate does have its private key
+        ///         stored with NCrypt.
+        ///     </para>
+        ///     <para>
+        ///         The X509Certificate that is used to get the key must be kept alive for the lifetime of the
+        ///         CngKey that is returned - otherwise the handle may be cleaned up when the certificate is
+        ///         finalized.
+        ///     </para>
+        /// </summary>
+        /// <permission cref="SecurityPermission">The caller of this method must have SecurityPermission/UnmanagedCode.</permission>
+        [SecurityCritical]
+        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands",
+            Justification = "Safe use of LinkDemand methods")]
+        public static CngKey GetCngPrivateKey(X509Certificate2 certificate)
+        {
+            using (SafeCertContextHandle certContext = GetCertificateContext(certificate))
+            using (SafeNCryptKeyHandle privateKeyHandle = X509Native.AcquireCngPrivateKey(certContext))
+            {
+                // We need to assert for full trust when opening the CNG key because
+                // CngKey.Open(SafeNCryptKeyHandle) does a full demand for full trust, and we want to allow
+                // access to a certificate's private key by anyone who has access to the certificate itself.
+                new PermissionSet(PermissionState.Unrestricted).Assert();
+                return CngKey.Open(privateKeyHandle, CngKeyHandleOpenOptions.None);
+            }
+        }
+
+        /// <summary>
+        ///     Get a <see cref="SafeCertContextHandle" /> for the X509 certificate.  The caller of this
+        ///     method owns the returned safe handle, and should dispose of it when they no longer need it. 
+        ///     This handle can be used independently of the lifetime of the original X509 certificate.
+        /// </summary>
+        /// <permission cref="SecurityPermission">
+        ///     The immediate caller must have SecurityPermission/UnmanagedCode to use this method
+        /// </permission>
+        [SecurityCritical]
+        [SuppressMessage("Microsoft.Reliability", "CA2004:RemoveCallsToGCKeepAlive",
+            Justification =
+                "This method is used to create the safe handle, and KeepAlive is needed to prevent racing the GC while doing so"
+            )]
+        public static SafeCertContextHandle GetCertificateContext(X509Certificate certificate)
+        {
+            SafeCertContextHandle certContext = X509Native.DuplicateCertContext(certificate.Handle);
+
+            // Make sure to keep the X509Certificate object alive until after its certificate context is
+            // duplicated, otherwise it could end up being closed out from underneath us before we get a
+            // chance to duplicate the handle.
+            GC.KeepAlive(certificate);
+
+            return certContext;
+        }
+    }
+
+
+
+
+    [SecurityCritical]
+    internal sealed class SafeCertContextHandle : SafeHandleZeroOrMinusOneIsInvalid
+    {
+        private SafeCertContextHandle()
+            : base(true)
+        {
+        }
+
+        [DllImport("crypt32.dll")]
+        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+        [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass",
+            Justification = "SafeHandle release method")]
+        [SuppressUnmanagedCodeSecurity]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        private static extern bool CertFreeCertificateContext(IntPtr pCertContext);
+
+        protected override bool ReleaseHandle()
+        {
+            return CertFreeCertificateContext(handle);
         }
     }
 }

--- a/src/ADAL.PCL.Desktop/DeviceAuthHelper.cs
+++ b/src/ADAL.PCL.Desktop/DeviceAuthHelper.cs
@@ -29,18 +29,11 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
-using System.IdentityModel.Tokens;
-using System.IO;
-using System.Runtime.ConstrainedExecution;
-using System.Runtime.InteropServices;
-using System.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using System.Security.Permissions;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Native;
-using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
@@ -58,7 +51,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             X509Certificate2 certificate = FindCertificate(challengeData);
             DeviceAuthJWTResponse response = new DeviceAuthJWTResponse(challengeData["SubmitUrl"],
                 challengeData["nonce"], Convert.ToBase64String(certificate.GetRawCertData()));
-            CngKey key = GetCngPrivateKey(certificate);
+            CngKey key = CryptographyHelper.GetCngPrivateKey(certificate);
             byte[] sig = null;
             using (RSACng rsa = new RSACng(key))
             {
@@ -140,89 +133,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             {
                 store.Close();
             }
-        }
-
-
-        /// <summary>
-        ///     <para>
-        ///         The GetCngPrivateKey method will return a <see cref="CngKey"/> representing the private
-        ///         key of an X.509 certificate which has its private key stored with NCrypt rather than with
-        ///         CAPI. If the key is not stored with NCrypt or if there is no private key available,
-        ///         GetCngPrivateKey returns null.
-        ///     </para>
-        ///     <para>
-        ///         The HasCngKey method can be used to test if the certificate does have its private key
-        ///         stored with NCrypt.
-        ///     </para>
-        ///     <para>
-        ///         The X509Certificate that is used to get the key must be kept alive for the lifetime of the
-        ///         CngKey that is returned - otherwise the handle may be cleaned up when the certificate is
-        ///         finalized.
-        ///     </para>
-        /// </summary>
-        /// <permission cref="SecurityPermission">The caller of this method must have SecurityPermission/UnmanagedCode.</permission>
-        [SecurityCritical]
-        [SuppressMessage("Microsoft.Security", "CA2122:DoNotIndirectlyExposeMethodsWithLinkDemands",
-            Justification = "Safe use of LinkDemand methods")]
-        public static CngKey GetCngPrivateKey(X509Certificate2 certificate)
-        {
-            using (SafeCertContextHandle certContext = GetCertificateContext(certificate))
-            using (SafeNCryptKeyHandle privateKeyHandle = X509Native.AcquireCngPrivateKey(certContext))
-            {
-                // We need to assert for full trust when opening the CNG key because
-                // CngKey.Open(SafeNCryptKeyHandle) does a full demand for full trust, and we want to allow
-                // access to a certificate's private key by anyone who has access to the certificate itself.
-                new PermissionSet(PermissionState.Unrestricted).Assert();
-                return CngKey.Open(privateKeyHandle, CngKeyHandleOpenOptions.None);
-            }
-        }
-
-        /// <summary>
-        ///     Get a <see cref="SafeCertContextHandle" /> for the X509 certificate.  The caller of this
-        ///     method owns the returned safe handle, and should dispose of it when they no longer need it. 
-        ///     This handle can be used independently of the lifetime of the original X509 certificate.
-        /// </summary>
-        /// <permission cref="SecurityPermission">
-        ///     The immediate caller must have SecurityPermission/UnmanagedCode to use this method
-        /// </permission>
-        [SecurityCritical]
-        [SuppressMessage("Microsoft.Reliability", "CA2004:RemoveCallsToGCKeepAlive",
-            Justification =
-                "This method is used to create the safe handle, and KeepAlive is needed to prevent racing the GC while doing so"
-            )]
-        public static SafeCertContextHandle GetCertificateContext(X509Certificate certificate)
-        {
-            SafeCertContextHandle certContext = X509Native.DuplicateCertContext(certificate.Handle);
-
-            // Make sure to keep the X509Certificate object alive until after its certificate context is
-            // duplicated, otherwise it could end up being closed out from underneath us before we get a
-            // chance to duplicate the handle.
-            GC.KeepAlive(certificate);
-
-            return certContext;
-        }
-    }
-
-
-    [SecurityCritical]
-    internal sealed class SafeCertContextHandle : SafeHandleZeroOrMinusOneIsInvalid
-    {
-        private SafeCertContextHandle()
-            : base(true)
-        {
-        }
-
-        [DllImport("crypt32.dll")]
-        [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
-        [SuppressMessage("Microsoft.Design", "CA1060:MovePInvokesToNativeMethodsClass",
-            Justification = "SafeHandle release method")]
-        [SuppressUnmanagedCodeSecurity]
-        [return: MarshalAs(UnmanagedType.Bool)]
-        private static extern bool CertFreeCertificateContext(IntPtr pCertContext);
-
-        protected override bool ReleaseHandle()
-        {
-            return CertFreeCertificateContext(handle);
         }
     }
 }


### PR DESCRIPTION
This PR includes fix to use RSACng instead of RSACSP in case of  .net 4.7. Existing code was attempting to export private key and create RSA CSP from it. This would fail if the key is marked as non-exportable, per #752

The CI builds will fail as they expect multi-target project configuration. Internal build system will still be able to create a successful build