### PR TITLE
Authority Migration: TokenCache read/write changes (implemented inside TokenCache class)

### DIFF
--- a/automation/WinFormsAutomationApp/AuthenticationHelper.cs
+++ b/automation/WinFormsAutomationApp/AuthenticationHelper.cs
@@ -118,7 +118,7 @@ namespace WinFormsAutomationApp
                     {
                         var updated = item;
                         updated.Value.Result.ExpiresOn = DateTime.UtcNow;
-                        await UpdateCache(item, updated);
+                        await UpdateCache(item, updated).ConfigureAwait(false);
                     }
                 }
                 Dictionary<string, object> output = new Dictionary<string, object>();
@@ -147,7 +147,7 @@ namespace WinFormsAutomationApp
                         var updated = item;
                         updated.Value.RefreshToken = "bad_refresh_token";
                         updated.Value.Result.ExpiresOn = DateTime.UtcNow;
-                        await UpdateCache(item, updated);
+                        await UpdateCache(item, updated).ConfigureAwait(false);
                     }
                     //Send back error if userId or displayableId is not sent back to the user
                     output.Add("invalidated_refresh_token_count", CacheItems.Count.ToString());
@@ -375,7 +375,9 @@ namespace WinFormsAutomationApp
         {
             NotifyBeforeAccessCache(item.Key.Resource, item.Key.ClientId, item.Value.Result.UserInfo.UniqueId, item.Value.Result.UserInfo.DisplayableId);
             TokenCache.DefaultShared.tokenCacheDictionary[updated.Key] = updated.Value;
-            await TokenCache.DefaultShared.StoreToCache(updated.Value, updated.Key.Authority, updated.Key.Resource, updated.Key.ClientId, updated.Key.TokenSubjectType, new CallState(new Guid()));
+            await TokenCache.DefaultShared.StoreToCache(
+                updated.Value, updated.Key.Authority, updated.Key.Resource, updated.Key.ClientId, updated.Key.TokenSubjectType, new CallState(new Guid())
+                ).ConfigureAwait(false);
             NotifyAfterAccessCache(updated.Key.Resource, updated.Key.ClientId, updated.Value.Result.UserInfo.UniqueId, updated.Value.Result.UserInfo.DisplayableId);
         }
 

