### PR TITLE
Replace string interpolation with old school string.Format(...)

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Instance/Authenticator.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Instance/Authenticator.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -107,9 +108,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Instance
                     InstanceDiscovery.AddMetadataEntry(host);
                 }
                 this.AuthorizationUri = InstanceDiscovery.FormatAuthorizeEndpoint(host, tenant);
-                this.DeviceCodeUri = $"https://{host}/{tenant}/oauth2/devicecode";
-                this.TokenUri = $"https://{host}/{tenant}/oauth2/token";
-                this.UserRealmUri = CanonicalizeUri($"https://{host}/common/UserRealm");
+                this.DeviceCodeUri = string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/oauth2/devicecode", host, tenant);
+                this.TokenUri = string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/oauth2/token", host, tenant);
+                this.UserRealmUri = CanonicalizeUri(string.Format(CultureInfo.InvariantCulture, "https://{0}/common/UserRealm", host));
                 this.IsTenantless = (string.Compare(tenant, TenantlessTenantName, StringComparison.OrdinalIgnoreCase) == 0);
                 this.SelfSignedJwtAudience = this.TokenUri;
                 this.updatedFromTemplate = true;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Instance/InstanceDiscovery.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Instance/InstanceDiscovery.cs
@@ -27,6 +27,7 @@
 
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 using System.Threading;
@@ -106,7 +107,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         public static string FormatAuthorizeEndpoint(string host, string tenant)
         {
-            return $"https://{host}/{tenant}/oauth2/authorize";
+            return string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/oauth2/authorize", host, tenant);
         }
 
         // No return value. Modifies InstanceCache directly.
@@ -114,8 +115,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             string tentativeAuthorizeEndpoint = FormatAuthorizeEndpoint(host, "irrelevant");
             string instanceDiscoveryHost = WhitelistedAuthorities.Contains(host) ? host : DefaultTrustedAuthority;
-            string instanceDiscoveryEndpoint =
-                $"https://{instanceDiscoveryHost}/common/discovery/instance?api-version=1.1&authorization_endpoint={tentativeAuthorizeEndpoint}";
+            string instanceDiscoveryEndpoint = string.Format(
+                CultureInfo.InvariantCulture,
+                "https://{0}/common/discovery/instance?api-version=1.1&authorization_endpoint={1}",
+                instanceDiscoveryHost, tentativeAuthorizeEndpoint);
             var client = new AdalHttpClient(instanceDiscoveryEndpoint, callState);
             InstanceDiscoveryResponse discoveryResponse = null;
             try

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
@@ -379,7 +379,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 throw new ArgumentNullException();
             }
 
-            return $"https://{newHost}{new Uri(oldUri).AbsolutePath}";
+            return string.Format(CultureInfo.InvariantCulture, "https://{0}{1}", newHost, new Uri(oldUri).AbsolutePath);
         }
 
         internal static async Task<List<string>> GetOrderedAliases(string host, bool validateAuthority, CallState callState)


### PR DESCRIPTION
This is exactly the same issue mentioned in
[this StackOverflow question](https://stackoverflow.com/questions/32076823/string-interpolation-in-visual-studio-2015-and-iformatprovider-ca1305).

Since we are not targeting framework 4.6 yet, we will have to switch back
to the old school string.Format(...)