### PR TITLE
Created one negative test for acquiring token using device code where…

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/DeviceCode/AcquireTokenByDeviceCodeHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/DeviceCode/AcquireTokenByDeviceCodeHandler.cs
@@ -47,6 +47,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             TimeSpan timeRemaining = deviceCodeResult.ExpiresOn - DateTimeOffset.UtcNow;
             AuthenticationResultEx resultEx = null;
+            //the interval is added so that the while loop does not end before aquiring the last response from the STS stating that the code has expired.
+            //Without it, resultEx will end up being null.
             while (timeRemaining.TotalSeconds + deviceCodeResult.Interval > 0)
             {
                 try

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/DeviceCode/AcquireTokenByDeviceCodeHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/DeviceCode/AcquireTokenByDeviceCodeHandler.cs
@@ -66,6 +66,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 timeRemaining = deviceCodeResult.ExpiresOn - DateTimeOffset.UtcNow;
             }
 
+            if (resultEx == null)
+            {
+                //Get the error message from the STS after the device code has expired
+                resultEx = await base.SendTokenRequestAsync().ConfigureAwait(false);
+            }
+
             return resultEx;
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/DeviceCode/AcquireTokenByDeviceCodeHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/DeviceCode/AcquireTokenByDeviceCodeHandler.cs
@@ -47,7 +47,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             TimeSpan timeRemaining = deviceCodeResult.ExpiresOn - DateTimeOffset.UtcNow;
             AuthenticationResultEx resultEx = null;
-            while (timeRemaining.TotalSeconds > 0)
+            while (timeRemaining.TotalSeconds + deviceCodeResult.Interval > 0)
             {
                 try
                 {
@@ -64,12 +64,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
                 await Task.Delay(TimeSpan.FromSeconds(deviceCodeResult.Interval)).ConfigureAwait(false);
                 timeRemaining = deviceCodeResult.ExpiresOn - DateTimeOffset.UtcNow;
-            }
-
-            if (resultEx == null)
-            {
-                //Get the error message from the STS after the device code has expired
-                resultEx = await base.SendTokenRequestAsync().ConfigureAwait(false);
             }
 
             return resultEx;

--- a/tests/Test.ADAL.NET.Integration/DeviceProfileTests.cs
+++ b/tests/Test.ADAL.NET.Integration/DeviceProfileTests.cs
@@ -31,6 +31,7 @@ using System.Threading.Tasks;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Test.ADAL.NET.Unit.Mocks;
+using Test.ADAL.Common;
 
 namespace Test.ADAL.NET.Unit
 {
@@ -143,5 +144,69 @@ namespace Test.ADAL.NET.Unit
             Assert.AreEqual("some-access-token", result.AccessToken);
         }
 
+        [TestMethod]
+        public void NegativeDeviceCodeTest()
+        {
+            MockHttpMessageHandler mockMessageHandler = new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Get,
+                Url = TestConstants.DefaultAuthorityHomeTenant + "oauth2/devicecode",
+                ResponseMessage = MockHelpers.CreateDeviceCodeErrorResponse()
+            };
+
+            HttpMessageHandlerFactory.AddMockHandler(mockMessageHandler);
+
+            TokenCache cache = new TokenCache();
+            AuthenticationContext ctx = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, cache);
+            DeviceCodeResult dcr;
+            AdalServiceException ex = AssertException.TaskThrows<AdalServiceException>(async () => dcr = await ctx.AcquireDeviceCodeAsync("some-resource", "some-client"));
+            Assert.IsTrue(ex.Message.Contains("some error message"));
+        }
+
+
+        [TestMethod]
+        public async Task NegativeDeviceCodeTimeoutTest()
+        {
+            MockHttpMessageHandler mockMessageHandler = new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Get,
+                Url = TestConstants.DefaultAuthorityHomeTenant + "oauth2/devicecode",
+                ResponseMessage = MockHelpers.CreateSuccessDeviceCodeResponseMessage("1")
+            };
+
+            HttpMessageHandlerFactory.AddMockHandler(mockMessageHandler);
+
+            mockMessageHandler = new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                Url = TestConstants.DefaultAuthorityHomeTenant + "oauth2/token",
+                ResponseMessage = MockHelpers.CreateFailureResponseMessage("{\"error\":\"authorization_pending\"," +
+                                                               "\"error_description\":\"AADSTS70016: Pending end-user authorization." +
+                                                               "\\r\\nTrace ID: f6c2c73f-a21d-474e-a71f-d8b121a58205\\r\\nCorrelation ID: " +
+                                                               "36fe3e82-442f-4418-b9f4-9f4b9295831d\\r\\nTimestamp: 2015-09-24 19:51:51Z\"," +
+                                                               "\"error_codes\":[70016],\"timestamp\":\"2015-09-24 19:51:51Z\",\"trace_id\":" +
+                                                               "\"f6c2c73f-a21d-474e-a71f-d8b121a58205\",\"correlation_id\":" +
+                                                               "\"36fe3e82-442f-4418-b9f4-9f4b9295831d\"}")
+            };
+
+            HttpMessageHandlerFactory.AddMockHandler(mockMessageHandler);
+
+            mockMessageHandler = new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                Url = TestConstants.DefaultAuthorityHomeTenant + "oauth2/token",
+                ResponseMessage = MockHelpers.CreateDeviceCodeExpirationErrorResponse()
+            };
+            HttpMessageHandlerFactory.AddMockHandler(mockMessageHandler);
+
+            TokenCache cache = new TokenCache();
+            AuthenticationContext ctx = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, cache);
+            DeviceCodeResult dcr = await ctx.AcquireDeviceCodeAsync("some resource", "some authority");
+
+            Assert.IsNotNull(dcr);
+            AuthenticationResult result;
+            AdalServiceException ex = AssertException.TaskThrows<AdalServiceException>(async () => result = await ctx.AcquireTokenByDeviceCodeAsync(dcr));
+            Assert.IsTrue(ex.Message.Contains("Verification code expired"));
+        }
     }
 }

