### PR TITLE
Updating the contribution guide (contributing.md)

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -25,7 +25,7 @@ $ git remote add upstream git@github.com:AzureAD/azure-activedirectory-library-f
 ```
 
 ### Initial build of ADAL.Net
-We recommand that you use Visual Studio 2017 with Xamarin, .Net Core and UWP installed. 
+We recommend that you use Visual Studio 2017 with Xamarin, .Net Core and UWP installed. 
 You will also need Visual Studio 2015 update 3 with the windows 8.1 SDK installed in order to build ADAL.NET for the WinRT platform
 > Important node: 
 ADAL.Net uses a multi-targeting projects to generate assemblies for several platforms. There are issues with the Nuget package manager in Visual Studio 2017, not recogizing nuget pacakges in the ADAL.NET project. Therefore you'd want to restore the nuget packages using this command line:
@@ -39,7 +39,7 @@ you can then either build ADAL.Net in Visual Studio or from the command line:
 $ msbuild ADAL.NET.NoWinRT.sln /t:build /p:configuration=release 
 ```
 
-To run the unit tests:
+To run the tests:
 -Skip strong name Verification for this assembly for on your machine (run in command prompt as an admin)
 ```
 sn -Vr *,31bf3856ad364e35
@@ -49,6 +49,12 @@ Run the unit tests:
 ```
 vstest.console tests\Test.ADAL.NET.Unit\bin\release\net462\Test.ADAL.NET.Unit.dll
 ```
+
+Run the integration tests:
+```
+vstest.console tests\Test.ADAL.NET.Integration\bin\Release\net462\Test.ADAL.NET.Integration.dll
+```
+
 When you are done re-enable  strong name Verification for this assembly for on your machine (run in command prompt as an admin)
 ```
 sn -Vu *,31bf3856ad364e35

--- a/contributing.md
+++ b/contributing.md
@@ -3,13 +3,13 @@
 Azure Active Directory SDK projects welcomes new contributors.  This document will guide you
 through the process.
 
