### PR TITLE
Refactor pre-existing test cases to reduce dependency

### DIFF
--- a/tests/Test.ADAL.NET.Common/Mocks/MockHelpers.cs
+++ b/tests/Test.ADAL.NET.Common/Mocks/MockHelpers.cs
@@ -74,8 +74,42 @@ namespace Test.ADAL.NET.Common.Mocks
         public static HttpMessageHandler CreateInstanceDiscoveryMockHandler(string Url)
         {
             return CreateInstanceDiscoveryMockHandler(Url,
-                "{\"tenant_discovery_endpoint\" : \"https://login.microsoftonline.com/v1/.well-known/openid-configuration\"}"
-                );
+                @"{
+                        ""tenant_discovery_endpoint"":""https://login.microsoftonline.com/tenant/.well-known/openid-configuration"",
+                        ""api-version"":""1.1"",
+                        ""metadata"":[
+                            {
+                            ""preferred_network"":""login.microsoftonline.com"",
+                            ""preferred_cache"":""login.windows.net"",
+                            ""aliases"":[
+                                ""login.microsoftonline.com"",
+                                ""login.windows.net"",
+                                ""login.microsoft.com"",
+                                ""sts.windows.net""]},
+                            {
+                            ""preferred_network"":""login.partner.microsoftonline.cn"",
+                            ""preferred_cache"":""login.partner.microsoftonline.cn"",
+                            ""aliases"":[
+                                ""login.partner.microsoftonline.cn"",
+                                ""login.chinacloudapi.cn""]},
+                            {
+                            ""preferred_network"":""login.microsoftonline.de"",
+                            ""preferred_cache"":""login.microsoftonline.de"",
+                            ""aliases"":[
+                                    ""login.microsoftonline.de""]},
+                            {
+                            ""preferred_network"":""login.microsoftonline.us"",
+                            ""preferred_cache"":""login.microsoftonline.us"",
+                            ""aliases"":[
+                                ""login.microsoftonline.us"",
+                                ""login.usgovcloudapi.net""]},
+                            {
+                            ""preferred_network"":""login-us.microsoftonline.com"",
+                            ""preferred_cache"":""login-us.microsoftonline.com"",
+                            ""aliases"":[
+                                ""login-us.microsoftonline.com""]}
+                        ]
+                }");
         }
 
         public static HttpMessageHandler CreateInstanceDiscoveryMockHandler(string Url, string content)

--- a/tests/Test.ADAL.NET.Integration/FederatedUserCredentialTests.cs
+++ b/tests/Test.ADAL.NET.Integration/FederatedUserCredentialTests.cs
@@ -54,6 +54,11 @@ namespace Test.ADAL.NET.Integration
         public void Initialize()
         {
             HttpMessageHandlerFactory.ClearMockHandlers();
+            ResetInstanceDiscovery();
+        }
+
+        public void ResetInstanceDiscovery()
+        {
             InstanceDiscovery.InstanceCache.Clear();
             HttpMessageHandlerFactory.AddMockHandler(MockHelpers.CreateInstanceDiscoveryMockHandler(TestConstants.GetDiscoveryEndpoint(TestConstants.DefaultAuthorityCommonTenant)));
         }
@@ -289,16 +294,6 @@ namespace Test.ADAL.NET.Integration
             AuthenticationContext context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             await context.Authenticator.UpdateFromTemplateAsync(null);
 
-            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
-            {
-                Method = HttpMethod.Post,
-                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
-                PostData = new Dictionary<string, string>()
-                {
-                    {"grant_type", "refresh_token"}
-                }
-            });
-
             await context.TokenCache.StoreToCache(new AuthenticationResultEx
             {
                 RefreshToken = "some-rt",
@@ -315,6 +310,17 @@ namespace Test.ADAL.NET.Integration
             },
             TestConstants.DefaultAuthorityCommonTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             new CallState(new Guid()));
+            ResetInstanceDiscovery();
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"grant_type", "refresh_token"}
+                }
+            });
 
             // Call acquire token
             AuthenticationResult result = await context.AcquireTokenAsync(TestConstants.DefaultResource, TestConstants.DefaultClientId,

--- a/tests/Test.ADAL.NET.Integration/PromptBehaviorTests.cs
+++ b/tests/Test.ADAL.NET.Integration/PromptBehaviorTests.cs
@@ -133,15 +133,22 @@ namespace Test.ADAL.NET.Integration
 
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AuthenticationResultEx
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
                 Result = new AuthenticationResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
-            };
+                {
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = TestConstants.DefaultDisplayableId,
+                            UniqueId = TestConstants.DefaultUniqueId
+                        }
+                },
+            },
+            TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+            new CallState(new Guid()));
 
             AuthenticationResult result =
                 await