--- a/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
+++ b/tests/Test.ADAL.NET.Unit/Mocks/MockHelpers.cs
@@ -82,12 +82,12 @@ namespace Test.ADAL.NET.Unit.Mocks
             return responseMessage;
         }
 
-        public static HttpResponseMessage CreateSuccessDeviceCodeResponseMessage()
+        public static HttpResponseMessage CreateSuccessDeviceCodeResponseMessage(string expirationTime = "900")
         {
             HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK);
 
             HttpContent content = new StringContent(
-                "{\"user_code\":\"some-user-code\",\"device_code\":\"some-device-code\",\"verification_url\":\"some-URL\",\"expires_in\":\"900\",\"interval\":\"5\",\"message\":\"some-message\"}");
+                "{\"user_code\":\"some-user-code\",\"device_code\":\"some-device-code\",\"verification_url\":\"some-URL\",\"expires_in\":\"" + expirationTime + "\",\"interval\":\"5\",\"message\":\"some-message\"}");
             responseMessage.Content = content;
             return responseMessage;
         }
@@ -111,6 +111,18 @@ namespace Test.ADAL.NET.Unit.Mocks
             return
                 CreateFailureResponseMessage(
                     "{\"ErrorSubCode\":\"70323\",\"error\":\"invalid_grant\",\"error_description\":\"AADSTS70002: Error validating credentials.AADSTS70008: The provided access grant is expired or revoked.Trace ID: f7ec686c-9196-4220-a754-cd9197de44e9Correlation ID: 04bb0cae-580b-49ac-9a10-b6c3316b1eaaTimestamp: 2015-09-16 07:24:55Z\",\"error_codes\":[70002,70008],\"timestamp\":\"2015-09-16 07:24:55Z\",\"trace_id\":\"f7ec686c-9196-4220-a754-cd9197de44e9\",\"correlation_id\":\"04bb0cae-580b-49ac-9a10-b6c3316b1eaa\"}");
+        }
+
+        public static HttpResponseMessage CreateDeviceCodeErrorResponse()
+        {
+            return
+                CreateFailureResponseMessage("{\"error\":\"invalid_request\",\"error_description\":\"AADSTS90014: some error message.\\r\\nTrace ID: 290d2ab9-40f2-4716-92e2-4a72fc480000\\r\\nCorrelation ID: 2eee49ee-620e-42c2-9a3c-dcf81955b20f\\r\\nTimestamp: 2017-09-20 23:05:56Z\",\"error_codes\":[90014],\"timestamp\":\"2017-09-20 23:05:56Z\",\"trace_id\":\"290d2ab9-40f2-4716-92e2-4a72fc480000\",\"correlation_id\":\"2eee49ee-620e-42c2-9a3c-dcf81955b20f\"}");
+        }
+
+        public static HttpResponseMessage CreateDeviceCodeExpirationErrorResponse()
+        {
+            return
+                CreateFailureResponseMessage("{\"error\":\"code_expired\",\"error_description\":\"AADSTS70019: Verification code expired.\\r\\nTrace ID: c16f4b65-c002-493a-b7cc-a33f3fe70000\\r\\nCorrelation ID: 91e8e5de-8974-4899-beec-08f7654fa1fd\\r\\nTimestamp: 2017-09-22 19:39:55Z\",\"error_codes\":[70019],\"timestamp\":\"2017-09-22 19:39:55Z\",\"trace_id\":\"c16f4b65-c002-493a-b7cc-a33f3fe70000\",\"correlation_id\":\"91e8e5de-8974-4899-beec-08f7654fa1fd\"}");
         }
 
         public static HttpResponseMessage CreateFailureResponseMessage(string message)


### PR DESCRIPTION
… the polling times out.

Resolved issue where ADAL did not return the STS response after a device code has expired.

#804 