### PR TITLE
Hide GetAuthorizationRequestUrl() API from WinRT, iOS and Android

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -141,13 +141,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         //these APIs are not exposed on iOS or android
-#if !ANDROID && !iOS
-        /// <summary>
-        /// Acquires device code from the authority.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientId">Identifier of the client requesting the token.</param>
-        /// <returns>It contains Device Code, its expiration time, User Code.</returns>
+#if !ANDROID && !iOS 
+/// <summary>
+/// Acquires device code from the authority.
+/// </summary>
+/// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+/// <param name="clientId">Identifier of the client requesting the token.</param>
+/// <returns>It contains Device Code, its expiration time, User Code.</returns>
         public async Task<DeviceCodeResult> AcquireDeviceCodeAsync(string resource, string clientId)
         {
             return await this.AcquireDeviceCodeAsync(resource, clientId, null).ConfigureAwait(false);
@@ -256,48 +256,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         /// <summary>
-        /// Gets URL of the authorize endpoint including the query parameters.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientId">Identifier of the client requesting the token.</param>
-        /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
-        /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
-        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
-        /// <returns>URL of the authorize endpoint including the query parameters.</returns>
-        public async Task<Uri> GetAuthorizationRequestUrlAsync(string resource, string clientId, Uri redirectUri,
-            UserIdentifier userId, string extraQueryParameters)
-        {
-            return await GetAuthorizationRequestUrlAsync(resource, clientId, redirectUri, userId, extraQueryParameters,
-                null);
-        }
-
-        /// <summary>
-        /// Gets URL of the authorize endpoint including the query parameters.
-        /// </summary>
-        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
-        /// <param name="clientId">Identifier of the client requesting the token.</param>
-        /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
-        /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
-        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
-        /// <param name="claims">Additional claims that are needed for authentication. Acquired from the AdalClaimChallengeException. This parameter can be null.</param>
-        /// <returns>URL of the authorize endpoint including the query parameters.</returns>
-        public async Task<Uri> GetAuthorizationRequestUrlAsync(string resource, string clientId, Uri redirectUri,
-            UserIdentifier userId, string extraQueryParameters, string claims)
-        {
-            RequestData requestData = new RequestData
-            {
-                Authenticator = this.Authenticator,
-                TokenCache = this.TokenCache,
-                Resource = resource,
-                ClientKey = new ClientKey(clientId),
-                ExtendedLifeTimeEnabled = ExtendedLifeTimeEnabled
-            };
-            var handler = new AcquireTokenInteractiveHandler(requestData, redirectUri, null, userId,
-                extraQueryParameters, null, claims);
-            return await handler.CreateAuthorizationUriAsync(this.CorrelationId).ConfigureAwait(false);
-        }
-
-        /// <summary>
         /// Acquires security token from the authority.
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
@@ -346,6 +304,24 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             return await this.AcquireTokenCommonAsync(resource, clientId, redirectUri, parameters, userId,
                 extraQueryParameters).ConfigureAwait(false);
+        }
+
+
+        internal async Task<Uri> GetAuthorizationRequestUrlCommonAsync(string resource, string clientId,
+            Uri redirectUri,
+            UserIdentifier userId, string extraQueryParameters, string claims)
+        {
+            RequestData requestData = new RequestData
+            {
+                Authenticator = this.Authenticator,
+                TokenCache = this.TokenCache,
+                Resource = resource,
+                ClientKey = new ClientKey(clientId),
+                ExtendedLifeTimeEnabled = ExtendedLifeTimeEnabled
+            };
+            var handler = new AcquireTokenInteractiveHandler(requestData, redirectUri, null, userId,
+                extraQueryParameters, null, claims);
+            return await handler.CreateAuthorizationUriAsync(this.CorrelationId).ConfigureAwait(false);
         }
 
         internal async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeCommonAsync(string authorizationCode,

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextConfidentialClientExtensions.cs
@@ -38,8 +38,47 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// </summary>
     public static class AuthenticationContextConfidentialClientExtensions
     {
-
 #if !WINDOWS_APP
+
+        /// <summary>
+        /// Gets URL of the authorize endpoint including the query parameters.
+        /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientId">Identifier of the client requesting the token.</param>
+        /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
+        /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
+        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
+        /// <returns>URL of the authorize endpoint including the query parameters.</returns>
+        public static async Task<Uri> GetAuthorizationRequestUrlAsync(this AuthenticationContext ctx, string resource,
+            string clientId, Uri redirectUri,
+            UserIdentifier userId, string extraQueryParameters)
+        {
+            return await GetAuthorizationRequestUrlAsync(ctx, resource, clientId, redirectUri, userId,
+                extraQueryParameters,
+                null);
+        }
+
+        /// <summary>
+        /// Gets URL of the authorize endpoint including the query parameters.
+        /// </summary>
+        /// <param name="ctx">Authentication context instance</param>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientId">Identifier of the client requesting the token.</param>
+        /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
+        /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
+        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
+        /// <param name="claims">Additional claims that are needed for authentication. Acquired from the AdalClaimChallengeException. This parameter can be null.</param>
+        /// <returns>URL of the authorize endpoint including the query parameters.</returns>
+        public static async Task<Uri> GetAuthorizationRequestUrlAsync(this AuthenticationContext ctx, string resource,
+            string clientId, Uri redirectUri,
+            UserIdentifier userId, string extraQueryParameters, string claims)
+        {
+            return await ctx
+                .GetAuthorizationRequestUrlCommonAsync(resource, clientId, redirectUri, userId, extraQueryParameters,
+                    claims).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Acquires security token without asking for user credential.
         /// </summary>
@@ -48,7 +87,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientCredential">The client credential to use for token acquisition.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
         /// <returns>It contains Access Token, its expiration time, user information. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx, string resource,
+        public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx,
+            string resource,
             ClientCredential clientCredential, UserIdentifier userId)
         {
             return await ctx.AcquireTokenSilentCommonAsync(resource, new ClientKey(clientCredential), userId, null)
@@ -63,7 +103,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
         /// <returns>It contains Access Token, its expiration time, user information. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx, string resource,
+        public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx,
+            string resource,
             IClientAssertionCertificate clientCertificate, UserIdentifier userId)
         {
             return await ctx.AcquireTokenSilentCommonAsync(resource,
@@ -78,7 +119,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <param name="userId">Identifier of the user token is requested for. This parameter can be <see cref="UserIdentifier"/>.Any.</param>
         /// <returns>It contains Access Token, its expiration time, user information. If acquiring token without user credential is not possible, the method throws AdalException.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx, string resource,
+        public static async Task<AuthenticationResult> AcquireTokenSilentAsync(this AuthenticationContext ctx,
+            string resource,
             ClientAssertion clientAssertion, UserIdentifier userId)
         {
             return await ctx.AcquireTokenSilentCommonAsync(resource, new ClientKey(clientAssertion), userId, null)
@@ -94,7 +136,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="redirectUri">Address to return to upon receiving a response from the authority.</param>
         /// <param name="clientCredential">The credential to use for token acquisition.</param>
         /// <returns>It contains Access Token, its expiration time, user information.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(
+            this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, ClientCredential clientCredential)
         {
             return await ctx
@@ -112,7 +155,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientCredential">The credential to use for token acquisition.</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
         /// <returns>It contains Access Token, its expiration time, user information.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(
+            this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, ClientCredential clientCredential, string resource)
         {
             return await ctx
@@ -129,7 +173,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <returns>It contains Access Token, its expiration time, user information.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(
+            this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, ClientAssertion clientAssertion)
         {
             return await ctx
@@ -147,7 +192,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
         /// <returns>It contains Access Token, its expiration time, user information.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(
+            this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, ClientAssertion clientAssertion, string resource)
         {
             return await ctx
@@ -164,7 +210,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
         /// <returns>It contains Access Token, its expiration time, user information.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(
+            this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, IClientAssertionCertificate clientCertificate)
         {
             return await ctx.AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
@@ -181,7 +228,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
         /// <returns>It contains Access Token, its expiration time, user information.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(this AuthenticationContext ctx, string authorizationCode,
+        public static async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(
+            this AuthenticationContext ctx, string authorizationCode,
             Uri redirectUri, IClientAssertionCertificate clientCertificate, string resource)
         {
             return await ctx.AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
@@ -196,7 +244,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientCredential">The client credential to use for token acquisition.</param>
         /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, ClientCredential clientCredential,
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx,
+            string resource, ClientCredential clientCredential,
             UserAssertion userAssertion)
         {
             return await ctx.AcquireTokenOnBehalfCommonAsync(resource, new ClientKey(clientCredential), userAssertion)
@@ -212,7 +261,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
         /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource,
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx,
+            string resource,
             IClientAssertionCertificate clientCertificate, UserAssertion userAssertion)
         {
             return await ctx
@@ -228,7 +278,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <param name="userAssertion">The user assertion (token) to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, ClientAssertion clientAssertion,
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx,
+            string resource, ClientAssertion clientAssertion,
             UserAssertion userAssertion)
         {
             return await ctx.AcquireTokenOnBehalfCommonAsync(resource, new ClientKey(clientAssertion), userAssertion)
@@ -244,12 +295,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="userAssertion">The assertion to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, string clientId,
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx,
+            string resource, string clientId,
             UserAssertion userAssertion)
         {
             return await ctx.AcquireTokenCommonAsync(resource, clientId, userAssertion).ConfigureAwait(false);
         }
-        
+
         /// <summary>
         /// Acquires security token from the authority.
         /// </summary>
@@ -257,7 +309,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource,
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx,
+            string resource,
             IClientAssertionCertificate clientCertificate)
         {
             return await ctx
@@ -272,7 +325,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, ClientAssertion clientAssertion)
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx,
+            string resource, ClientAssertion clientAssertion)
         {
             return await ctx.AcquireTokenForClientCommonAsync(resource, new ClientKey(clientAssertion))
                 .ConfigureAwait(false);
@@ -286,7 +340,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCredential">The client credential to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, ClientCredential clientCredential)
+        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx,
+            string resource, ClientCredential clientCredential)
         {
             return await ctx.AcquireTokenForClientCommonAsync(resource, new ClientKey(clientCredential))
                 .ConfigureAwait(false);

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/EncodingHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/EncodingHelper.cs
@@ -107,6 +107,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="delimiter">Character used as a delimiter between key-value pairs</param>
         /// <param name="urlDecode">True to perform URL decoding of both the keys and values</param>
         /// <param name="lowercaseKeys">True to make all resulting keys lower-case</param>
+        /// <param name="callState">call state to pass correlation id and logger instance</param>
         /// <returns>Dictionary of string key-value pairs</returns>
         public static Dictionary<string, string> ParseKeyValueList(string input, char delimiter, bool urlDecode, bool lowercaseKeys,
             CallState callState)
@@ -121,6 +122,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="delimiter">Character used as a delimiter between key-value pairs</param>
         /// <param name="urlDecode">True to perform URL decoding of both the keys and values</param>
         /// <param name="lowercaseKeys">True to make all resulting keys lower-case</param>
+        /// <param name="callState">call state to pass correlation id and logger instance</param>
         /// <exception cref="ArgumentException">Thrown if a malformed key-value pair is present in <paramref name="input"/></exception>
         /// <returns>Dictionary of string key-value pairs</returns>
         public static Dictionary<string, string> ParseKeyValueListStrict(string input, char delimiter, bool urlDecode, bool lowercaseKeys,
@@ -136,6 +138,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="delimiter">Character used as a delimiter between key-value pairs</param>
         /// <param name="urlDecode">True to perform URL decoding of both the keys and values</param>
         /// <param name="lowercaseKeys">True to make all resulting keys lower-case</param>
+        /// <param name="callState">call state to pass correlation id and logger instance</param>
         /// <param name="strict">Throw <see cref="ArgumentException"/> when the input string contains a malformed key-value pair</param>
         /// <exception cref="ArgumentException">Thrown if <paramref name="strict"/> is true and a malformed key-value pair is present in <paramref name="input"/></exception>
         /// <returns>Dictionary of string key-value pairs</returns>
@@ -191,6 +194,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="input">Delimited string of key-value pairs</param>
         /// <param name="delimiter">Character used as a delimiter between key-value pairs</param>
         /// <param name="urlDecode">True to perform URL decoding of both the keys and values</param>
+        /// <param name="callState">call state to pass correlation id and logger instance</param>
         /// <remarks>Keys are forced to lower-cased</remarks>
         /// <returns>Dictionary of string key-value pairs</returns>
         public static Dictionary<string, string> ParseKeyValueList(string input, char delimiter, bool urlDecode, CallState callState)


### PR DESCRIPTION
Hide GetAuthorizationRequestUrl() API from WinRT, iOS and Android as this API is only relevant for confidential client use in net45 and net core., per #808 