### PR TITLE
Enable netcore45 for nuget packaging

### DIFF
--- a/build/LayoutNugetPackage.proj
+++ b/build/LayoutNugetPackage.proj
@@ -101,7 +101,6 @@
       <TargetFolder>Xamarin.iOS10</TargetFolder>
     </SourceFile>
 
-    <!--
     <SourceFile Include="..\src\Microsoft.IdentityModel.Clients.ActiveDirectory\bin\$(Configuration)\netcore45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll">
       <TargetFolder>netcore45</TargetFolder>
     </SourceFile>
@@ -112,7 +111,6 @@
                 Condition="$(CopyXmlDocFiles)=='true'">
       <TargetFolder>netcore45</TargetFolder>
     </SourceFile>
-    -->
 
   </ItemGroup>
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/ADAL.WinRT.VS2015.csproj
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/ADAL.WinRT.VS2015.csproj
@@ -24,7 +24,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>bin\Debug\netcore45\</OutputPath>
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -33,7 +33,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>bin\Release\netcore45\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>


### PR DESCRIPTION
Current netcore45 binaries are not getting published in the nuget. This PR updates the build scripts to include the binaries correctly. per #792 