-### CONTRIBUTOR LICENSE AGREEMENT
+### Contributor License agreement
 
 Please visit [https://cla.microsoft.com/](https://cla.microsoft.com/) and sign the Contributor License
 Agreement.  You only need to do that once. We can not look at your code until you've submitted this request.
 
 
-### FORK
+### Fork
 > Important node: 
 Because Nuget brings very long assemblies file names, you'd want to clone ADAL.NET in a folder which has a short name and is very close to the root of your hard drive (for instance C:\aad). then,  might want to rename the cloned folder to a shorted name (see below).
 
@@ -19,11 +19,14 @@ your copy.
 Example for .NET:
 
 ```
-$ git clone git@github.com:username/azure-activedirectory-library-for-dotnet.git
-$ rename azure-activedirectory-library-for-dotnet adal.net
+$ git clone git@github.com:username/azure-activedirectory-library-for-dotnet.git adal.net
+$ cd adal.net
 $ git remote add upstream git@github.com:AzureAD/azure-activedirectory-library-for-dotnet.git
 ```
 
+### Initial build of ADAL.Net
+We recommand that you use Visual Studio 2017 with Xamarin, .Net Core and UWP installed. 
+You will also need Visual Studio 2015 update 3 with the windows 8.1 SDK installed in order to build ADAL.NET for the WinRT platform
 > Important node: 
 ADAL.Net uses a multi-targeting projects to generate assemblies for several platforms. There are issues with the Nuget package manager in Visual Studio 2017, not recogizing nuget pacakges in the ADAL.NET project. Therefore you'd want to restore the nuget packages using this command line:
 
@@ -31,6 +34,28 @@ ADAL.Net uses a multi-targeting projects to generate assemblies for several plat
 $ msbuild ADAL.NET.NoWinRT.sln /t:restore 
 ```
 
+you can then either build ADAL.Net in Visual Studio or from the command line:
+```
+$ msbuild ADAL.NET.NoWinRT.sln /t:build /p:configuration=release 
+```
+
+To run the unit tests:
+-Skip strong name Verification for this assembly for on your machine (run in command prompt as an admin)
+```
+sn -Vr *,31bf3856ad364e35
+```
+
+Run the unit tests:
+```
+vstest.console tests\Test.ADAL.NET.Unit\bin\release\net462\Test.ADAL.NET.Unit.dll
+```
+When you are done re-enable  strong name Verification for this assembly for on your machine (run in command prompt as an admin)
+```
+sn -Vu *,31bf3856ad364e35
+```
+
+
+### Decide on which branch to create
 Now decide if you want your feature or bug fix to go into the current stable version or the next version of the library. 
 
 **Bug fixes for the current stable version need to go to 'servicing' branch.**
@@ -50,7 +75,7 @@ frustrating than seeing your hard work go to waste because your vision
 does not align with our goals for the SDK.
 
 
-### BRANCH
+### Branch
 
 Okay, so you have decided on the proper branch.  Create a feature branch
 and start hacking:
@@ -60,7 +85,7 @@ $ git checkout -b my-feature-branch
 ```
 
 
-### COMMIT
+### Commit
 
 Make sure git knows your name and email address:
 
@@ -100,7 +125,7 @@ Check the output of `git log --oneline files_that_you_changed` to find out
 what directories your changes touch.
 
 
-### REBASE
+### Rebase
 
 Use `git rebase` (not `git merge`) to sync your work from time to time.
 
@@ -110,13 +135,13 @@ $ git rebase upstream/v0.1  # or upstream/master
 ```
 
 
-### TEST
+### Test
 
 Bug fixes and features should come with tests.  Add your tests in the
 test directory. This varies by repository but often follows the same convention of /src/test.  Look at other tests to see how they should be
 structured (license boilerplate, common includes, etc.).
 
-Before you can run tests you will need to enable Skip Verification for on your machine.  Open the 'Developer Command Prompt for VS2015' as an administrator and run the following command:
+Before you can run tests you will need to enable Skip Verification for on your machine.  Open the 'Developer Command Prompt for VS2017' as an administrator and run the following command:
 
 ```
 sn -Vr *,31bf3856ad364e35
@@ -125,7 +150,7 @@ sn -Vr *,31bf3856ad364e35
 Make sure that all tests pass.
 
 
-### PUSH
+### Push
 
 ```
 $ git push origin my-feature-branch

--- a/contributing.md
+++ b/contributing.md
@@ -10,6 +10,8 @@ Agreement.  You only need to do that once. We can not look at your code until yo
 
 
 ### FORK
+> Important node: 
+Because Nuget brings very long assemblies file names, you'd want to clone ADAL.NET in a folder which has a short name and is very close to the root of your hard drive (for instance C:\aad). then,  might want to rename the cloned folder to a shorted name (see below).
 
 Fork the project [on GitHub][] and check out
 your copy.
@@ -18,8 +20,15 @@ Example for .NET:
 
 ```
 $ git clone git@github.com:username/azure-activedirectory-library-for-dotnet.git
-$ cd azure-activedirectory-library-for-dotnet
+$ rename azure-activedirectory-library-for-dotnet adal.net
 $ git remote add upstream git@github.com:AzureAD/azure-activedirectory-library-for-dotnet.git
+```
+
+> Important node: 
+ADAL.Net uses a multi-targeting projects to generate assemblies for several platforms. There are issues with the Nuget package manager in Visual Studio 2017, not recogizing nuget pacakges in the ADAL.NET project. Therefore you'd want to restore the nuget packages using this command line:
+
+```
+$ msbuild ADAL.NET.NoWinRT.sln /t:restore 
 ```
 
 Now decide if you want your feature or bug fix to go into the current stable version or the next version of the library. 


### PR DESCRIPTION
Updating the contribution guide (contributing.md) to explain:
- how to clone/fork to avoid long names issues, 
- how to restore the nuget packages
See #895 
