### PR TITLE
Fixing #918  (tests don't show-up in the Test Explorer in VS2017.4+)

### DIFF
--- a/tests/Test.ADAL.NET.Common/Test.ADAL.NET.Common.csproj
+++ b/tests/Test.ADAL.NET.Common/Test.ADAL.NET.Common.csproj
@@ -34,9 +34,9 @@
       <Name>Microsoft.IdentityModel.Clients.ActiveDirectory</Name>
     </ProjectReference>
     <PackageReference Include="NSubstitute" Version="2.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="35MSSharedLib1024.snk" />

--- a/tests/Test.ADAL.NET.Integration/Test.ADAL.NET.Integration.csproj
+++ b/tests/Test.ADAL.NET.Integration/Test.ADAL.NET.Integration.csproj
@@ -49,10 +49,10 @@
       <Project>{412f8f05-2694-4d2e-8fe0-a821721cf682}</Project>
       <Name>Test.ADAL.NET.Common</Name>
     </ProjectReference>
-	
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -54,9 +54,9 @@
       <Project>{412f8f05-2694-4d2e-8fe0-a821721cf682}</Project>
       <Name>Test.ADAL.NET.Common</Name>
     </ProjectReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.2.0" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />


### PR DESCRIPTION
Fixing #918  (tests don't show-up in the Test Explorer in VS2017.4+)
by upgrading the NuGet packages for the test adapter and test framework.
See minimum version requirements (https://docs.microsoft.com/en-us/visualstudio/test/live-unit-testing-faq#what-test-frameworks-does-live-unit-testing-support-and-what-are-the-minimum-supported-versions)