### PR TITLE
disable sovereign cloud feature

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationResult.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationResult.cs
@@ -122,6 +122,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public string IdToken { get; internal set; }
 
         /// <summary>
+        /// Gets the authority which has issued tokens.
+        /// </summary>
+        internal string Authority { get; set; }
+
+        /// <summary>
         /// Creates authorization header from authentication result.
         /// </summary>
         /// <returns>Created authorization header</returns>
@@ -139,9 +144,5 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 this.UserInfo = new UserInfo(userInfo);
             }
         }
-        /// <summary>
-        /// Gets the authority which has issued tokens.
-        /// </summary>
-        public string Authority { get; internal set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenByAuthorizationCodeHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenByAuthorizationCodeHandler.cs
@@ -70,9 +70,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             requestParameters[OAuthParameter.RedirectUri] = this.redirectUri.OriginalString;
         }
 
-        protected override async Task PostTokenRequest(AuthenticationResultEx resultEx)
+        protected override void PostTokenRequest(AuthenticationResultEx resultEx)
         {
-            await base.PostTokenRequest(resultEx).ConfigureAwait(false);
+            base.PostTokenRequest(resultEx);
             UserInfo userInfo = resultEx.Result.UserInfo;
             this.UniqueId = (userInfo == null) ? null : userInfo.UniqueId;
             this.DisplayableId = (userInfo == null) ? null : userInfo.DisplayableId;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -169,10 +169,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                         throw ResultEx.Exception;
                     }
 
-                    await this.PostTokenRequest(ResultEx).ConfigureAwait(false);
-
+                    this.PostTokenRequest(ResultEx);
                     StoreResultExToCache(ref notifiedBeforeAccessCache);
                 }
+
                 await this.PostRunAsync(ResultEx.Result).ConfigureAwait(false);
                 return ResultEx.Result;
             }
@@ -255,27 +255,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             return CompletedTask;
         }
-
-        protected async Task UpdateAuthority(string updatedAuthority)
+        
+        protected virtual void PostTokenRequest(AuthenticationResultEx result)
         {
-            if (!Authenticator.Authority.Equals(updatedAuthority))
-            {
-                await Authenticator.UpdateAuthority(updatedAuthority, this.CallState).ConfigureAwait(false);
-                this.ValidateAuthorityType();
-            }
-        }
-
-        protected virtual async Task PostTokenRequest(AuthenticationResultEx resultEx)
-        {
-            // if broker returned Authority update Authenticator
-            if (!string.IsNullOrEmpty(resultEx.Result.Authority)) 
-            {
-                await UpdateAuthority(resultEx.Result.Authority).ConfigureAwait(false);
-            }
-
-            this.Authenticator.UpdateTenantId(resultEx.Result.TenantId);
-
-            resultEx.Result.Authority = Authenticator.Authority;
+            this.Authenticator.UpdateTenantId(result.Result.TenantId);
         }
 
         protected abstract void AddAditionalRequestParameters(DictionaryRequestParameters requestParameters);

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenInteractiveHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenInteractiveHandler.cs
@@ -126,12 +126,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             await this.AcquireAuthorizationAsync().ConfigureAwait(false);
             this.VerifyAuthorizationResult();
 
-            if (!string.IsNullOrEmpty(authorizationResult.CloudInstanceHost))
+            //this code is commented out to disable sovereign cloud flow
+/*            if (!string.IsNullOrEmpty(authorizationResult.CloudInstanceHost))
             {
                 var updatedAuthority = ReplaceHost(Authenticator.Authority, authorizationResult.CloudInstanceHost);
 
                 await UpdateAuthority(updatedAuthority).ConfigureAwait(false);
-            }
+            }*/
         }
 
         internal async Task AcquireAuthorizationAsync()

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenInteractiveHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenInteractiveHandler.cs
@@ -113,11 +113,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             brokerHelper.PlatformParameters = authorizationParameters;
         }
 
-        private static string ReplaceHost(string original, string newHost)
-        {
-            return new UriBuilder(original) {Host = newHost}.Uri.ToString();
-        }
-
         protected override async Task PreTokenRequest()
         {
             await base.PreTokenRequest().ConfigureAwait(false);
@@ -125,14 +120,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             // We do not have async interactive API in .NET, so we call this synchronous method instead.
             await this.AcquireAuthorizationAsync().ConfigureAwait(false);
             this.VerifyAuthorizationResult();
-
-            //this code is commented out to disable sovereign cloud flow
-/*            if (!string.IsNullOrEmpty(authorizationResult.CloudInstanceHost))
-            {
-                var updatedAuthority = ReplaceHost(Authenticator.Authority, authorizationResult.CloudInstanceHost);
-
-                await UpdateAuthority(updatedAuthority).ConfigureAwait(false);
-            }*/
         }
 
         internal async Task AcquireAuthorizationAsync()

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenInteractiveHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenInteractiveHandler.cs
@@ -141,9 +141,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             requestParameters[OAuthParameter.RedirectUri] = this.redirectUriRequestParameter;
         }
 