--- a/automation/WinFormsAutomationApp/AuthenticationHelper.cs
+++ b/automation/WinFormsAutomationApp/AuthenticationHelper.cs
@@ -104,7 +104,7 @@ namespace WinFormsAutomationApp
         public static async Task<string> ExpireAccessToken(Dictionary<string, string> input)
         {
 
-            Task<string> myTask = Task<string>.Factory.StartNew(() =>
+            Task<string> myTask = Task.Run(async () =>
             {
                 TokenCache.DefaultShared.ReadItems();
                 List<KeyValuePair<TokenCacheKey, AuthenticationResultEx>> CacheItems = QueryCache(input["authority"],
@@ -118,7 +118,7 @@ namespace WinFormsAutomationApp
                     {
                         var updated = item;
                         updated.Value.Result.ExpiresOn = DateTime.UtcNow;
-                        UpdateCache(item, updated);
+                        await UpdateCache(item, updated);
                     }
                 }
                 Dictionary<string, object> output = new Dictionary<string, object>();
@@ -134,7 +134,7 @@ namespace WinFormsAutomationApp
         public static async Task<string> InvalidateRefreshToken(Dictionary<string, string> input)
         {
             Dictionary<string, object> output = new Dictionary<string, object>();
-            Task<string> myTask = Task<string>.Factory.StartNew(() =>
+            Task<string> myTask = Task.Run(async () =>
             {
                 try
                 {
@@ -147,7 +147,7 @@ namespace WinFormsAutomationApp
                         var updated = item;
                         updated.Value.RefreshToken = "bad_refresh_token";
                         updated.Value.Result.ExpiresOn = DateTime.UtcNow;
-                        UpdateCache(item, updated);
+                        await UpdateCache(item, updated);
                     }
                     //Send back error if userId or displayableId is not sent back to the user
                     output.Add("invalidated_refresh_token_count", CacheItems.Count.ToString());
@@ -371,11 +371,11 @@ namespace WinFormsAutomationApp
             });
         }
 
-        private static void UpdateCache(KeyValuePair<TokenCacheKey, AuthenticationResultEx> item, KeyValuePair<TokenCacheKey, AuthenticationResultEx> updated)
+        private static async Task UpdateCache(KeyValuePair<TokenCacheKey, AuthenticationResultEx> item, KeyValuePair<TokenCacheKey, AuthenticationResultEx> updated)
         {
             NotifyBeforeAccessCache(item.Key.Resource, item.Key.ClientId, item.Value.Result.UserInfo.UniqueId, item.Value.Result.UserInfo.DisplayableId);
             TokenCache.DefaultShared.tokenCacheDictionary[updated.Key] = updated.Value;
-            TokenCache.DefaultShared.StoreToCache(updated.Value, updated.Key.Authority, updated.Key.Resource, updated.Key.ClientId, updated.Key.TokenSubjectType, new CallState(new Guid()));
+            await TokenCache.DefaultShared.StoreToCache(updated.Value, updated.Key.Authority, updated.Key.Resource, updated.Key.ClientId, updated.Key.TokenSubjectType, new CallState(new Guid()));
             NotifyAfterAccessCache(updated.Key.Resource, updated.Key.ClientId, updated.Value.Result.UserInfo.UniqueId, updated.Value.Result.UserInfo.DisplayableId);
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -142,7 +142,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
 
                     this.NotifyBeforeAccessCache();
                     notifiedBeforeAccessCache = true;
-                    ResultEx = await this.tokenCache.LoadFromCache(CacheQueryData, this.CallState);
+                    ResultEx = await this.tokenCache.LoadFromCache(CacheQueryData, this.CallState).ConfigureAwait(false);
                     extendedLifetimeResultEx = ResultEx;
 
                     if (ResultEx?.Result != null &&
@@ -152,7 +152,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
                         ResultEx = await this.RefreshAccessTokenAsync(ResultEx).ConfigureAwait(false);
                         if (ResultEx != null && ResultEx.Exception == null)
                         {
-                            notifiedBeforeAccessCache = await StoreResultExToCache(notifiedBeforeAccessCache);
+                            notifiedBeforeAccessCache = await StoreResultExToCache(notifiedBeforeAccessCache).ConfigureAwait(false);
                         }
                     }
                 }
@@ -177,7 +177,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
                     }
 
                     this.PostTokenRequest(ResultEx);
-                    notifiedBeforeAccessCache = await StoreResultExToCache(notifiedBeforeAccessCache);
+                    notifiedBeforeAccessCache = await StoreResultExToCache(notifiedBeforeAccessCache).ConfigureAwait(false);
                 }
 
                 await this.PostRunAsync(ResultEx.Result).ConfigureAwait(false);
@@ -214,7 +214,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
                 }
 
                 await this.tokenCache.StoreToCache(ResultEx, this.Authenticator.Authority, this.Resource,
-                    this.ClientKey.ClientId, this.TokenSubjectType, this.CallState);
+                    this.ClientKey.ClientId, this.TokenSubjectType, this.CallState).ConfigureAwait(false);
             }
             return notifiedBeforeAccessCache;
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -142,7 +142,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
 
                     this.NotifyBeforeAccessCache();
                     notifiedBeforeAccessCache = true;
-                    ResultEx = this.tokenCache.LoadFromCache(CacheQueryData, this.CallState);
+                    ResultEx = await this.tokenCache.LoadFromCache(CacheQueryData, this.CallState);
                     extendedLifetimeResultEx = ResultEx;
 
                     if (ResultEx?.Result != null &&

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -152,7 +152,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
                         ResultEx = await this.RefreshAccessTokenAsync(ResultEx).ConfigureAwait(false);
                         if (ResultEx != null && ResultEx.Exception == null)
                         {
-                            StoreResultExToCache(ref notifiedBeforeAccessCache);
+                            notifiedBeforeAccessCache = await StoreResultExToCache(notifiedBeforeAccessCache);
                         }
                     }
                 }
@@ -177,7 +177,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
                     }
 
                     this.PostTokenRequest(ResultEx);
-                    StoreResultExToCache(ref notifiedBeforeAccessCache);
+                    notifiedBeforeAccessCache = await StoreResultExToCache(notifiedBeforeAccessCache);
                 }
 
                 await this.PostRunAsync(ResultEx.Result).ConfigureAwait(false);
@@ -203,7 +203,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
             }
         }
 
-        private void StoreResultExToCache(ref bool notifiedBeforeAccessCache)
+        private async Task<bool> StoreResultExToCache(bool notifiedBeforeAccessCache)
         {
             if (this.StoreToCache)
             {
@@ -213,9 +213,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
                     notifiedBeforeAccessCache = true;
                 }
 
-                this.tokenCache.StoreToCache(ResultEx, this.Authenticator.Authority, this.Resource,
+                await this.tokenCache.StoreToCache(ResultEx, this.Authenticator.Authority, this.Resource,
                     this.ClientKey.ClientId, this.TokenSubjectType, this.CallState);
             }
+            return notifiedBeforeAccessCache;
         }
 
         private async Task CheckAndAcquireTokenUsingBroker()

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
@@ -485,7 +485,14 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
         }
 