@@ -175,15 +182,22 @@ namespace Test.ADAL.NET.Integration
 
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AuthenticationResultEx
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
                 Result = new AuthenticationResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
-            };
+                {
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = TestConstants.DefaultDisplayableId,
+                            UniqueId = TestConstants.DefaultUniqueId
+                        }
+                },
+            },
+            TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+            new CallState(new Guid()));
 
             AuthenticationResult result =
                 await
@@ -218,16 +232,23 @@ namespace Test.ADAL.NET.Integration
 
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AuthenticationResultEx
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
                 Result = new AuthenticationResult("Bearer", "existing-access-token",
                     DateTimeOffset.UtcNow + TimeSpan.FromMinutes(100))
-            };
+                {
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = TestConstants.DefaultDisplayableId,
+                            UniqueId = TestConstants.DefaultUniqueId
+                        }
+                },
+            },
+            TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+            new CallState(new Guid()));
 
             AuthenticationResult result =
                 await
@@ -297,15 +318,22 @@ namespace Test.ADAL.NET.Integration
 
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AuthenticationResultEx
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
                 Result = new AuthenticationResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
-            };
+                {
+                    UserInfo =
+                        new UserInfo()
+                        {
+                            DisplayableId = TestConstants.DefaultDisplayableId,
+                            UniqueId = TestConstants.DefaultUniqueId
+                        }
+                },
+            },
+            TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+            new CallState(new Guid()));
 
             AuthenticationResult result =
                 await

--- a/tests/Test.ADAL.NET.Integration/PromptBehaviorTests.cs
+++ b/tests/Test.ADAL.NET.Integration/PromptBehaviorTests.cs
@@ -50,6 +50,11 @@ namespace Test.ADAL.NET.Integration
         public void Initialize()
         {
             HttpMessageHandlerFactory.ClearMockHandlers();
+            ResetInstanceDiscovery();
+        }
+
+        public void ResetInstanceDiscovery()
+        {
             InstanceDiscovery.InstanceCache.Clear();
             HttpMessageHandlerFactory.AddMockHandler(MockHelpers.CreateInstanceDiscoveryMockHandler(TestConstants.GetDiscoveryEndpoint(TestConstants.DefaultAuthorityCommonTenant)));
         }
@@ -121,16 +126,6 @@ namespace Test.ADAL.NET.Integration
             MockHelpers.ConfigureMockWebUI(new AuthorizationResult(AuthorizationStatus.Success,
                 TestConstants.DefaultRedirectUri + "?code=some-code"));
 
-            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
-            {
-                Method = HttpMethod.Post,
-                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
-                PostData = new Dictionary<string, string>()
-                {
-                    {"grant_type", "refresh_token"}
-                }
-            });
-
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
             await context.TokenCache.StoreToCache(new AuthenticationResultEx
@@ -149,6 +144,17 @@ namespace Test.ADAL.NET.Integration
             },
             TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             new CallState(new Guid()));
+            ResetInstanceDiscovery();
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"grant_type", "refresh_token"}
+                }
+            });
 
             AuthenticationResult result =
                 await
@@ -170,16 +176,6 @@ namespace Test.ADAL.NET.Integration
             MockHelpers.ConfigureMockWebUI(new AuthorizationResult(AuthorizationStatus.Success,
                 TestConstants.DefaultRedirectUri + "?code=some-code"));
 
-            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
-            {
-                Method = HttpMethod.Post,
-                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
-                PostData = new Dictionary<string, string>()
-                {
-                    {"grant_type", "authorization_code"}
-                }
-            });
-
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
             await context.TokenCache.StoreToCache(new AuthenticationResultEx
@@ -198,6 +194,17 @@ namespace Test.ADAL.NET.Integration
             },
             TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             new CallState(new Guid()));
+            ResetInstanceDiscovery();
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"grant_type", "authorization_code"}
+                }
+            });
 
             AuthenticationResult result =
                 await
@@ -220,16 +227,6 @@ namespace Test.ADAL.NET.Integration
                 // validate that authorizationUri passed to WebUi contains prompt=select_account query parameter
                 new Dictionary<string, string> { { "prompt", "select_account" } });
 
-            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
-            {
-                Method = HttpMethod.Post,
-                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
-                PostData = new Dictionary<string, string>
-                {
-                    {"grant_type", "authorization_code"}
-                }
-            });
-
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
             await context.TokenCache.StoreToCache(new AuthenticationResultEx
@@ -249,6 +246,17 @@ namespace Test.ADAL.NET.Integration
             },
             TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             new CallState(new Guid()));
