### PR TITLE
fixes for Android and IOS platforms

### DIFF
--- a/devApps/XFormsApp/SecondPage.cs
+++ b/devApps/XFormsApp/SecondPage.cs
@@ -29,6 +29,7 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using System;
 using System.Text;
 using Xamarin.Forms;
+using Xamarin.Forms.PlatformConfiguration;
 
 namespace XFormsApp
 {
@@ -53,7 +54,6 @@ namespace XFormsApp
     public class SecondPage : ContentPage
     {
         private Label result;
-        private Label logLabel;
         private AdalCallback callback = new AdalCallback();
         public SecondPage()
         {
@@ -77,9 +77,22 @@ namespace XFormsApp
                 Text = "Clear Cache"
             };
 
-            result = new Label { };
-            logLabel = new Label
+            result = new Label()
             {
+                VerticalOptions = LayoutOptions.FillAndExpand
+            };
+
+            var scrollView = new ScrollView()
+            {
+                VerticalOptions = LayoutOptions.FillAndExpand,
+                Content = new StackLayout()
+                {
+                    VerticalOptions = LayoutOptions.FillAndExpand,
+                    Children =
+                    {
+                        result
+                    }
+                }
             };
 
             acquireTokenButton.Clicked += browseButton_Clicked;
@@ -87,16 +100,27 @@ namespace XFormsApp
             conditionalAccessButton.Clicked += conditionalAccessButton_Clicked;
             clearButton.Clicked += clearButton_Clicked;
 
+            Thickness padding;
+            switch (Device.RuntimePlatform)
+            {
+                case Device.iOS:
+                    padding = new Thickness(0, 40, 0, 0);
+                    break;
+                default:
+                    padding = new Thickness(0, 0, 0, 0);
+                    break;
+            }
+
             Content = new StackLayout
             {
-                VerticalOptions = LayoutOptions.Center,
+                Padding = padding,
+                VerticalOptions = LayoutOptions.FillAndExpand,
                 Children = {
                     acquireTokenButton,
                     acquireTokenSilentButton,
                     conditionalAccessButton,
                     clearButton,
-                    result,
-                    logLabel
+                    scrollView
                 }
             };
 
@@ -121,8 +145,9 @@ namespace XFormsApp
             {
                 Device.BeginInvokeOnMainThread(() =>
                 {
-                    this.logLabel.Text = callback.DrainLogs();
-                    this.result.Text = output;
+                    this.result.Text += "Result : " + output;
+
+                    this.result.Text += "Logs : " + callback.DrainLogs();
                 });
             }
 
@@ -152,8 +177,9 @@ namespace XFormsApp
             {
                 Device.BeginInvokeOnMainThread(() =>
                 {
-                    this.logLabel.Text = callback.DrainLogs();
-                    this.result.Text = output;
+                    this.result.Text += "Result : " + output;
+
+                    this.result.Text += "Logs : " + callback.DrainLogs();
                 });
             }
 
@@ -182,8 +208,9 @@ namespace XFormsApp
             {
                 Device.BeginInvokeOnMainThread(() =>
                 {
-                    this.logLabel.Text = callback.DrainLogs();
-                    this.result.Text = output;
+                    this.result.Text += "Result : " + output;
+
+                    this.result.Text += "Logs : " + callback.DrainLogs();
                 });
             }
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerHelper.cs
@@ -59,7 +59,14 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return false;
         }
 
-        public bool CanInvokeBroker { get { return WillUseBroker() && mBrokerProxy.CanSwitchToBroker(); } }
+        public bool CanInvokeBroker
+        {
+            get
+            {
+                mBrokerProxy.CallState = CallState;
+                return WillUseBroker() && mBrokerProxy.CanSwitchToBroker();
+            }
+        }
 
 
         public async Task<AuthenticationResultEx> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerProxy.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerProxy.cs
@@ -104,6 +104,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         private bool VerifyManifestPermission(string permission)
         {
+
             if (Permission.Granted !=
                 Application.Context.PackageManager.CheckPermission(permission, Application.Context.PackageName))
             {
@@ -466,39 +467,32 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     Account[] accountList = mAcctManager
                         .GetAccountsByType(BrokerConstants.BrokerAccountType);
 
-                    // Authenticator installed from Company portal
-                    // This supports only one account
+                    string packageName;
+
                     if (authenticator.PackageName
-                        .Equals(BrokerConstants.PackageName, StringComparison.OrdinalIgnoreCase))
-                    {
-                        // Adal should not connect if given username does not match
-                        if (accountList != null && accountList.Length > 0)
-                        {
-                            return VerifyAccount(accountList, username, uniqueId);
-                        }
-
-                        return false;
-
-                        // Check azure authenticator and allow calls for test
-                        // versions
+                        .Equals(BrokerConstants.AzureAuthenticatorAppPackageName, StringComparison.OrdinalIgnoreCase){
+                        packageName = BrokerConstants.AzureAuthenticatorAppPackageName;
                     }
                     else if (authenticator.PackageName
-                        .Equals(BrokerConstants.AzureAuthenticatorAppPackageName, StringComparison.OrdinalIgnoreCase)
-                             || authenticator.PackageName
-                                 .Equals(BrokerConstants.PackageName, StringComparison.OrdinalIgnoreCase))
+                        .Equals(BrokerConstants.PackageName, StringComparison.OrdinalIgnoreCase){
+                        packageName = BrokerConstants.PackageName;
+                    }
+                    else
                     {
-                        // Existing broker logic only connects to broker for token
-                        // requests if account exists. New version can allow to
-                        // add accounts through Adal.
-                        if (HasSupportToAddUserThroughBroker())
-                        {
-                            CallState.Logger.Verbose(null, "Broker supports to add user through app");
-                            return true;
-                        }
-                        else if (accountList != null && accountList.Length > 0)
-                        {
-                            return VerifyAccount(accountList, username, uniqueId);
-                        }
+                        return false;
+                    }
+
+                    // Existing broker logic only connects to broker for token
+                    // requests if account exists. New version can allow to
+                    // add accounts through Adal.
+                    if (HasSupportToAddUserThroughBroker(packageName))
+                    {
+                        CallState.Logger.Verbose(null, "Broker supports to add user through app");
+                        return true;
+                    }
+                    else if (accountList != null && accountList.Length > 0)
+                    {
+                        return VerifyAccount(accountList, username, uniqueId);
                     }
                 }
             }
@@ -539,13 +533,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return true;
         }
 
-        private bool HasSupportToAddUserThroughBroker()
+        private bool HasSupportToAddUserThroughBroker(string packageName)
         {
             Intent intent = new Intent();
-            intent.SetPackage(BrokerConstants.AzureAuthenticatorAppPackageName);
-            intent.SetClassName(BrokerConstants.AzureAuthenticatorAppPackageName,
-                BrokerConstants.AzureAuthenticatorAppPackageName
-                + ".ui.AccountChooserActivity");
+            intent.SetPackage(packageName);
+            intent.SetClassName(packageName, packageName + ".ui.AccountChooserActivity");
+
             PackageManager packageManager = mContext.PackageManager;
             IList<ResolveInfo> infos = packageManager.QueryIntentActivities(intent, 0);
             return infos.Count > 0;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/BrokerHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/BrokerHelper.cs
@@ -115,8 +115,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
 
             await brokerResponseReady.WaitAsync().ConfigureAwait(false);
-            PlatformParameters pp = PlatformParameters as PlatformParameters;
-            pp.CallerViewController = null;
             PlatformParameters = null;
             return ProcessBrokerResponse();
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/PlatformParameters.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/PlatformParameters.cs
@@ -79,7 +79,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Caller UIViewController
         /// </summary>
-        public UIViewController CallerViewController { get; internal set; }
+        public UIViewController CallerViewController { get; private set; }
 
         /// <summary>
         /// Skips calling to broker if broker is present. false, by default

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
@@ -52,7 +52,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             Authenticate(authorizationUri, redirectUri, callState);
             await returnedUriReady.WaitAsync().ConfigureAwait(false);
 
-            this.parameters.CallerViewController = null;
             this.parameters = null;
             return authorizationResult;
         }
@@ -82,7 +81,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
             catch (Exception ex)
             {
-                this.parameters.CallerViewController = null;
                 this.parameters = null;
                 throw new AdalException(AdalError.AuthenticationUiFailed, ex);
             }


### PR DESCRIPTION
- adding scrollable log section to XFormsApp
- adding padding to IOS XFormsApp to keep all ui elements visible
- fixing CallerViewController Null pointer exception for IOS platform
last fix is related to recent fix for "memory leaks on IOS"
Since PlatformParameter instance might an probably should be used across few AcquireToken calls, and because AcquireToken methods do not  own it (PlatformParameter created and owned by outer to AcquireToken method code )  It should not be changed inside  AcquireToken calls 
- fix for null pointer exception on Android while calling CanSwitchToBroker
- fix for applying SupportToAddUserThroughBroker logic to Company Portal broker