-        internal void StoreToCache(AuthenticationResultEx result, string authority, string resource, string clientId,
+        internal async Task StoreToCache(AuthenticationResultEx result, string authority, string resource, string clientId,
+            TokenSubjectType subjectType, CallState callState)
+        {
+            var metadata = await InstanceDiscovery.GetMetadataEntry(GetHost(authority), false, callState).ConfigureAwait(false);
+            StoreToCacheCommon(result, ReplaceHost(authority, metadata.PreferredCache), resource, clientId, subjectType, callState);
+        }
+
+        internal void StoreToCacheCommon(AuthenticationResultEx result, string authority, string resource, string clientId,
             TokenSubjectType subjectType, CallState callState)
         {
             lock (cacheLock)

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
@@ -344,7 +344,53 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
         }
 
-        internal AuthenticationResultEx LoadFromCache(CacheQueryData cacheQueryData, CallState callState)
+        internal async Task<AuthenticationResultEx> LoadFromCache(CacheQueryData cacheQueryData, CallState callState)
+        {
+            AuthenticationResultEx resultEx = null;
+            var aliasedAuthorities = await GetOrderedAliases(
+                GetHost(cacheQueryData.Authority), false, callState).ConfigureAwait(false);
+            foreach (var aliasedAuthority in aliasedAuthorities)
+            {
+                cacheQueryData.Authority = ReplaceHost(cacheQueryData.Authority, aliasedAuthority);
+                resultEx = LoadFromCacheCommon(cacheQueryData, callState);
+                if (resultEx?.Result != null)
+                {
+                    break;
+                }
+            }
+
+            return resultEx;
+        }
+
+        private string GetHost(string uri)
+        {
+            // The following line serves as a validation for uri. Relevant exceptions will be throwed.
+            new Uri(uri); //NOSONAR
+
+            // Note: host is supposed to be case insensitive, and would be normalized to lowercase by: new Uri(uri).Host
+            // but we would like to preserve its case to match a previously cached token
+            return uri.Split('/')[2];
+        }
+
+        private static string ReplaceHost(string oldUri, string newHost)
+        {
+            if (string.IsNullOrEmpty(oldUri) || string.IsNullOrEmpty(newHost))
+            {
+                throw new ArgumentNullException();
+            }
+
+            return $"https://{newHost}{new Uri(oldUri).AbsolutePath}";
+        }
+
+        internal static async Task<List<string>> GetOrderedAliases(string host, bool validateAuthority, CallState callState)
+        {
+            var metadata = await InstanceDiscovery.GetMetadataEntry(host, validateAuthority, callState).ConfigureAwait(false);
+            var aliasedAuthorities = new List<string>(new string[] { metadata.PreferredCache, host });
+            aliasedAuthorities.AddRange(metadata.Aliases ?? Enumerable.Empty<string>());
+            return aliasedAuthorities;
+        }
+
+        internal AuthenticationResultEx LoadFromCacheCommon(CacheQueryData cacheQueryData, CallState callState)
         {
             lock (cacheLock)
             {

--- a/tests/Test.ADAL.NET.Unit/InstanceDiscoveryTests.cs
+++ b/tests/Test.ADAL.NET.Unit/InstanceDiscoveryTests.cs
@@ -165,7 +165,7 @@ namespace Test.ADAL.NET.Unit
         {
             HttpMessageHandlerFactory.AddMockHandler(MockHelpers.CreateInstanceDiscoveryMockHandler());
             var authenticator = new Authenticator("https://login.contoso.com/adfs", false);
-            await authenticator.UpdateFromTemplateAsync(new CallState(Guid.NewGuid()));
+            await authenticator.UpdateFromTemplateAsync(new CallState(Guid.NewGuid())).ConfigureAwait(false);
             Assert.AreEqual(1, HttpMessageHandlerFactory.MockHandlersCount()); // mock is NOT consumed, so no new request was NOT attempted
         }
 
@@ -181,7 +181,7 @@ namespace Test.ADAL.NET.Unit
                 PreferredCache = preferredCache,
                 Aliases = new string[] { "login.microsoftonline.com", "login.windows.net", "sts.microsoft.com" }
             });
-            var orderedList = await TokenCache.GetOrderedAliases(givenHost, false, new CallState(Guid.NewGuid()));
+            var orderedList = await TokenCache.GetOrderedAliases(givenHost, false, new CallState(Guid.NewGuid())).ConfigureAwait(false);
             CollectionAssert.AreEqual(
                 new string[] { preferredCache, givenHost, "login.microsoftonline.com", "login.windows.net", "sts.microsoft.com" },
                 orderedList);

--- a/tests/Test.ADAL.NET.Unit/InstanceDiscoveryTests.cs
+++ b/tests/Test.ADAL.NET.Unit/InstanceDiscoveryTests.cs
@@ -104,7 +104,7 @@ namespace Test.ADAL.NET.Unit
 
         [TestMethod]
         [TestCategory("InstanceDiscoveryTests")]
-        public async Task TestInstanceDiscovery_WhenMultipleSimultaneousCallsWithTheSameAuthority_ShouldMakeOnlyOneRequest()
+        public void TestInstanceDiscovery_WhenMultipleSimultaneousCallsWithTheSameAuthority_ShouldMakeOnlyOneRequest()
         {
             for (int i = 0; i < 2; i++) // Prepare 2 mock responses
             {
@@ -167,6 +167,24 @@ namespace Test.ADAL.NET.Unit
             var authenticator = new Authenticator("https://login.contoso.com/adfs", false);
             await authenticator.UpdateFromTemplateAsync(new CallState(Guid.NewGuid()));
             Assert.AreEqual(1, HttpMessageHandlerFactory.MockHandlersCount()); // mock is NOT consumed, so no new request was NOT attempted
+        }
+
+        [TestMethod]
+        [TestCategory("InstanceDiscoveryTests")]
+        public async Task TestGetOrderedAliases_ShouldStartWithPreferredCacheAndGivenHost()
+        {
+            string givenHost = "sts.microsoft.com";
+            string preferredCache = "login.windows.net";
+            InstanceDiscovery.InstanceCache.TryAdd(givenHost, new InstanceDiscoveryMetadataEntry
+            {
+                PreferredNetwork = "login.microsoftonline.com",
+                PreferredCache = preferredCache,
+                Aliases = new string[] { "login.microsoftonline.com", "login.windows.net", "sts.microsoft.com" }
+            });
+            var orderedList = await TokenCache.GetOrderedAliases(givenHost, false, new CallState(Guid.NewGuid()));
+            CollectionAssert.AreEqual(
+                new string[] { preferredCache, givenHost, "login.microsoftonline.com", "login.windows.net", "sts.microsoft.com" },
+                orderedList);
         }
     }
 }