+            ResetInstanceDiscovery();
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>
+                {
+                    {"grant_type", "authorization_code"}
+                }
+            });
 
             AuthenticationResult result =
                 await
@@ -306,16 +314,6 @@ namespace Test.ADAL.NET.Integration
                 // validate that authorizationUri passed to WebUi contains prompt=refresh_session query parameter
                 new Dictionary<string, string> { { "prompt", "refresh_session" } });
 
-            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
-            {
-                Method = HttpMethod.Post,
-                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
-                PostData = new Dictionary<string, string>()
-                {
-                    {"grant_type", "authorization_code"}
-                }
-            });
-
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
             await context.TokenCache.StoreToCache(new AuthenticationResultEx
@@ -334,6 +332,17 @@ namespace Test.ADAL.NET.Integration
             },
             TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             new CallState(new Guid()));
+            ResetInstanceDiscovery();
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
+                PostData = new Dictionary<string, string>()
+                {
+                    {"grant_type", "authorization_code"}
+                }
+            });
 
             AuthenticationResult result =
                 await

--- a/tests/Test.ADAL.NET.Unit/InstanceDiscoveryTests.cs
+++ b/tests/Test.ADAL.NET.Unit/InstanceDiscoveryTests.cs
@@ -87,13 +87,14 @@ namespace Test.ADAL.NET.Unit
         [TestCategory("InstanceDiscoveryTests")]
         public async Task TestInstanceDiscovery_WhenAuthorityIsValidButNoMetadataIsReturned_ShouldCacheTheProvidedAuthority()
         {
+            string host = "login.windows.net";  // A whitelisted host
+            CallState callState = new CallState(Guid.NewGuid());
             for (int i = 0; i < 2; i++) // Prepare 2 mock responses
             {
-                HttpMessageHandlerFactory.AddMockHandler(MockHelpers.CreateInstanceDiscoveryMockHandler("https://login.windows.net/common/discovery/instance"));
+                HttpMessageHandlerFactory.AddMockHandler(MockHelpers.CreateInstanceDiscoveryMockHandler(
+                    $"https://{host}/common/discovery/instance",
+                    @"{""tenant_discovery_endpoint"":""https://login.microsoftonline.com/tenant/.well-known/openid-configuration""}"));
             }
-
-            CallState callState = new CallState(Guid.NewGuid());
-            string host = "login.windows.net";
 
             // ADAL still behaves correctly using developer provided authority
             var entry = await InstanceDiscovery.GetMetadataEntry(new Uri($"https://{host}/tenant"), true, callState).ConfigureAwait(false);

--- a/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
+++ b/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
@@ -61,6 +61,11 @@ namespace Test.ADAL.NET.Unit
         public void TestInitialize()
         {
             HttpMessageHandlerFactory.ClearMockHandlers();
+            ResetInstanceDiscovery();
+        }
+
+        public void ResetInstanceDiscovery()
+        {
             InstanceDiscovery.InstanceCache.Clear();
             HttpMessageHandlerFactory.AddMockHandler(MockHelpers.CreateInstanceDiscoveryMockHandler(TestConstants.GetDiscoveryEndpoint(TestConstants.DefaultAuthorityCommonTenant)));
         }
@@ -92,6 +97,7 @@ namespace Test.ADAL.NET.Unit
                 TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 new CallState(new Guid()));
             }
+            ResetInstanceDiscovery();
 
             ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
                 TestConstants.DefaultClientSecret);
@@ -152,6 +158,7 @@ namespace Test.ADAL.NET.Unit
                 TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 new CallState(new Guid()));
             }
+            ResetInstanceDiscovery();
 
             ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
                 TestConstants.DefaultClientSecret);
@@ -335,6 +342,7 @@ namespace Test.ADAL.NET.Unit
                 TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 new CallState(new Guid()));
             }
+            ResetInstanceDiscovery();
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
             {
@@ -448,6 +456,7 @@ namespace Test.ADAL.NET.Unit
                 TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 new CallState(new Guid()));
             }
+            ResetInstanceDiscovery();
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
             {
@@ -502,6 +511,7 @@ namespace Test.ADAL.NET.Unit
             },
             TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             new CallState(new Guid()));
+            ResetInstanceDiscovery();
 
             ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
                 TestConstants.DefaultClientSecret);
@@ -558,6 +568,7 @@ namespace Test.ADAL.NET.Unit
             },
             TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             new CallState(new Guid()));
+            ResetInstanceDiscovery();
 
             ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
                 TestConstants.DefaultClientSecret);
@@ -733,6 +744,7 @@ namespace Test.ADAL.NET.Unit
             },
             TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             new CallState(new Guid()));