-        protected override async Task PostTokenRequest(AuthenticationResultEx resultEx)
+        protected override void PostTokenRequest(AuthenticationResultEx resultEx)
         {
-            await base.PostTokenRequest(resultEx).ConfigureAwait(false);
+            base.PostTokenRequest(resultEx);
             if ((this.DisplayableId == null && this.UniqueId == null) || this.UserIdentifierType == UserIdentifierType.OptionalDisplayableId)
             {
                 return;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Instance/TokenResponse.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Instance/TokenResponse.cs
@@ -118,7 +118,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
             return new TokenResponse
             {
-                Authority = responseDictionary.ContainsKey("authority") ? EncodingHelper.UrlDecode(responseDictionary["authority"]) : null,
+                //Authority = responseDictionary.ContainsKey("authority") ? EncodingHelper.UrlDecode(responseDictionary["authority"]) : null,
                 AccessToken = responseDictionary["access_token"],
                 RefreshToken = responseDictionary["refresh_token"],
                 IdTokenString = responseDictionary["id_token"],

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerHelper.cs
@@ -195,7 +195,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             {
                 var tokenResponse = new TokenResponse
                 {
-                    Authority = data.GetStringExtra(BrokerConstants.AccountAuthority),
+                   // Authority = data.GetStringExtra(BrokerConstants.AccountAuthority),
                     AccessToken = data.GetStringExtra(BrokerConstants.AccountAccessToken),
                     IdTokenString = data.GetStringExtra(BrokerConstants.AccountIdToken),
                     TokenType = "Bearer",

--- a/tests/Test.ADAL.NET.Integration/DeviceProfileTests.cs
+++ b/tests/Test.ADAL.NET.Integration/DeviceProfileTests.cs
@@ -104,7 +104,7 @@ namespace Test.ADAL.NET.Unit
             mockMessageHandler = new MockHttpMessageHandler()
             {
                 Method = HttpMethod.Post,
-                Url = "https://login.microsoftonline.com/home/oauth2/token",
+                Url = TestConstants.DefaultAuthorityHomeTenant + "oauth2/token",
                 ResponseMessage = MockHelpers.CreateFailureResponseMessage("{\"error\":\"authorization_pending\"," +
                                                                "\"error_description\":\"AADSTS70016: Pending end-user authorization." +
                                                                "\\r\\nTrace ID: f6c2c73f-a21d-474e-a71f-d8b121a58205\\r\\nCorrelation ID: " +
@@ -118,7 +118,7 @@ namespace Test.ADAL.NET.Unit
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
             {
                 Method = HttpMethod.Post,
-                Url = "https://login.microsoftonline.com/home/oauth2/token",
+                Url = TestConstants.DefaultAuthorityHomeTenant + "oauth2/token",
                 ResponseMessage =
                     MockHelpers.CreateSuccessTokenResponseMessage(TestConstants.DefaultUniqueId,
                         TestConstants.DefaultDisplayableId, TestConstants.DefaultResource)

--- a/tests/Test.ADAL.NET.Integration/SovereignCloudsTests.cs
+++ b/tests/Test.ADAL.NET.Integration/SovereignCloudsTests.cs
@@ -21,7 +21,7 @@ namespace Test.ADAL.NET.Unit
             platformParameters = new PlatformParameters(PromptBehavior.Auto);
         }
 
-        [TestMethod]
+/*        [TestMethod]
         [Description("Sovereign user use world wide authority")]
         public async Task SovereignUserWorldWideAuthorityIntegrationTest()
         {
@@ -70,6 +70,6 @@ namespace Test.ADAL.NET.Unit
             Assert.AreEqual(1, authenticationContext.TokenCache.tokenCacheDictionary.Count);
             Assert.AreEqual(sovereignTenantSpesificAuthority,
                 authenticationContext.TokenCache.tokenCacheDictionary.Keys.FirstOrDefault().Authority);
-        }
+        }*/
     }
 }

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
@@ -63,6 +63,16 @@ namespace Test.ADAL.NET.Unit.Mocks
             return responseMessage;
         }
 
+        public static HttpResponseMessage CreateSuccessDeviceCodeResponseMessage()
+        {
+            HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
+
+            HttpContent content = new StringContent(
+                "{\"user_code\":\"some-user-code\",\"device_code\":\"some-device-code\",\"verification_url\":\"some-URL\",\"expires_in\":\"900\",\"interval\":\"5\",\"message\":\"some-message\"}");
+            responseMessage.Content = content;
+            return responseMessage;
+        }
+
         public static HttpResponseMessage CreateInvalidRequestTokenResponseMessage()
         {
             return

--- a/tests/Test.ADAL.NET.Unit/UnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/UnitTests.cs
@@ -45,7 +45,6 @@ namespace Test.ADAL.NET.Unit
     [TestClass]
     [DeploymentItem("valid_cert.pfx")]
     [DeploymentItem("valid_cert2.pfx")]
-    [DeploymentItem("Microsoft.Owin.Host.HttpListener.dll")]
     public class UnitTests
     {
         private const string ComplexString = "asdfk+j0a-=skjwe43;1l234 1#$!$#%345903485qrq@#$!@#$!(rekr341!#$%Ekfaآزمايشsdsdfsddfdgsfgjsglk==CVADS";


### PR DESCRIPTION
disable sovereign cloud feature for 3.17.0 because some services are not ready for a full end to end validation.