### PR TITLE
doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ This is obviously the first diagnostic.  We try to provide helpful error message
 
 ### Logs
 
-In order to configure logging, static property Callback of the LoggerCallbackHandler class should be set to the instance of class implementing IAdalLogCallback interface
+In order to configure logging, static property Callback of the LoggerCallbackHandler class should be set to the instance of a class implementing IAdalLogCallback interface
 
 ### Brokered Authentication for iOS
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,22 @@ This is obviously the first diagnostic.  We try to provide helpful error message
 
 ### Logs
 
-In order to configure logging, static property Callback of the LoggerCallbackHandler class should be set to the instance of a class implementing IAdalLogCallback interface
+In order to configure logging, implementation of IAdalLogCallback interface should be provided
+
+```C#
+class LoggerCallbackImpl : IAdalLogCallback
+{
+    public void Log(LogLevel level, string message)
+    {
+        // process log message, for example write it to your favorite logging framework
+    }
+}
+```
+static property Callback of the LoggerCallbackHandler class should be set to the instance of a class implementing IAdalLogCallback interface
+
+```C#
+LoggerCallbackHandler.Callback = new LoggerCallbackImpl();
+```
 
 ### Brokered Authentication for iOS
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Active Directory Authentication Library (ADAL) for .NET, Windows Store, Xamarin iOS and Xamarin Android. 
+# Active Directory Authentication Library (ADAL) for .NET, Windows Store, Xamarin iOS and Xamarin Android.
 
 | [Code Samples](https://github.com/azure-samples?utf8=✓&q=active-directory-dotnet) | [Reference Docs](https://docs.microsoft.com/active-directory/adal/microsoft.identitymodel.clients.activedirectory) | [Developer Guide](https://aka.ms/aaddev)
 | --- | --- | --- |
@@ -34,11 +34,11 @@ Affected 3.x versions: 3.11.305310302-alpha, 3.10.305231913, 3.10.305161347, 3.1
 
 ## Samples and Documentation
 
-We provide a full suite of [sample applications](https://github.com/Azure-Samples?utf8=%E2%9C%93&q=active-directory) and [ADAL documentation](https://docs.microsoft.com/active-directory/adal/microsoft.identitymodel.clients.activedirectory) to help you get started with learning the Azure Identity system. Our [Azure AD Developer Guide](https://aka.ms/aaddev) includes tutorials for native clients such as Windows, Windows Phone, iOS, OSX, Android, and Linux. We also provide full walkthroughs for authentication flows such as OAuth2, OpenID Connect, Graph API, and other awesome features. 
+We provide a full suite of [sample applications](https://github.com/Azure-Samples?utf8=%E2%9C%93&q=active-directory) and [ADAL documentation](https://docs.microsoft.com/active-directory/adal/microsoft.identitymodel.clients.activedirectory) to help you get started with learning the Azure Identity system. Our [Azure AD Developer Guide](https://aka.ms/aaddev) includes tutorials for native clients such as Windows, Windows Phone, iOS, OSX, Android, and Linux. We also provide full walkthroughs for authentication flows such as OAuth2, OpenID Connect, Graph API, and other awesome features.
 
 ## Community Help and Support
 
-We leverage [Stack Overflow](http://stackoverflow.com/) to work with the community on supporting Azure Active Directory and its SDKs, including this one! We highly recommend you ask your questions on Stack Overflow (we're all on there!) Also browser existing issues to see if someone has had your question before. 
+We leverage [Stack Overflow](http://stackoverflow.com/) to work with the community on supporting Azure Active Directory and its SDKs, including this one! We highly recommend you ask your questions on Stack Overflow (we're all on there!) Also browser existing issues to see if someone has had your question before.
 
 We recommend you use the "adal" tag so we can see it! Here is the latest Q&A on Stack Overflow for ADAL: [http://stackoverflow.com/questions/tagged/adal](http://stackoverflow.com/questions/tagged/adal)
 
@@ -66,101 +66,7 @@ This is obviously the first diagnostic.  We try to provide helpful error message
 
 ### Logs
 
-You can configure the library to generate log messages that you can use to help diagnose issues.  You configure logging by setting properties of the static class `AdalTrace`; however, depending on the platform, logging methods and the properties of this class differ. Here is how logging works on each platform:
-
-#### Desktop Applications
-
-ADAL.NET for desktop applications by default logs via `System.Diagnostics.Trace` class. You can add a trace listener to receive those logs. You can also control tracing using this method (e.g. change trace level or turn it off) using `AdalTrace.LegacyTraceSwitch`. 
-
-The following example shows how to add a Console based listener and set trace level to `Information` (the default trace level is `Verbose`):
-
-```
-Trace.Listeners.Add(new ConsoleTraceListener());
-AdalTrace.LegacyTraceSwitch.Level = TraceLevel.Info;
-```
-
-You can achieve the same result by adding the following lines to your application's config file:
-
-```
-  <system.diagnostics>
-    <sharedListeners>
-      <add name="console" 
-        type="System.Diagnostics.ConsoleTraceListener" 
-        initializeData="false"/>
-    </sharedListeners>
-    <trace autoflush="true">
-      <listeners>
-        <add name="console" />
-      </listeners>
-    </trace>    
-    <switches>
-      <add name="ADALLegacySwitch" value="Info"/>
-    </switches>
-  </system.diagnostics>
-```
-
-If you would like to have more control over how tracing is done in ADAL, you can add a `TraceListener` to ADAL's dedicated `TraceSource` with name **"Microsoft.IdentityModel.Clients.ActiveDirectory"**. 
-
-The following example shows how to write ADAL's traces to a text file using this method:
-
-```
-Stream logFile = File.Create("logFile.txt");
-AdalTrace.TraceSource.Listeners.Add(new TextWriterTraceListener(logFile));
-AdalTrace.TraceSource.Switch.Level = SourceLevels.Information;
-```
-
-You can achieve the same result by adding the following lines to your application's config file:
-
-```
-  <system.diagnostics>
-    <trace autoflush="true"/>
-    <sources>
-      <source name="Microsoft.IdentityModel.Clients.ActiveDirectory" 
-        switchName="sourceSwitch" 
-        switchType="System.Diagnostics.SourceSwitch">
-        <listeners>
-          <add name="textListener" 
-            type="System.Diagnostics.TextWriterTraceListener" 
-            initializeData="logFile.txt"/>
-          <remove name="Default" />
-        </listeners>
-      </source>
-    </sources>    
-    <switches>
-      <add name="sourceSwitch" value="Information"/>
-    </switches>
-  </system.diagnostics>
-``` 
-
-#### Windows Store Applications
-
-Tracing in ADAL for Windows Store is done via an instance of class `System.Diagnostics.Tracing.EventSource` with name **"Microsoft.IdentityModel.Clients.ActiveDirectory"**. You can define your own ```EventListener```, connect it to the event source and set your desired trace level. Here is an example:
-```
-var eventListener = new SampleEventListener();
-
-class SampleEventListener : EventListener
-{
-    protected override void OnEventSourceCreated(EventSource eventSource)
-    {
-        if (eventSource.Name == "Microsoft.IdentityModel.Clients.ActiveDirectory")
-        {
-            this.EnableEvents(eventSource, EventLevel.Verbose);
-        }
-    }
-
-    protected override void OnEventWritten(EventWrittenEventArgs eventData)
-    {
-	    ...
-    }
-}
-
-```
-
-There is also a default event listener which writes logs to a local file named **"AdalTraces.log"**. You can control the level of tracing to that event listener using the property ```AdalTrace.Level```. By default, trace level for this event listener is set to "None" and to enable tracing to this particular listener, you need to set the above property. This is an example:
-
-```
-AdalTrace.Level = AdalTraceLevel.Informational;
-```
+In order to configure logging, static property Callback of the LoggerCallbackHandler class should be set to the instance of class implementing IAdalLogCallback interface
 
 ### Brokered Authentication for iOS
 
@@ -176,7 +82,7 @@ public PlatformParameters(UIViewController callerViewController, bool useBroker)
 The userBroker flag setting will allow ADAL to try to call out to the broker.
 
 #### AppDelegate changes
-Update the AppDelegate.cs file to  include the override method below. This method is invoked everytime the application is launched and is used as an opportunity to process response from the Broker and complete the authentication process. 
+Update the AppDelegate.cs file to  include the override method below. This method is invoked everytime the application is launched and is used as an opportunity to process response from the Broker and complete the authentication process.
 ```C#
 public override bool OpenUrl(UIApplication app, NSUrl url, NSDictionary options)
 {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -145,7 +145,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public async Task<DeviceCodeResult> AcquireDeviceCodeAsync(string resource, string clientId)
         {
             return await this.AcquireDeviceCodeAsync(resource, clientId, null).ConfigureAwait(false);
@@ -157,7 +157,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public async Task<DeviceCodeResult> AcquireDeviceCodeAsync(string resource, string clientId,
             string extraQueryParameters)
         {
@@ -170,7 +170,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
         /// </summary>
         /// <param name="deviceCodeResult">The device code result received from calling AcquireDeviceCodeAsync.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public async Task<AuthenticationResult> AcquireTokenByDeviceCodeAsync(DeviceCodeResult deviceCodeResult)
         {
             if (deviceCodeResult == null)
@@ -217,7 +217,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
         public async Task<AuthenticationResult> AcquireTokenSilentAsync(string resource, string clientId)
         {
             return await this.AcquireTokenSilentAsync(resource, clientId, UserIdentifier.AnyUser).ConfigureAwait(false);
@@ -229,7 +229,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
         public async Task<AuthenticationResult> AcquireTokenSilentAsync(string resource, string clientId,
             UserIdentifier userId)
         {
@@ -244,7 +244,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
         /// <param name="parameters">Instance of PlatformParameters containing platform specific arguments and information.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
         public async Task<AuthenticationResult> AcquireTokenSilentAsync(string resource, string clientId,
             UserIdentifier userId, IPlatformParameters parameters)
         {
@@ -301,7 +301,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
         /// <param name="parameters">An object of type PlatformParameters which may pass additional parameters used for authorization.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public async Task<AuthenticationResult> AcquireTokenAsync(string resource, string clientId, Uri redirectUri,
             IPlatformParameters parameters)
         {
@@ -319,7 +319,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="parameters">An object of type PlatformParameters which may pass additional parameters used for authorization.</param>
         /// <param name="userId">Identifier of the user token is requested for. If created from DisplayableId, this parameter will be used to pre-populate the username field in the authentication form. Please note that the end user can still edit the username field and authenticate as a different user.
         /// If you want to be notified of such change with an exception, create UserIdentifier with type RequiredDisplayableId. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public async Task<AuthenticationResult> AcquireTokenAsync(string resource, string clientId, Uri redirectUri,
             IPlatformParameters parameters, UserIdentifier userId)
         {
@@ -337,7 +337,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// If you want to be notified of such change with an exception, create UserIdentifier with type RequiredDisplayableId. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
         /// <param name="parameters">Parameters needed for interactive flow requesting authorization code. Pass an instance of PlatformParameters.</param>
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public async Task<AuthenticationResult> AcquireTokenAsync(string resource, string clientId, Uri redirectUri,
             IPlatformParameters parameters, UserIdentifier userId, string extraQueryParameters)
         {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -145,7 +145,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
-        /// <returns>It contains Access Token, its expiration time, user information.</returns>
+        /// <returns>It contains Device Code, its expiration time, User Code.</returns>
         public async Task<DeviceCodeResult> AcquireDeviceCodeAsync(string resource, string clientId)
         {
             return await this.AcquireDeviceCodeAsync(resource, clientId, null).ConfigureAwait(false);
@@ -157,7 +157,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
-        /// <returns>It contains Access Token, its expiration time, user information.</returns>
+        /// <returns>It contains Device Code, its expiration time, User Code.</returns>
         public async Task<DeviceCodeResult> AcquireDeviceCodeAsync(string resource, string clientId,
             string extraQueryParameters)
         {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
@@ -47,7 +47,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCredential">The client credential to use for token acquisition.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
         public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx, string resource,
             ClientCredential clientCredential, UserIdentifier userId)
         {
@@ -62,7 +62,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
         public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx, string resource,
             IClientAssertionCertificate clientCertificate, UserIdentifier userId)
         {
@@ -77,7 +77,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
         public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx, string resource,
             ClientAssertion clientAssertion, UserIdentifier userId)
         {
@@ -93,7 +93,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
         /// <param name="clientCredential">The credential to use for token acquisition.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, ClientCredential clientCredential)
         {
@@ -111,7 +111,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
         /// <param name="clientCredential">The credential to use for token acquisition.</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, ClientCredential clientCredential, string resource)
         {
@@ -128,7 +128,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, ClientAssertion clientAssertion)
         {
@@ -146,7 +146,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, ClientAssertion clientAssertion, string resource)
         {
@@ -163,7 +163,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, IClientAssertionCertificate clientCertificate)
         {
@@ -180,7 +180,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, IClientAssertionCertificate clientCertificate, string resource)
         {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextIntegratedAuthExtensions.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextIntegratedAuthExtensions.cs
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="userCredential">The user credential to use for token acquisition.</param>
-        /// <returns>It contains Access Token, Refresh Token and the Access Token's expiration time.</returns>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
         public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, string clientId, UserCredential userCredential)
         {
             return await ctx.AcquireTokenCommonAsync(resource, clientId, userCredential).ConfigureAwait(false);

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/UserPasswordCredential.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/UserPasswordCredential.cs
@@ -37,7 +37,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     public sealed class UserPasswordCredential : UserCredential
     {
         /// <summary>
-        /// Constructor to create credential with client id and secret
+        /// Constructor to create credential with username and password
         /// </summary>
         /// <param name="userName">Identifier of the user application requests token on behalf.</param>
         /// <param name="password">User password.</param>
@@ -47,7 +47,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         /// <summary>
-        /// Constructor to create credential with client id and secret
+        /// Constructor to create credential with username and password
         /// </summary>
         /// <param name="userName">Identifier of the user application requests token on behalf.</param>
         /// <param name="securePassword">User password.</param>

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/UserAssertion.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/UserAssertion.cs
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         /// <summary>
-        /// Constructor to create credential with client id, assertion and assertionType
+        /// Constructor to create credential with assertion and assertionType
         /// </summary>
         /// <param name="assertion">Assertion representing the user.</param>
         /// <param name="assertionType">Type of the assertion representing the user.</param>
@@ -54,7 +54,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         /// <summary>
-        /// Constructor to create credential with client id, assertion, assertionType and userId
+        /// Constructor to create credential with assertion, assertionType and username
         /// </summary>
         /// <param name="assertion">Assertion representing the user.</param>
         /// <param name="assertionType">Type of the assertion representing the user.</param>

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/UserCredential.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/UserCredential.cs
@@ -48,7 +48,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         /// <summary>
-        /// Constructor to create credential with client id and secret
+        /// Constructor to create credential with username
         /// </summary>
         /// <param name="userName">Identifier of the user application requests token on behalf.</param>
         public UserCredential(string userName) : this(userName, UserAuthType.IntegratedAuth)


### PR DESCRIPTION
UserPasswordCredential triple slash comment is incorrect  https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/624

ADALTrace removed; diagnostics instructions need updating https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/527

Invalid methods documentation https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/654