+            ResetInstanceDiscovery();
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
             {
@@ -843,6 +855,7 @@ namespace Test.ADAL.NET.Unit
             },
             TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             new CallState(new Guid()));
+            ResetInstanceDiscovery();
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
             {

--- a/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
+++ b/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
@@ -74,11 +74,8 @@ namespace Test.ADAL.NET.Unit
 
             foreach (var cachenoise in _cacheNoise)
             {
-                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
                 //cache entry has no user assertion hash
-                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                await context.TokenCache.StoreToCache(new AuthenticationResultEx
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
@@ -91,7 +88,9 @@ namespace Test.ADAL.NET.Unit
                                 UniqueId = cachenoise + TestConstants.DefaultUniqueId
                             }
                     },
-                };
+                },
+                TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                new CallState(new Guid()));
             }
 
             ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
@@ -135,11 +134,8 @@ namespace Test.ADAL.NET.Unit
 
             foreach (var cachenoise in _cacheNoise)
             {
-                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
                 //cache entry has no user assertion hash
-                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                await context.TokenCache.StoreToCache(new AuthenticationResultEx
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
@@ -152,7 +148,9 @@ namespace Test.ADAL.NET.Unit
                                 UniqueId = cachenoise + TestConstants.DefaultUniqueId
                             }
                     },
-                };
+                },
+                TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                new CallState(new Guid()));
             }
 
             ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
@@ -318,10 +316,7 @@ namespace Test.ADAL.NET.Unit
 
             foreach (var cachenoise in _cacheNoise)
             {
-                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
-                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                await context.TokenCache.StoreToCache(new AuthenticationResultEx
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
@@ -336,7 +331,9 @@ namespace Test.ADAL.NET.Unit
                                 }
                         },
                     UserAssertionHash = CryptographyHelper.CreateSha256Hash(cachenoise + accessToken)
-                };
+                },
+                TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                new CallState(new Guid()));
             }
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
@@ -432,11 +429,7 @@ namespace Test.ADAL.NET.Unit
             string tokenInCache = "obo-access-token";
             foreach (var cachenoise in _cacheNoise)
             {
-                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                    TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                    cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
-
-                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                await context.TokenCache.StoreToCache(new AuthenticationResultEx
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
@@ -451,7 +444,9 @@ namespace Test.ADAL.NET.Unit
                                 }
                         },
                     UserAssertionHash = CryptographyHelper.CreateSha256Hash(cachenoise + accessToken)
-                };
+                },
+                TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+                new CallState(new Guid()));
             }
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
@@ -490,11 +485,7 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            //cache entry has no user assertion hash
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AuthenticationResultEx
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
@@ -507,7 +498,10 @@ namespace Test.ADAL.NET.Unit
                             UniqueId = TestConstants.DefaultUniqueId
                         }
                 },
-            };
+                //cache entry has no user assertion hash
+            },
+            TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+            new CallState(new Guid()));
 
             ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
                 TestConstants.DefaultClientSecret);
@@ -547,11 +541,7 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            //cache entry has no user assertion hash
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AuthenticationResultEx
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
@@ -564,7 +554,10 @@ namespace Test.ADAL.NET.Unit
                             UniqueId = TestConstants.DefaultUniqueId
                         }
                 },
-            };
+                //cache entry has no user assertion hash
+            },
+            TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+            new CallState(new Guid()));
 
             ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId,
                 TestConstants.DefaultClientSecret);
@@ -721,13 +714,8 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-
-            //cache entry has user assertion hash
             string tokenInCache = "obo-access-token";
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AuthenticationResultEx
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
@@ -742,7 +730,9 @@ namespace Test.ADAL.NET.Unit
                             }
                     },
                 UserAssertionHash = CryptographyHelper.CreateSha256Hash(accessToken + "different")
-            };
+            },
+            TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+            new CallState(new Guid()));
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
             {
@@ -834,13 +824,8 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
-                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
-                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-
-            //cache entry has user assertion hash
             string tokenInCache = "obo-access-token";
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AuthenticationResultEx
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
@@ -855,7 +840,9 @@ namespace Test.ADAL.NET.Unit
                             }
                     },
                 UserAssertionHash = CryptographyHelper.CreateSha256Hash(accessToken + "different")
-            };
+            },
+            TestConstants.DefaultAuthorityHomeTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
+            new CallState(new Guid()));
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
             {


### PR DESCRIPTION
While this PR is triggered by the modification for the default Instance Discovery mock, the actual adjustment to those affected test cases (some of them are 1 year old) is orthogonal to the Instance Discovery feature, and rightfully so. In fact, after those test cases refactor, they would pass no matter the default Instance Discovery mock contain Authority Migration metadata or not.