--- a/tests/Test.ADAL.NET.Unit/TokenCacheTests.cs
+++ b/tests/Test.ADAL.NET.Unit/TokenCacheTests.cs
@@ -384,7 +384,7 @@ namespace Test.ADAL.Common.Unit
                 SubjectType = TokenSubjectType.User
             };
 
-            AuthenticationResultEx resultEx = await tokenCache.LoadFromCache(data, CallState.Default);
+            AuthenticationResultEx resultEx = await tokenCache.LoadFromCache(data, CallState.Default).ConfigureAwait(false);
             Assert.IsNotNull(resultEx);
 
 
@@ -508,18 +508,18 @@ namespace Test.ADAL.Common.Unit
                 DisplayableId = null
             };
 
-            AuthenticationResultEx resultEx = await cache.LoadFromCache(data, CallState.Default);
+            AuthenticationResultEx resultEx = await cache.LoadFromCache(data, CallState.Default).ConfigureAwait(false);
             AreAuthenticationResultExsEqual(value, resultEx);
 
             data.AssertionHash = "hash2";
-            resultEx = await cache.LoadFromCache(data, CallState.Default);
+            resultEx = await cache.LoadFromCache(data, CallState.Default).ConfigureAwait(false);
             AreAuthenticationResultExsEqual(value2, resultEx);
 
             data.AssertionHash = null;
 
             // Multiple tokens in cache -> error
             var exc = AssertException.TaskThrows<AdalException>(async () =>
-                await cache.LoadFromCache(data, CallState.Default));
+                await cache.LoadFromCache(data, CallState.Default).ConfigureAwait(false));
             Assert.AreEqual(exc.ErrorCode, AdalError.MultipleTokensMatched);
         }
 

--- a/tests/Test.ADAL.NET.Unit/TokenCacheTests.cs
+++ b/tests/Test.ADAL.NET.Unit/TokenCacheTests.cs
@@ -333,7 +333,7 @@ namespace Test.ADAL.Common.Unit
             AuthenticationResultEx value = CreateCacheValue(null, "user1");
         }
 
