### PR TITLE
Authority Migration: TokenCache read/write changes

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -142,7 +142,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     {
                         CacheQueryData.Authority = ReplaceHost(this.Authenticator.Authority, aliasedAuthority);
                         ResultEx = this.tokenCache.LoadFromCache(CacheQueryData, this.CallState);
-                        if (ResultEx?.Result != null) {break;} //NOSONAR
+                        if (ResultEx?.Result != null) //NOSONAR
+                        {
+                            break;
+                        }
                     }
 
                     extendedLifetimeResultEx = ResultEx;
@@ -242,9 +245,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return uri.Split('/')[2];
         }
 
-        private string ReplaceHost(string oldUri, string newHost)
+        private static string ReplaceHost(string oldUri, string newHost)
         {
-            if (string.IsNullOrEmpty(oldUri) || string.IsNullOrEmpty(newHost)) {throw new ArgumentNullException();}
+            if (string.IsNullOrEmpty(oldUri) || string.IsNullOrEmpty(newHost))
+            {
+                throw new ArgumentNullException();
+            }
             return $"https://{newHost}{new Uri(oldUri).AbsolutePath}";
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -234,13 +234,17 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         private string GetHost(string uri)
         {
-            // Note: host is supposed to be case insensitive, but we would like to preserve its case to match a previously cached token
+            // The following line serves as a validation for uri. Relevant exceptions will be throwed.
+            new Uri(uri); //NOSONAR
+
+            // Note: host is supposed to be case insensitive, and would be normalized to lowercase by: new Uri(uri).Host
+            // but we would like to preserve its case to match a previously cached token
             return uri.Split('/')[2];
-            // return new Uri(uri).Host; // This canonical implementation normalizes the host into lower case
         }
 
         private string ReplaceHost(string oldUri, string newHost)
         {
+            if (string.IsNullOrEmpty(oldUri) || string.IsNullOrEmpty(newHost)) {throw new ArgumentNullException();}
             return $"https://{newHost}{new Uri(oldUri).AbsolutePath}";
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -137,7 +137,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     notifiedBeforeAccessCache = true;
 
                     var aliasedAuthorities = await GetOrderedAliases(
-                        GetHostCaseSensitive(this.Authenticator.Authority), this.Authenticator.ValidateAuthority, this.CallState).ConfigureAwait(false);
+                        GetHost(this.Authenticator.Authority), this.Authenticator.ValidateAuthority, this.CallState).ConfigureAwait(false);
                     foreach (var aliasedAuthority in aliasedAuthorities)
                     {
                         CacheQueryData.Authority = ReplaceHost(this.Authenticator.Authority, aliasedAuthority);
@@ -224,7 +224,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     notifiedBeforeAccessCache = true;
                 }
                 var metadata = await InstanceDiscovery.GetMetadataEntry(
-                    GetHostCaseSensitive(this.Authenticator.Authority), this.Authenticator.ValidateAuthority, this.CallState).ConfigureAwait(false);
+                    GetHost(this.Authenticator.Authority), this.Authenticator.ValidateAuthority, this.CallState).ConfigureAwait(false);
                 this.tokenCache.StoreToCache(
                     ResultEx, ReplaceHost(this.Authenticator.Authority, metadata.PreferredCache), this.Resource,
                     this.ClientKey.ClientId, this.TokenSubjectType, this.CallState);
@@ -232,11 +232,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return notifiedBeforeAccessCache;
         }
 
-        // Note: host is supposed to be case insensitive, but we would like to preserve its case to match a previously cached token
-        private string GetHostCaseSensitive(string uri)
+        private string GetHost(string uri)
         {
-            // return new Uri(uri).Host; // This canonical implementation normalizes the host into lower case
+            // Note: host is supposed to be case insensitive, but we would like to preserve its case to match a previously cached token
             return uri.Split('/')[2];
+            // return new Uri(uri).Host; // This canonical implementation normalizes the host into lower case
         }
 
         private string ReplaceHost(string oldUri, string newHost)

--- a/tests/Test.ADAL.NET.Unit/InstanceDiscoveryTests.cs
+++ b/tests/Test.ADAL.NET.Unit/InstanceDiscoveryTests.cs
@@ -165,5 +165,21 @@ namespace Test.ADAL.NET.Unit
             await authenticator.UpdateFromTemplateAsync(new CallState(Guid.NewGuid()));
             Assert.AreEqual(1, HttpMessageHandlerFactory.MockHandlersCount()); // mock is NOT consumed, so no new request was NOT attempted
         }
+
+        public async Task TestGetOrderedAliases_ShouldStartWithPreferredCacheAndGivenHost()
+        {
+            string givenHost = "sts.microsoft.com";
+            string preferredCache = "login.windows.net";
+            InstanceDiscovery.InstanceCache.TryAdd(givenHost, new InstanceDiscoveryMetadataEntry
+            {
+                PreferredNetwork = "login.microsoftonline.com",
+                PreferredCache = preferredCache,
+                Aliases = new string[] { "login.microsoftonline.com", "login.windows.net", "sts.microsoft.com" }
+            });
+            var orderedList = await AcquireTokenHandlerBase.GetOrderedAliases(givenHost, false, new CallState(Guid.NewGuid()));
+            CollectionAssert.AreEqual(
+                new string[] { preferredCache, givenHost, "login.microsoftonline.com", "login.windows.net", "sts.microsoft.com" },
+                orderedList);
+        }
     }
 }


### PR DESCRIPTION
* Use the preferred_cache, given host, and aliases from the Authority validation cache to look up tokens in the token cache
* Use the preferred_cache when writing tokens into cache

~PS: This PR is now ready for review, but please do NOT merge this PR yet. Because it is based on a [previous PR](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/796/files) which has not yet been merged as of today. I'll need to change the base branch later.~