-        internal static void TokenCacheOperationsTest()
+        internal static async Task TokenCacheOperationsTest()
         {
             var tokenCache = new TokenCache();
             var cacheDictionary = tokenCache.tokenCacheDictionary;
@@ -384,7 +384,7 @@ namespace Test.ADAL.Common.Unit
                 SubjectType = TokenSubjectType.User
             };
 
-            AuthenticationResultEx resultEx = tokenCache.LoadFromCache(data, CallState.Default);
+            AuthenticationResultEx resultEx = await tokenCache.LoadFromCache(data, CallState.Default);
             Assert.IsNotNull(resultEx);
 
 
@@ -483,7 +483,7 @@ namespace Test.ADAL.Common.Unit
             Assert.AreEqual(0, cacheDictionary.Keys.Count);
         }
 
-        internal static void MultipleUserAssertionHashTest()
+        internal static async Task MultipleUserAssertionHashTest()
         {
             TokenCacheKey key = new TokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
                 TokenSubjectType.Client, null, "user1");
@@ -508,18 +508,18 @@ namespace Test.ADAL.Common.Unit
                 DisplayableId = null
             };
 
-            AuthenticationResultEx resultEx = cache.LoadFromCache(data, CallState.Default);
+            AuthenticationResultEx resultEx = await cache.LoadFromCache(data, CallState.Default);
             AreAuthenticationResultExsEqual(value, resultEx);
 
             data.AssertionHash = "hash2";
-            resultEx = cache.LoadFromCache(data, CallState.Default);
+            resultEx = await cache.LoadFromCache(data, CallState.Default);
             AreAuthenticationResultExsEqual(value2, resultEx);
 
             data.AssertionHash = null;
 
             // Multiple tokens in cache -> error
-            var exc = AssertException.Throws<AdalException>(() =>
-                cache.LoadFromCache(data, CallState.Default));
+            var exc = AssertException.TaskThrows<AdalException>(async () =>
+                await cache.LoadFromCache(data, CallState.Default));
             Assert.AreEqual(exc.ErrorCode, AdalError.MultipleTokensMatched);
         }
 

--- a/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
@@ -63,9 +63,9 @@ namespace Test.ADAL.NET.Unit
         [TestMethod]
         [Description("Test for Token Cache Operations")]
         [TestCategory("AdalDotNetUnit")]
-        public void TokenCacheOperationsTest()
+        public async Task TokenCacheOperationsTest()
         {
-            TokenCacheTests.TokenCacheOperationsTest();
+            await TokenCacheTests.TokenCacheOperationsTest();
         }
 
         [TestMethod]
@@ -87,9 +87,9 @@ namespace Test.ADAL.NET.Unit
         [TestMethod]
         [Description("Test for Multiple User tokens found, hash fallback test")]
         [TestCategory("AdalDotNetUnit")]
-        public void MultipleUserAssertionHashTest()
+        public async Task MultipleUserAssertionHashTest()
         {
-            TokenCacheTests.MultipleUserAssertionHashTest();
+            await TokenCacheTests.MultipleUserAssertionHashTest();
         }
 
         [TestMethod]

--- a/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
@@ -65,7 +65,7 @@ namespace Test.ADAL.NET.Unit
         [TestCategory("AdalDotNetUnit")]
         public async Task TokenCacheOperationsTest()
         {
-            await TokenCacheTests.TokenCacheOperationsTest();
+            await TokenCacheTests.TokenCacheOperationsTest().ConfigureAwait(false);
         }
 
         [TestMethod]
@@ -89,7 +89,7 @@ namespace Test.ADAL.NET.Unit
         [TestCategory("AdalDotNetUnit")]
         public async Task MultipleUserAssertionHashTest()
         {
-            await TokenCacheTests.MultipleUserAssertionHashTest();
+            await TokenCacheTests.MultipleUserAssertionHashTest().ConfigureAwait(false);
         }
 
         [TestMethod]


### PR DESCRIPTION
Functionality:

* Use the preferred_cache, given host, and aliases from the Authority validation cache to look up tokens in the token cache
* Use the preferred_cache when writing tokens into cache

Difference between | PR #816 | This PR
--- | ------- | --------
Functionality | See above | Same
Implemented in | class AcquireTokenHandlerBase | class TokenCache
Files changed | 2 | 7 (Because the `LoadFromCache()` and `StoreToCache()` become async methods now, we do need to adjust all pre-existing test cases 

Pick the one you like to review. Once merged, we will close the other PR.
