### PR TITLE
changes to move AuthenticationResultEx to core

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ environment:
 
 before_build:
   - nuget restore ADAL.NET.NoWinRT.sln
-  - '"C:/Program Files (x86)/Microsoft SDKs/Windows/v10.0A/bin/NETFX 4.6.1 Tools/sn.exe" -Vr *,31bf3856ad364e35'
+  - '"C:/Program Files (x86)/Microsoft SDKs/Windows/v10.0A/bin/NETFX 4.6.1 Tools/sn.exe" -Vr *,*'
 
 build:
   project: ADAL.NET.NoWinRT.sln

--- a/automation/WinFormsAutomationApp/AuthenticationHelper.cs
+++ b/automation/WinFormsAutomationApp/AuthenticationHelper.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization.Json;
 using System.Threading.Tasks;
 using System.Web.Script.Serialization;
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;
 using Newtonsoft.Json;

--- a/automation/WinFormsAutomationApp/AuthenticationHelper.cs
+++ b/automation/WinFormsAutomationApp/AuthenticationHelper.cs
@@ -108,10 +108,10 @@ namespace WinFormsAutomationApp
             Task<string> myTask = Task.Run(async () =>
             {
                 TokenCache.DefaultShared.ReadItems();
-                List<KeyValuePair<TokenCacheKey, AuthenticationResultEx>> CacheItems = QueryCache(input["authority"],
+                List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> CacheItems = QueryCache(input["authority"],
                     input["client_id"], input["user_identifier"]);
 
-                foreach (KeyValuePair<TokenCacheKey, AuthenticationResultEx> item in CacheItems)
+                foreach (KeyValuePair<TokenCacheKey, AdalResultWrapper> item in CacheItems)
                 {
                     // if resource was passed to cache lookup, then only expire token for that resource.
                     // otherwise expire all matching access tokens.
@@ -140,10 +140,10 @@ namespace WinFormsAutomationApp
                 try
                 {
                     TokenCache.DefaultShared.ReadItems();
-                    List<KeyValuePair<TokenCacheKey, AuthenticationResultEx>> CacheItems = QueryCache(input["authority"],
+                    List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> CacheItems = QueryCache(input["authority"],
                     input["client_id"], input["user_identifier"]);
 
-                    foreach (KeyValuePair<TokenCacheKey, AuthenticationResultEx> item in CacheItems)
+                    foreach (KeyValuePair<TokenCacheKey, AdalResultWrapper> item in CacheItems)
                     {
                         var updated = item;
                         updated.Value.RefreshToken = "bad_refresh_token";
@@ -372,7 +372,7 @@ namespace WinFormsAutomationApp
             });
         }
 
-        private static async Task UpdateCache(KeyValuePair<TokenCacheKey, AuthenticationResultEx> item, KeyValuePair<TokenCacheKey, AuthenticationResultEx> updated)
+        private static async Task UpdateCache(KeyValuePair<TokenCacheKey, AdalResultWrapper> item, KeyValuePair<TokenCacheKey, AdalResultWrapper> updated)
         {
             NotifyBeforeAccessCache(item.Key.Resource, item.Key.ClientId, item.Value.Result.UserInfo.UniqueId, item.Value.Result.UserInfo.DisplayableId);
             TokenCache.DefaultShared.tokenCacheDictionary[updated.Key] = updated.Value;
@@ -382,7 +382,7 @@ namespace WinFormsAutomationApp
             NotifyAfterAccessCache(updated.Key.Resource, updated.Key.ClientId, updated.Value.Result.UserInfo.UniqueId, updated.Value.Result.UserInfo.DisplayableId);
         }
 
-        private static List<KeyValuePair<TokenCacheKey, AuthenticationResultEx>> QueryCache(string authority,
+        private static List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> QueryCache(string authority,
             string clientId, string displayableId)
         {
             return TokenCache.DefaultShared.tokenCacheDictionary.Where(

--- a/devApps/XFormsApp.Droid/Resources/Resource.Designer.cs
+++ b/devApps/XFormsApp.Droid/Resources/Resource.Designer.cs
@@ -1486,449 +1486,449 @@ namespace XFormsApp.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f070018
-			public const int abc_action_bar_content_inset_material = 2131165208;
+			// aapt resource value: 0x7f080018
+			public const int abc_action_bar_content_inset_material = 2131230744;
 			
-			// aapt resource value: 0x7f070019
-			public const int abc_action_bar_content_inset_with_nav = 2131165209;
+			// aapt resource value: 0x7f080019
+			public const int abc_action_bar_content_inset_with_nav = 2131230745;
 			
-			// aapt resource value: 0x7f07000d
-			public const int abc_action_bar_default_height_material = 2131165197;
+			// aapt resource value: 0x7f08000d
+			public const int abc_action_bar_default_height_material = 2131230733;
 			
-			// aapt resource value: 0x7f07001a
-			public const int abc_action_bar_default_padding_end_material = 2131165210;
+			// aapt resource value: 0x7f08001a
+			public const int abc_action_bar_default_padding_end_material = 2131230746;
 			
-			// aapt resource value: 0x7f07001b
-			public const int abc_action_bar_default_padding_start_material = 2131165211;
+			// aapt resource value: 0x7f08001b
+			public const int abc_action_bar_default_padding_start_material = 2131230747;
 			
-			// aapt resource value: 0x7f070021
-			public const int abc_action_bar_elevation_material = 2131165217;
+			// aapt resource value: 0x7f080021
+			public const int abc_action_bar_elevation_material = 2131230753;
 			
-			// aapt resource value: 0x7f070022
-			public const int abc_action_bar_icon_vertical_padding_material = 2131165218;
+			// aapt resource value: 0x7f080022
+			public const int abc_action_bar_icon_vertical_padding_material = 2131230754;
 			
-			// aapt resource value: 0x7f070023
-			public const int abc_action_bar_overflow_padding_end_material = 2131165219;
+			// aapt resource value: 0x7f080023
+			public const int abc_action_bar_overflow_padding_end_material = 2131230755;
 			
-			// aapt resource value: 0x7f070024
-			public const int abc_action_bar_overflow_padding_start_material = 2131165220;
+			// aapt resource value: 0x7f080024
+			public const int abc_action_bar_overflow_padding_start_material = 2131230756;
 			
-			// aapt resource value: 0x7f07000e
-			public const int abc_action_bar_progress_bar_size = 2131165198;
+			// aapt resource value: 0x7f08000e
+			public const int abc_action_bar_progress_bar_size = 2131230734;
 			
-			// aapt resource value: 0x7f070025
-			public const int abc_action_bar_stacked_max_height = 2131165221;
+			// aapt resource value: 0x7f080025
+			public const int abc_action_bar_stacked_max_height = 2131230757;
 			
-			// aapt resource value: 0x7f070026
-			public const int abc_action_bar_stacked_tab_max_width = 2131165222;
+			// aapt resource value: 0x7f080026
+			public const int abc_action_bar_stacked_tab_max_width = 2131230758;
 			
-			// aapt resource value: 0x7f070027
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131165223;
+			// aapt resource value: 0x7f080027
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131230759;
 			
-			// aapt resource value: 0x7f070028
-			public const int abc_action_bar_subtitle_top_margin_material = 2131165224;
+			// aapt resource value: 0x7f080028
+			public const int abc_action_bar_subtitle_top_margin_material = 2131230760;
 			
-			// aapt resource value: 0x7f070029
-			public const int abc_action_button_min_height_material = 2131165225;
+			// aapt resource value: 0x7f080029
+			public const int abc_action_button_min_height_material = 2131230761;
 			
-			// aapt resource value: 0x7f07002a
-			public const int abc_action_button_min_width_material = 2131165226;
+			// aapt resource value: 0x7f08002a
+			public const int abc_action_button_min_width_material = 2131230762;
 			
-			// aapt resource value: 0x7f07002b
-			public const int abc_action_button_min_width_overflow_material = 2131165227;
+			// aapt resource value: 0x7f08002b
+			public const int abc_action_button_min_width_overflow_material = 2131230763;
 			
-			// aapt resource value: 0x7f07000c
-			public const int abc_alert_dialog_button_bar_height = 2131165196;
+			// aapt resource value: 0x7f08000c
+			public const int abc_alert_dialog_button_bar_height = 2131230732;
 			
-			// aapt resource value: 0x7f07002c
-			public const int abc_button_inset_horizontal_material = 2131165228;
+			// aapt resource value: 0x7f08002c
+			public const int abc_button_inset_horizontal_material = 2131230764;
 			
-			// aapt resource value: 0x7f07002d
-			public const int abc_button_inset_vertical_material = 2131165229;
+			// aapt resource value: 0x7f08002d
+			public const int abc_button_inset_vertical_material = 2131230765;
 			
-			// aapt resource value: 0x7f07002e
-			public const int abc_button_padding_horizontal_material = 2131165230;
+			// aapt resource value: 0x7f08002e
+			public const int abc_button_padding_horizontal_material = 2131230766;
 			
-			// aapt resource value: 0x7f07002f
-			public const int abc_button_padding_vertical_material = 2131165231;
+			// aapt resource value: 0x7f08002f
+			public const int abc_button_padding_vertical_material = 2131230767;
 			
-			// aapt resource value: 0x7f070030
-			public const int abc_cascading_menus_min_smallest_width = 2131165232;
+			// aapt resource value: 0x7f080030
+			public const int abc_cascading_menus_min_smallest_width = 2131230768;
 			
-			// aapt resource value: 0x7f070011
-			public const int abc_config_prefDialogWidth = 2131165201;
+			// aapt resource value: 0x7f080011
+			public const int abc_config_prefDialogWidth = 2131230737;
 			
-			// aapt resource value: 0x7f070031
-			public const int abc_control_corner_material = 2131165233;
+			// aapt resource value: 0x7f080031
+			public const int abc_control_corner_material = 2131230769;
 			
-			// aapt resource value: 0x7f070032
-			public const int abc_control_inset_material = 2131165234;
+			// aapt resource value: 0x7f080032
+			public const int abc_control_inset_material = 2131230770;
 			
-			// aapt resource value: 0x7f070033
-			public const int abc_control_padding_material = 2131165235;
+			// aapt resource value: 0x7f080033
+			public const int abc_control_padding_material = 2131230771;
 			
-			// aapt resource value: 0x7f070012
-			public const int abc_dialog_fixed_height_major = 2131165202;
+			// aapt resource value: 0x7f080012
+			public const int abc_dialog_fixed_height_major = 2131230738;
 			
-			// aapt resource value: 0x7f070013
-			public const int abc_dialog_fixed_height_minor = 2131165203;
+			// aapt resource value: 0x7f080013
+			public const int abc_dialog_fixed_height_minor = 2131230739;
 			
-			// aapt resource value: 0x7f070014
-			public const int abc_dialog_fixed_width_major = 2131165204;
+			// aapt resource value: 0x7f080014
+			public const int abc_dialog_fixed_width_major = 2131230740;
 			
-			// aapt resource value: 0x7f070015
-			public const int abc_dialog_fixed_width_minor = 2131165205;
+			// aapt resource value: 0x7f080015
+			public const int abc_dialog_fixed_width_minor = 2131230741;
 			
-			// aapt resource value: 0x7f070034
-			public const int abc_dialog_list_padding_bottom_no_buttons = 2131165236;
+			// aapt resource value: 0x7f080034
+			public const int abc_dialog_list_padding_bottom_no_buttons = 2131230772;
 			
-			// aapt resource value: 0x7f070035
-			public const int abc_dialog_list_padding_top_no_title = 2131165237;
+			// aapt resource value: 0x7f080035
+			public const int abc_dialog_list_padding_top_no_title = 2131230773;
 			
-			// aapt resource value: 0x7f070016
-			public const int abc_dialog_min_width_major = 2131165206;
+			// aapt resource value: 0x7f080016
+			public const int abc_dialog_min_width_major = 2131230742;
 			
-			// aapt resource value: 0x7f070017
-			public const int abc_dialog_min_width_minor = 2131165207;
+			// aapt resource value: 0x7f080017
+			public const int abc_dialog_min_width_minor = 2131230743;
 			
-			// aapt resource value: 0x7f070036
-			public const int abc_dialog_padding_material = 2131165238;
+			// aapt resource value: 0x7f080036
+			public const int abc_dialog_padding_material = 2131230774;
 			
-			// aapt resource value: 0x7f070037
-			public const int abc_dialog_padding_top_material = 2131165239;
+			// aapt resource value: 0x7f080037
+			public const int abc_dialog_padding_top_material = 2131230775;
 			
-			// aapt resource value: 0x7f070038
-			public const int abc_dialog_title_divider_material = 2131165240;
+			// aapt resource value: 0x7f080038
+			public const int abc_dialog_title_divider_material = 2131230776;
 			
-			// aapt resource value: 0x7f070039
-			public const int abc_disabled_alpha_material_dark = 2131165241;
+			// aapt resource value: 0x7f080039
+			public const int abc_disabled_alpha_material_dark = 2131230777;
 			
-			// aapt resource value: 0x7f07003a
-			public const int abc_disabled_alpha_material_light = 2131165242;
+			// aapt resource value: 0x7f08003a
+			public const int abc_disabled_alpha_material_light = 2131230778;
 			
-			// aapt resource value: 0x7f07003b
-			public const int abc_dropdownitem_icon_width = 2131165243;
+			// aapt resource value: 0x7f08003b
+			public const int abc_dropdownitem_icon_width = 2131230779;
 			
-			// aapt resource value: 0x7f07003c
-			public const int abc_dropdownitem_text_padding_left = 2131165244;
+			// aapt resource value: 0x7f08003c
+			public const int abc_dropdownitem_text_padding_left = 2131230780;
 			
-			// aapt resource value: 0x7f07003d
-			public const int abc_dropdownitem_text_padding_right = 2131165245;
+			// aapt resource value: 0x7f08003d
+			public const int abc_dropdownitem_text_padding_right = 2131230781;
 			
-			// aapt resource value: 0x7f07003e
-			public const int abc_edit_text_inset_bottom_material = 2131165246;
+			// aapt resource value: 0x7f08003e
+			public const int abc_edit_text_inset_bottom_material = 2131230782;
 			
-			// aapt resource value: 0x7f07003f
-			public const int abc_edit_text_inset_horizontal_material = 2131165247;
+			// aapt resource value: 0x7f08003f
+			public const int abc_edit_text_inset_horizontal_material = 2131230783;
 			
-			// aapt resource value: 0x7f070040
-			public const int abc_edit_text_inset_top_material = 2131165248;
+			// aapt resource value: 0x7f080040
+			public const int abc_edit_text_inset_top_material = 2131230784;
 			
-			// aapt resource value: 0x7f070041
-			public const int abc_floating_window_z = 2131165249;
+			// aapt resource value: 0x7f080041
+			public const int abc_floating_window_z = 2131230785;
 			
-			// aapt resource value: 0x7f070042
-			public const int abc_list_item_padding_horizontal_material = 2131165250;
+			// aapt resource value: 0x7f080042
+			public const int abc_list_item_padding_horizontal_material = 2131230786;
 			
-			// aapt resource value: 0x7f070043
-			public const int abc_panel_menu_list_width = 2131165251;
+			// aapt resource value: 0x7f080043
+			public const int abc_panel_menu_list_width = 2131230787;
 			
-			// aapt resource value: 0x7f070044
-			public const int abc_progress_bar_height_material = 2131165252;
+			// aapt resource value: 0x7f080044
+			public const int abc_progress_bar_height_material = 2131230788;
 			
-			// aapt resource value: 0x7f070045
-			public const int abc_search_view_preferred_height = 2131165253;
+			// aapt resource value: 0x7f080045
+			public const int abc_search_view_preferred_height = 2131230789;
 			
-			// aapt resource value: 0x7f070046
-			public const int abc_search_view_preferred_width = 2131165254;
+			// aapt resource value: 0x7f080046
+			public const int abc_search_view_preferred_width = 2131230790;
 			
-			// aapt resource value: 0x7f070047
-			public const int abc_seekbar_track_background_height_material = 2131165255;
+			// aapt resource value: 0x7f080047
+			public const int abc_seekbar_track_background_height_material = 2131230791;
 			
-			// aapt resource value: 0x7f070048
-			public const int abc_seekbar_track_progress_height_material = 2131165256;
+			// aapt resource value: 0x7f080048
+			public const int abc_seekbar_track_progress_height_material = 2131230792;
 			
-			// aapt resource value: 0x7f070049
-			public const int abc_select_dialog_padding_start_material = 2131165257;
+			// aapt resource value: 0x7f080049
+			public const int abc_select_dialog_padding_start_material = 2131230793;
 			
-			// aapt resource value: 0x7f07001d
-			public const int abc_switch_padding = 2131165213;
+			// aapt resource value: 0x7f08001d
+			public const int abc_switch_padding = 2131230749;
 			
-			// aapt resource value: 0x7f07004a
-			public const int abc_text_size_body_1_material = 2131165258;
+			// aapt resource value: 0x7f08004a
+			public const int abc_text_size_body_1_material = 2131230794;
 			
-			// aapt resource value: 0x7f07004b
-			public const int abc_text_size_body_2_material = 2131165259;
+			// aapt resource value: 0x7f08004b
+			public const int abc_text_size_body_2_material = 2131230795;
 			
-			// aapt resource value: 0x7f07004c
-			public const int abc_text_size_button_material = 2131165260;
+			// aapt resource value: 0x7f08004c
+			public const int abc_text_size_button_material = 2131230796;
 			
-			// aapt resource value: 0x7f07004d
-			public const int abc_text_size_caption_material = 2131165261;
+			// aapt resource value: 0x7f08004d
+			public const int abc_text_size_caption_material = 2131230797;
 			
-			// aapt resource value: 0x7f07004e
-			public const int abc_text_size_display_1_material = 2131165262;
+			// aapt resource value: 0x7f08004e
+			public const int abc_text_size_display_1_material = 2131230798;
 			
-			// aapt resource value: 0x7f07004f
-			public const int abc_text_size_display_2_material = 2131165263;
+			// aapt resource value: 0x7f08004f
+			public const int abc_text_size_display_2_material = 2131230799;
 			
-			// aapt resource value: 0x7f070050
-			public const int abc_text_size_display_3_material = 2131165264;
+			// aapt resource value: 0x7f080050
+			public const int abc_text_size_display_3_material = 2131230800;
 			
-			// aapt resource value: 0x7f070051
-			public const int abc_text_size_display_4_material = 2131165265;
+			// aapt resource value: 0x7f080051
+			public const int abc_text_size_display_4_material = 2131230801;
 			
-			// aapt resource value: 0x7f070052
-			public const int abc_text_size_headline_material = 2131165266;
+			// aapt resource value: 0x7f080052
+			public const int abc_text_size_headline_material = 2131230802;
 			
-			// aapt resource value: 0x7f070053
-			public const int abc_text_size_large_material = 2131165267;
+			// aapt resource value: 0x7f080053
+			public const int abc_text_size_large_material = 2131230803;
 			
-			// aapt resource value: 0x7f070054
-			public const int abc_text_size_medium_material = 2131165268;
+			// aapt resource value: 0x7f080054
+			public const int abc_text_size_medium_material = 2131230804;
 			
-			// aapt resource value: 0x7f070055
-			public const int abc_text_size_menu_header_material = 2131165269;
+			// aapt resource value: 0x7f080055
+			public const int abc_text_size_menu_header_material = 2131230805;
 			
-			// aapt resource value: 0x7f070056
-			public const int abc_text_size_menu_material = 2131165270;
+			// aapt resource value: 0x7f080056
+			public const int abc_text_size_menu_material = 2131230806;
 			
-			// aapt resource value: 0x7f070057
-			public const int abc_text_size_small_material = 2131165271;
+			// aapt resource value: 0x7f080057
+			public const int abc_text_size_small_material = 2131230807;
 			
-			// aapt resource value: 0x7f070058
-			public const int abc_text_size_subhead_material = 2131165272;
+			// aapt resource value: 0x7f080058
+			public const int abc_text_size_subhead_material = 2131230808;
 			
-			// aapt resource value: 0x7f07000f
-			public const int abc_text_size_subtitle_material_toolbar = 2131165199;
+			// aapt resource value: 0x7f08000f
+			public const int abc_text_size_subtitle_material_toolbar = 2131230735;
 			
-			// aapt resource value: 0x7f070059
-			public const int abc_text_size_title_material = 2131165273;
+			// aapt resource value: 0x7f080059
+			public const int abc_text_size_title_material = 2131230809;
 			
-			// aapt resource value: 0x7f070010
-			public const int abc_text_size_title_material_toolbar = 2131165200;
+			// aapt resource value: 0x7f080010
+			public const int abc_text_size_title_material_toolbar = 2131230736;
 			
-			// aapt resource value: 0x7f070009
-			public const int cardview_compat_inset_shadow = 2131165193;
+			// aapt resource value: 0x7f080009
+			public const int cardview_compat_inset_shadow = 2131230729;
 			
-			// aapt resource value: 0x7f07000a
-			public const int cardview_default_elevation = 2131165194;
+			// aapt resource value: 0x7f08000a
+			public const int cardview_default_elevation = 2131230730;
 			
-			// aapt resource value: 0x7f07000b
-			public const int cardview_default_radius = 2131165195;
+			// aapt resource value: 0x7f08000b
+			public const int cardview_default_radius = 2131230731;
 			
-			// aapt resource value: 0x7f070076
-			public const int design_appbar_elevation = 2131165302;
+			// aapt resource value: 0x7f080076
+			public const int design_appbar_elevation = 2131230838;
 			
-			// aapt resource value: 0x7f070077
-			public const int design_bottom_navigation_active_item_max_width = 2131165303;
+			// aapt resource value: 0x7f080077
+			public const int design_bottom_navigation_active_item_max_width = 2131230839;
 			
-			// aapt resource value: 0x7f070078
-			public const int design_bottom_navigation_active_text_size = 2131165304;
+			// aapt resource value: 0x7f080078
+			public const int design_bottom_navigation_active_text_size = 2131230840;
 			
-			// aapt resource value: 0x7f070079
-			public const int design_bottom_navigation_elevation = 2131165305;
+			// aapt resource value: 0x7f080079
+			public const int design_bottom_navigation_elevation = 2131230841;
 			
-			// aapt resource value: 0x7f07007a
-			public const int design_bottom_navigation_height = 2131165306;
+			// aapt resource value: 0x7f08007a
+			public const int design_bottom_navigation_height = 2131230842;
 			
-			// aapt resource value: 0x7f07007b
-			public const int design_bottom_navigation_item_max_width = 2131165307;
+			// aapt resource value: 0x7f08007b
+			public const int design_bottom_navigation_item_max_width = 2131230843;
 			
-			// aapt resource value: 0x7f07007c
-			public const int design_bottom_navigation_item_min_width = 2131165308;
+			// aapt resource value: 0x7f08007c
+			public const int design_bottom_navigation_item_min_width = 2131230844;
 			
-			// aapt resource value: 0x7f07007d
-			public const int design_bottom_navigation_margin = 2131165309;
+			// aapt resource value: 0x7f08007d
+			public const int design_bottom_navigation_margin = 2131230845;
 			
-			// aapt resource value: 0x7f07007e
-			public const int design_bottom_navigation_shadow_height = 2131165310;
+			// aapt resource value: 0x7f08007e
+			public const int design_bottom_navigation_shadow_height = 2131230846;
 			
-			// aapt resource value: 0x7f07007f
-			public const int design_bottom_navigation_text_size = 2131165311;
+			// aapt resource value: 0x7f08007f
+			public const int design_bottom_navigation_text_size = 2131230847;
 			
-			// aapt resource value: 0x7f070080
-			public const int design_bottom_sheet_modal_elevation = 2131165312;
+			// aapt resource value: 0x7f080080
+			public const int design_bottom_sheet_modal_elevation = 2131230848;
 			
-			// aapt resource value: 0x7f070081
-			public const int design_bottom_sheet_peek_height_min = 2131165313;
+			// aapt resource value: 0x7f080081
+			public const int design_bottom_sheet_peek_height_min = 2131230849;
 			
-			// aapt resource value: 0x7f070082
-			public const int design_fab_border_width = 2131165314;
+			// aapt resource value: 0x7f080082
+			public const int design_fab_border_width = 2131230850;
 			
-			// aapt resource value: 0x7f070083
-			public const int design_fab_elevation = 2131165315;
+			// aapt resource value: 0x7f080083
+			public const int design_fab_elevation = 2131230851;
 			
-			// aapt resource value: 0x7f070084
-			public const int design_fab_image_size = 2131165316;
+			// aapt resource value: 0x7f080084
+			public const int design_fab_image_size = 2131230852;
 			
-			// aapt resource value: 0x7f070085
-			public const int design_fab_size_mini = 2131165317;
+			// aapt resource value: 0x7f080085
+			public const int design_fab_size_mini = 2131230853;
 			
-			// aapt resource value: 0x7f070086
-			public const int design_fab_size_normal = 2131165318;
+			// aapt resource value: 0x7f080086
+			public const int design_fab_size_normal = 2131230854;
 			
-			// aapt resource value: 0x7f070087
-			public const int design_fab_translation_z_pressed = 2131165319;
+			// aapt resource value: 0x7f080087
+			public const int design_fab_translation_z_pressed = 2131230855;
 			
-			// aapt resource value: 0x7f070088
-			public const int design_navigation_elevation = 2131165320;
+			// aapt resource value: 0x7f080088
+			public const int design_navigation_elevation = 2131230856;
 			
-			// aapt resource value: 0x7f070089
-			public const int design_navigation_icon_padding = 2131165321;
+			// aapt resource value: 0x7f080089
+			public const int design_navigation_icon_padding = 2131230857;
 			
-			// aapt resource value: 0x7f07008a
-			public const int design_navigation_icon_size = 2131165322;
+			// aapt resource value: 0x7f08008a
+			public const int design_navigation_icon_size = 2131230858;
 			
-			// aapt resource value: 0x7f07006e
-			public const int design_navigation_max_width = 2131165294;
+			// aapt resource value: 0x7f08006e
+			public const int design_navigation_max_width = 2131230830;
 			
-			// aapt resource value: 0x7f07008b
-			public const int design_navigation_padding_bottom = 2131165323;
+			// aapt resource value: 0x7f08008b
+			public const int design_navigation_padding_bottom = 2131230859;
 			
-			// aapt resource value: 0x7f07008c
-			public const int design_navigation_separator_vertical_padding = 2131165324;
+			// aapt resource value: 0x7f08008c
+			public const int design_navigation_separator_vertical_padding = 2131230860;
 			
-			// aapt resource value: 0x7f07006f
-			public const int design_snackbar_action_inline_max_width = 2131165295;
+			// aapt resource value: 0x7f08006f
+			public const int design_snackbar_action_inline_max_width = 2131230831;
 			
-			// aapt resource value: 0x7f070070
-			public const int design_snackbar_background_corner_radius = 2131165296;
+			// aapt resource value: 0x7f080070
+			public const int design_snackbar_background_corner_radius = 2131230832;
 			
-			// aapt resource value: 0x7f07008d
-			public const int design_snackbar_elevation = 2131165325;
+			// aapt resource value: 0x7f08008d
+			public const int design_snackbar_elevation = 2131230861;
 			
-			// aapt resource value: 0x7f070071
-			public const int design_snackbar_extra_spacing_horizontal = 2131165297;
+			// aapt resource value: 0x7f080071
+			public const int design_snackbar_extra_spacing_horizontal = 2131230833;
 			
-			// aapt resource value: 0x7f070072
-			public const int design_snackbar_max_width = 2131165298;
+			// aapt resource value: 0x7f080072
+			public const int design_snackbar_max_width = 2131230834;
 			
-			// aapt resource value: 0x7f070073
-			public const int design_snackbar_min_width = 2131165299;
+			// aapt resource value: 0x7f080073
+			public const int design_snackbar_min_width = 2131230835;
 			
-			// aapt resource value: 0x7f07008e
-			public const int design_snackbar_padding_horizontal = 2131165326;
+			// aapt resource value: 0x7f08008e
+			public const int design_snackbar_padding_horizontal = 2131230862;
 			
-			// aapt resource value: 0x7f07008f
-			public const int design_snackbar_padding_vertical = 2131165327;
+			// aapt resource value: 0x7f08008f
+			public const int design_snackbar_padding_vertical = 2131230863;
 			
-			// aapt resource value: 0x7f070074
-			public const int design_snackbar_padding_vertical_2lines = 2131165300;
+			// aapt resource value: 0x7f080074
+			public const int design_snackbar_padding_vertical_2lines = 2131230836;
 			
-			// aapt resource value: 0x7f070090
-			public const int design_snackbar_text_size = 2131165328;
+			// aapt resource value: 0x7f080090
+			public const int design_snackbar_text_size = 2131230864;
 			
-			// aapt resource value: 0x7f070091
-			public const int design_tab_max_width = 2131165329;
+			// aapt resource value: 0x7f080091
+			public const int design_tab_max_width = 2131230865;
 			
-			// aapt resource value: 0x7f070075
-			public const int design_tab_scrollable_min_width = 2131165301;
+			// aapt resource value: 0x7f080075
+			public const int design_tab_scrollable_min_width = 2131230837;
 			
-			// aapt resource value: 0x7f070092
-			public const int design_tab_text_size = 2131165330;
+			// aapt resource value: 0x7f080092
+			public const int design_tab_text_size = 2131230866;
 			
-			// aapt resource value: 0x7f070093
-			public const int design_tab_text_size_2line = 2131165331;
+			// aapt resource value: 0x7f080093
+			public const int design_tab_text_size_2line = 2131230867;
 			
-			// aapt resource value: 0x7f07005a
-			public const int disabled_alpha_material_dark = 2131165274;
+			// aapt resource value: 0x7f08005a
+			public const int disabled_alpha_material_dark = 2131230810;
 			
-			// aapt resource value: 0x7f07005b
-			public const int disabled_alpha_material_light = 2131165275;
+			// aapt resource value: 0x7f08005b
+			public const int disabled_alpha_material_light = 2131230811;
 			
-			// aapt resource value: 0x7f07005c
-			public const int highlight_alpha_material_colored = 2131165276;
+			// aapt resource value: 0x7f08005c
+			public const int highlight_alpha_material_colored = 2131230812;
 			
-			// aapt resource value: 0x7f07005d
-			public const int highlight_alpha_material_dark = 2131165277;
+			// aapt resource value: 0x7f08005d
+			public const int highlight_alpha_material_dark = 2131230813;
 			
-			// aapt resource value: 0x7f07005e
-			public const int highlight_alpha_material_light = 2131165278;
+			// aapt resource value: 0x7f08005e
+			public const int highlight_alpha_material_light = 2131230814;
 			
-			// aapt resource value: 0x7f07005f
-			public const int hint_alpha_material_dark = 2131165279;
+			// aapt resource value: 0x7f08005f
+			public const int hint_alpha_material_dark = 2131230815;
 			
-			// aapt resource value: 0x7f070060
-			public const int hint_alpha_material_light = 2131165280;
+			// aapt resource value: 0x7f080060
+			public const int hint_alpha_material_light = 2131230816;
 			
-			// aapt resource value: 0x7f070061
-			public const int hint_pressed_alpha_material_dark = 2131165281;
+			// aapt resource value: 0x7f080061
+			public const int hint_pressed_alpha_material_dark = 2131230817;
 			
-			// aapt resource value: 0x7f070062
-			public const int hint_pressed_alpha_material_light = 2131165282;
+			// aapt resource value: 0x7f080062
+			public const int hint_pressed_alpha_material_light = 2131230818;
 			
-			// aapt resource value: 0x7f070000
-			public const int item_touch_helper_max_drag_scroll_per_frame = 2131165184;
+			// aapt resource value: 0x7f080000
+			public const int item_touch_helper_max_drag_scroll_per_frame = 2131230720;
 			
-			// aapt resource value: 0x7f070001
-			public const int item_touch_helper_swipe_escape_max_velocity = 2131165185;
+			// aapt resource value: 0x7f080001
+			public const int item_touch_helper_swipe_escape_max_velocity = 2131230721;
 			
-			// aapt resource value: 0x7f070002
-			public const int item_touch_helper_swipe_escape_velocity = 2131165186;
+			// aapt resource value: 0x7f080002
+			public const int item_touch_helper_swipe_escape_velocity = 2131230722;
 			
-			// aapt resource value: 0x7f070003
-			public const int mr_controller_volume_group_list_item_height = 2131165187;
+			// aapt resource value: 0x7f080003
+			public const int mr_controller_volume_group_list_item_height = 2131230723;
 			
-			// aapt resource value: 0x7f070004
-			public const int mr_controller_volume_group_list_item_icon_size = 2131165188;
+			// aapt resource value: 0x7f080004
+			public const int mr_controller_volume_group_list_item_icon_size = 2131230724;
 			
-			// aapt resource value: 0x7f070005
-			public const int mr_controller_volume_group_list_max_height = 2131165189;
+			// aapt resource value: 0x7f080005
+			public const int mr_controller_volume_group_list_max_height = 2131230725;
 			
-			// aapt resource value: 0x7f070008
-			public const int mr_controller_volume_group_list_padding_top = 2131165192;
+			// aapt resource value: 0x7f080008
+			public const int mr_controller_volume_group_list_padding_top = 2131230728;
 			
-			// aapt resource value: 0x7f070006
-			public const int mr_dialog_fixed_width_major = 2131165190;
+			// aapt resource value: 0x7f080006
+			public const int mr_dialog_fixed_width_major = 2131230726;
 			
-			// aapt resource value: 0x7f070007
-			public const int mr_dialog_fixed_width_minor = 2131165191;
+			// aapt resource value: 0x7f080007
+			public const int mr_dialog_fixed_width_minor = 2131230727;
 			
-			// aapt resource value: 0x7f070063
-			public const int notification_action_icon_size = 2131165283;
+			// aapt resource value: 0x7f080063
+			public const int notification_action_icon_size = 2131230819;
 			
-			// aapt resource value: 0x7f070064
-			public const int notification_action_text_size = 2131165284;
+			// aapt resource value: 0x7f080064
+			public const int notification_action_text_size = 2131230820;
 			
-			// aapt resource value: 0x7f070065
-			public const int notification_big_circle_margin = 2131165285;
+			// aapt resource value: 0x7f080065
+			public const int notification_big_circle_margin = 2131230821;
 			
-			// aapt resource value: 0x7f07001e
-			public const int notification_content_margin_start = 2131165214;
+			// aapt resource value: 0x7f08001e
+			public const int notification_content_margin_start = 2131230750;
 			
-			// aapt resource value: 0x7f070066
-			public const int notification_large_icon_height = 2131165286;
+			// aapt resource value: 0x7f080066
+			public const int notification_large_icon_height = 2131230822;
 			
-			// aapt resource value: 0x7f070067
-			public const int notification_large_icon_width = 2131165287;
+			// aapt resource value: 0x7f080067
+			public const int notification_large_icon_width = 2131230823;
 			
-			// aapt resource value: 0x7f07001f
-			public const int notification_main_column_padding_top = 2131165215;
+			// aapt resource value: 0x7f08001f
+			public const int notification_main_column_padding_top = 2131230751;
 			
-			// aapt resource value: 0x7f070020
-			public const int notification_media_narrow_margin = 2131165216;
+			// aapt resource value: 0x7f080020
+			public const int notification_media_narrow_margin = 2131230752;
 			
-			// aapt resource value: 0x7f070068
-			public const int notification_right_icon_size = 2131165288;
+			// aapt resource value: 0x7f080068
+			public const int notification_right_icon_size = 2131230824;
 			
-			// aapt resource value: 0x7f07001c
-			public const int notification_right_side_padding_top = 2131165212;
+			// aapt resource value: 0x7f08001c
+			public const int notification_right_side_padding_top = 2131230748;
 			
-			// aapt resource value: 0x7f070069
-			public const int notification_small_icon_background_padding = 2131165289;
+			// aapt resource value: 0x7f080069
+			public const int notification_small_icon_background_padding = 2131230825;
 			
-			// aapt resource value: 0x7f07006a
-			public const int notification_small_icon_size_as_large = 2131165290;
+			// aapt resource value: 0x7f08006a
+			public const int notification_small_icon_size_as_large = 2131230826;
 			
-			// aapt resource value: 0x7f07006b
-			public const int notification_subtext_size = 2131165291;
+			// aapt resource value: 0x7f08006b
+			public const int notification_subtext_size = 2131230827;
 			
-			// aapt resource value: 0x7f07006c
-			public const int notification_top_pad = 2131165292;
+			// aapt resource value: 0x7f08006c
+			public const int notification_top_pad = 2131230828;
 			
-			// aapt resource value: 0x7f07006d
-			public const int notification_top_pad_large_text = 2131165293;
+			// aapt resource value: 0x7f08006d
+			public const int notification_top_pad_large_text = 2131230829;
 			
 			static Dimension()
 			{
@@ -2784,548 +2784,548 @@ namespace XFormsApp.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f08009e
-			public const int action0 = 2131230878;
+			// aapt resource value: 0x7f09009e
+			public const int action0 = 2131296414;
 			
-			// aapt resource value: 0x7f080064
-			public const int action_bar = 2131230820;
+			// aapt resource value: 0x7f090064
+			public const int action_bar = 2131296356;
 			
-			// aapt resource value: 0x7f080001
-			public const int action_bar_activity_content = 2131230721;
+			// aapt resource value: 0x7f090001
+			public const int action_bar_activity_content = 2131296257;
 			
-			// aapt resource value: 0x7f080063
-			public const int action_bar_container = 2131230819;
+			// aapt resource value: 0x7f090063
+			public const int action_bar_container = 2131296355;
 			
-			// aapt resource value: 0x7f08005f
-			public const int action_bar_root = 2131230815;
+			// aapt resource value: 0x7f09005f
+			public const int action_bar_root = 2131296351;
 			
-			// aapt resource value: 0x7f080002
-			public const int action_bar_spinner = 2131230722;
+			// aapt resource value: 0x7f090002
+			public const int action_bar_spinner = 2131296258;
 			
-			// aapt resource value: 0x7f080042
-			public const int action_bar_subtitle = 2131230786;
+			// aapt resource value: 0x7f090042
+			public const int action_bar_subtitle = 2131296322;
 			
-			// aapt resource value: 0x7f080041
-			public const int action_bar_title = 2131230785;
+			// aapt resource value: 0x7f090041
+			public const int action_bar_title = 2131296321;
 			
-			// aapt resource value: 0x7f08009b
-			public const int action_container = 2131230875;
+			// aapt resource value: 0x7f09009b
+			public const int action_container = 2131296411;
 			
-			// aapt resource value: 0x7f080065
-			public const int action_context_bar = 2131230821;
+			// aapt resource value: 0x7f090065
+			public const int action_context_bar = 2131296357;
 			
-			// aapt resource value: 0x7f0800a2
-			public const int action_divider = 2131230882;
+			// aapt resource value: 0x7f0900a2
+			public const int action_divider = 2131296418;
 			
-			// aapt resource value: 0x7f08009c
-			public const int action_image = 2131230876;
+			// aapt resource value: 0x7f09009c
+			public const int action_image = 2131296412;
 			
-			// aapt resource value: 0x7f080003
-			public const int action_menu_divider = 2131230723;
+			// aapt resource value: 0x7f090003
+			public const int action_menu_divider = 2131296259;
 			
-			// aapt resource value: 0x7f080004
-			public const int action_menu_presenter = 2131230724;
+			// aapt resource value: 0x7f090004
+			public const int action_menu_presenter = 2131296260;
 			
-			// aapt resource value: 0x7f080061
-			public const int action_mode_bar = 2131230817;
+			// aapt resource value: 0x7f090061
+			public const int action_mode_bar = 2131296353;
 			
-			// aapt resource value: 0x7f080060
-			public const int action_mode_bar_stub = 2131230816;
+			// aapt resource value: 0x7f090060
+			public const int action_mode_bar_stub = 2131296352;
 			
-			// aapt resource value: 0x7f080043
-			public const int action_mode_close_button = 2131230787;
+			// aapt resource value: 0x7f090043
+			public const int action_mode_close_button = 2131296323;
 			
-			// aapt resource value: 0x7f08009d
-			public const int action_text = 2131230877;
+			// aapt resource value: 0x7f09009d
+			public const int action_text = 2131296413;
 			
-			// aapt resource value: 0x7f0800ab
-			public const int actions = 2131230891;
+			// aapt resource value: 0x7f0900ab
+			public const int actions = 2131296427;
 			
-			// aapt resource value: 0x7f080044
-			public const int activity_chooser_view_content = 2131230788;
+			// aapt resource value: 0x7f090044
+			public const int activity_chooser_view_content = 2131296324;
 			
-			// aapt resource value: 0x7f08001e
-			public const int add = 2131230750;
+			// aapt resource value: 0x7f09001e
+			public const int add = 2131296286;
 			
-			// aapt resource value: 0x7f0800b2
-			public const int agentWebView = 2131230898;
+			// aapt resource value: 0x7f0900b2
+			public const int agentWebView = 2131296434;
 			
-			// aapt resource value: 0x7f080058
-			public const int alertTitle = 2131230808;
+			// aapt resource value: 0x7f090058
+			public const int alertTitle = 2131296344;
 			
-			// aapt resource value: 0x7f08003d
-			public const int all = 2131230781;
+			// aapt resource value: 0x7f09003d
+			public const int all = 2131296317;
 			
-			// aapt resource value: 0x7f080023
-			public const int always = 2131230755;
+			// aapt resource value: 0x7f090023
+			public const int always = 2131296291;
 			
-			// aapt resource value: 0x7f08002f
-			public const int auto = 2131230767;
+			// aapt resource value: 0x7f09002f
+			public const int auto = 2131296303;
 			
-			// aapt resource value: 0x7f080020
-			public const int beginning = 2131230752;
+			// aapt resource value: 0x7f090020
+			public const int beginning = 2131296288;
 			
-			// aapt resource value: 0x7f080028
-			public const int bottom = 2131230760;
+			// aapt resource value: 0x7f090028
+			public const int bottom = 2131296296;
 			
-			// aapt resource value: 0x7f08004b
-			public const int buttonPanel = 2131230795;
+			// aapt resource value: 0x7f09004b
+			public const int buttonPanel = 2131296331;
 			
-			// aapt resource value: 0x7f08009f
-			public const int cancel_action = 2131230879;
+			// aapt resource value: 0x7f09009f
+			public const int cancel_action = 2131296415;
 			
-			// aapt resource value: 0x7f080030
-			public const int center = 2131230768;
+			// aapt resource value: 0x7f090030
+			public const int center = 2131296304;
 			
-			// aapt resource value: 0x7f080031
-			public const int center_horizontal = 2131230769;
+			// aapt resource value: 0x7f090031
+			public const int center_horizontal = 2131296305;
 			
-			// aapt resource value: 0x7f080032
-			public const int center_vertical = 2131230770;
+			// aapt resource value: 0x7f090032
+			public const int center_vertical = 2131296306;
 			
-			// aapt resource value: 0x7f08005b
-			public const int checkbox = 2131230811;
+			// aapt resource value: 0x7f09005b
+			public const int checkbox = 2131296347;
 			
-			// aapt resource value: 0x7f0800a7
-			public const int chronometer = 2131230887;
+			// aapt resource value: 0x7f0900a7
+			public const int chronometer = 2131296423;
 			
-			// aapt resource value: 0x7f080039
-			public const int clip_horizontal = 2131230777;
+			// aapt resource value: 0x7f090039
+			public const int clip_horizontal = 2131296313;
 			
-			// aapt resource value: 0x7f08003a
-			public const int clip_vertical = 2131230778;
+			// aapt resource value: 0x7f09003a
+			public const int clip_vertical = 2131296314;
 			
-			// aapt resource value: 0x7f080024
-			public const int collapseActionView = 2131230756;
+			// aapt resource value: 0x7f090024
+			public const int collapseActionView = 2131296292;
 			
-			// aapt resource value: 0x7f080075
-			public const int container = 2131230837;
+			// aapt resource value: 0x7f090075
+			public const int container = 2131296373;
 			
-			// aapt resource value: 0x7f08004e
-			public const int contentPanel = 2131230798;
+			// aapt resource value: 0x7f09004e
+			public const int contentPanel = 2131296334;
 			
-			// aapt resource value: 0x7f080076
-			public const int coordinator = 2131230838;
+			// aapt resource value: 0x7f090076
+			public const int coordinator = 2131296374;
 			
-			// aapt resource value: 0x7f080055
-			public const int custom = 2131230805;
+			// aapt resource value: 0x7f090055
+			public const int custom = 2131296341;
 			
-			// aapt resource value: 0x7f080054
-			public const int customPanel = 2131230804;
+			// aapt resource value: 0x7f090054
+			public const int customPanel = 2131296340;
 			
-			// aapt resource value: 0x7f080062
-			public const int decor_content_parent = 2131230818;
+			// aapt resource value: 0x7f090062
+			public const int decor_content_parent = 2131296354;
 			
-			// aapt resource value: 0x7f080047
-			public const int default_activity_button = 2131230791;
+			// aapt resource value: 0x7f090047
+			public const int default_activity_button = 2131296327;
 			
-			// aapt resource value: 0x7f080078
-			public const int design_bottom_sheet = 2131230840;
+			// aapt resource value: 0x7f090078
+			public const int design_bottom_sheet = 2131296376;
 			
-			// aapt resource value: 0x7f08007f
-			public const int design_menu_item_action_area = 2131230847;
+			// aapt resource value: 0x7f09007f
+			public const int design_menu_item_action_area = 2131296383;
 			
-			// aapt resource value: 0x7f08007e
-			public const int design_menu_item_action_area_stub = 2131230846;
+			// aapt resource value: 0x7f09007e
+			public const int design_menu_item_action_area_stub = 2131296382;
 			
-			// aapt resource value: 0x7f08007d
-			public const int design_menu_item_text = 2131230845;
+			// aapt resource value: 0x7f09007d
+			public const int design_menu_item_text = 2131296381;
 			
-			// aapt resource value: 0x7f08007c
-			public const int design_navigation_view = 2131230844;
+			// aapt resource value: 0x7f09007c
+			public const int design_navigation_view = 2131296380;
 			
-			// aapt resource value: 0x7f080012
-			public const int disableHome = 2131230738;
+			// aapt resource value: 0x7f090012
+			public const int disableHome = 2131296274;
 			
-			// aapt resource value: 0x7f080066
-			public const int edit_query = 2131230822;
+			// aapt resource value: 0x7f090066
+			public const int edit_query = 2131296358;
 			
-			// aapt resource value: 0x7f080021
-			public const int end = 2131230753;
+			// aapt resource value: 0x7f090021
+			public const int end = 2131296289;
 			
-			// aapt resource value: 0x7f0800b1
-			public const int end_padder = 2131230897;
+			// aapt resource value: 0x7f0900b1
+			public const int end_padder = 2131296433;
 			
-			// aapt resource value: 0x7f08002a
-			public const int enterAlways = 2131230762;
+			// aapt resource value: 0x7f09002a
+			public const int enterAlways = 2131296298;
 			
-			// aapt resource value: 0x7f08002b
-			public const int enterAlwaysCollapsed = 2131230763;
+			// aapt resource value: 0x7f09002b
+			public const int enterAlwaysCollapsed = 2131296299;
 			
-			// aapt resource value: 0x7f08002c
-			public const int exitUntilCollapsed = 2131230764;
+			// aapt resource value: 0x7f09002c
+			public const int exitUntilCollapsed = 2131296300;
 			
-			// aapt resource value: 0x7f080045
-			public const int expand_activities_button = 2131230789;
+			// aapt resource value: 0x7f090045
+			public const int expand_activities_button = 2131296325;
 			
-			// aapt resource value: 0x7f08005a
-			public const int expanded_menu = 2131230810;
+			// aapt resource value: 0x7f09005a
+			public const int expanded_menu = 2131296346;
 			
-			// aapt resource value: 0x7f08003b
-			public const int fill = 2131230779;
+			// aapt resource value: 0x7f09003b
+			public const int fill = 2131296315;
 			
-			// aapt resource value: 0x7f08003c
-			public const int fill_horizontal = 2131230780;
+			// aapt resource value: 0x7f09003c
+			public const int fill_horizontal = 2131296316;
 			
-			// aapt resource value: 0x7f080033
-			public const int fill_vertical = 2131230771;
+			// aapt resource value: 0x7f090033
+			public const int fill_vertical = 2131296307;
 			
-			// aapt resource value: 0x7f08003f
-			public const int @fixed = 2131230783;
+			// aapt resource value: 0x7f09003f
+			public const int @fixed = 2131296319;
 			
-			// aapt resource value: 0x7f080005
-			public const int home = 2131230725;
+			// aapt resource value: 0x7f090005
+			public const int home = 2131296261;
 			
-			// aapt resource value: 0x7f080013
-			public const int homeAsUp = 2131230739;
+			// aapt resource value: 0x7f090013
+			public const int homeAsUp = 2131296275;
 			
-			// aapt resource value: 0x7f080049
-			public const int icon = 2131230793;
+			// aapt resource value: 0x7f090049
+			public const int icon = 2131296329;
 			
-			// aapt resource value: 0x7f0800ac
-			public const int icon_group = 2131230892;
+			// aapt resource value: 0x7f0900ac
+			public const int icon_group = 2131296428;
 			
-			// aapt resource value: 0x7f080025
-			public const int ifRoom = 2131230757;
+			// aapt resource value: 0x7f090025
+			public const int ifRoom = 2131296293;
 			
-			// aapt resource value: 0x7f080046
-			public const int image = 2131230790;
+			// aapt resource value: 0x7f090046
+			public const int image = 2131296326;
 			
-			// aapt resource value: 0x7f0800a8
-			public const int info = 2131230888;
+			// aapt resource value: 0x7f0900a8
+			public const int info = 2131296424;
 			
-			// aapt resource value: 0x7f080000
-			public const int item_touch_helper_previous_elevation = 2131230720;
+			// aapt resource value: 0x7f090000
+			public const int item_touch_helper_previous_elevation = 2131296256;
 			
-			// aapt resource value: 0x7f080074
-			public const int largeLabel = 2131230836;
+			// aapt resource value: 0x7f090074
+			public const int largeLabel = 2131296372;
 			
-			// aapt resource value: 0x7f080034
-			public const int left = 2131230772;
+			// aapt resource value: 0x7f090034
+			public const int left = 2131296308;
 			
-			// aapt resource value: 0x7f0800ad
-			public const int line1 = 2131230893;
+			// aapt resource value: 0x7f0900ad
+			public const int line1 = 2131296429;
 			
-			// aapt resource value: 0x7f0800af
-			public const int line3 = 2131230895;
+			// aapt resource value: 0x7f0900af
+			public const int line3 = 2131296431;
 			
-			// aapt resource value: 0x7f08000f
-			public const int listMode = 2131230735;
+			// aapt resource value: 0x7f09000f
+			public const int listMode = 2131296271;
 			
-			// aapt resource value: 0x7f080048
-			public const int list_item = 2131230792;
+			// aapt resource value: 0x7f090048
+			public const int list_item = 2131296328;
 			
-			// aapt resource value: 0x7f0800b4
-			public const int masked = 2131230900;
+			// aapt resource value: 0x7f0900b4
+			public const int masked = 2131296436;
 			
-			// aapt resource value: 0x7f0800a1
-			public const int media_actions = 2131230881;
+			// aapt resource value: 0x7f0900a1
+			public const int media_actions = 2131296417;
 			
-			// aapt resource value: 0x7f080022
-			public const int middle = 2131230754;
+			// aapt resource value: 0x7f090022
+			public const int middle = 2131296290;
 			
-			// aapt resource value: 0x7f08003e
-			public const int mini = 2131230782;
+			// aapt resource value: 0x7f09003e
+			public const int mini = 2131296318;
 			
-			// aapt resource value: 0x7f08008d
-			public const int mr_art = 2131230861;
+			// aapt resource value: 0x7f09008d
+			public const int mr_art = 2131296397;
 			
-			// aapt resource value: 0x7f080082
-			public const int mr_chooser_list = 2131230850;
+			// aapt resource value: 0x7f090082
+			public const int mr_chooser_list = 2131296386;
 			
-			// aapt resource value: 0x7f080085
-			public const int mr_chooser_route_desc = 2131230853;
+			// aapt resource value: 0x7f090085
+			public const int mr_chooser_route_desc = 2131296389;
 			
-			// aapt resource value: 0x7f080083
-			public const int mr_chooser_route_icon = 2131230851;
+			// aapt resource value: 0x7f090083
+			public const int mr_chooser_route_icon = 2131296387;
 			
-			// aapt resource value: 0x7f080084
-			public const int mr_chooser_route_name = 2131230852;
+			// aapt resource value: 0x7f090084
+			public const int mr_chooser_route_name = 2131296388;
 			
-			// aapt resource value: 0x7f080081
-			public const int mr_chooser_title = 2131230849;
+			// aapt resource value: 0x7f090081
+			public const int mr_chooser_title = 2131296385;
 			
-			// aapt resource value: 0x7f08008a
-			public const int mr_close = 2131230858;
+			// aapt resource value: 0x7f09008a
+			public const int mr_close = 2131296394;
 			
-			// aapt resource value: 0x7f080090
-			public const int mr_control_divider = 2131230864;
+			// aapt resource value: 0x7f090090
+			public const int mr_control_divider = 2131296400;
 			
-			// aapt resource value: 0x7f080096
-			public const int mr_control_playback_ctrl = 2131230870;
+			// aapt resource value: 0x7f090096
+			public const int mr_control_playback_ctrl = 2131296406;
 			
-			// aapt resource value: 0x7f080099
-			public const int mr_control_subtitle = 2131230873;
+			// aapt resource value: 0x7f090099
+			public const int mr_control_subtitle = 2131296409;
 			
-			// aapt resource value: 0x7f080098
-			public const int mr_control_title = 2131230872;
+			// aapt resource value: 0x7f090098
+			public const int mr_control_title = 2131296408;
 			
-			// aapt resource value: 0x7f080097
-			public const int mr_control_title_container = 2131230871;
+			// aapt resource value: 0x7f090097
+			public const int mr_control_title_container = 2131296407;
 			
-			// aapt resource value: 0x7f08008b
-			public const int mr_custom_control = 2131230859;
+			// aapt resource value: 0x7f09008b
+			public const int mr_custom_control = 2131296395;
 			
-			// aapt resource value: 0x7f08008c
-			public const int mr_default_control = 2131230860;
+			// aapt resource value: 0x7f09008c
+			public const int mr_default_control = 2131296396;
 			
-			// aapt resource value: 0x7f080087
-			public const int mr_dialog_area = 2131230855;
+			// aapt resource value: 0x7f090087
+			public const int mr_dialog_area = 2131296391;
 			
-			// aapt resource value: 0x7f080086
-			public const int mr_expandable_area = 2131230854;
+			// aapt resource value: 0x7f090086
+			public const int mr_expandable_area = 2131296390;
 			
-			// aapt resource value: 0x7f08009a
-			public const int mr_group_expand_collapse = 2131230874;
+			// aapt resource value: 0x7f09009a
+			public const int mr_group_expand_collapse = 2131296410;
 			
-			// aapt resource value: 0x7f08008e
-			public const int mr_media_main_control = 2131230862;
+			// aapt resource value: 0x7f09008e
+			public const int mr_media_main_control = 2131296398;
 			
-			// aapt resource value: 0x7f080089
-			public const int mr_name = 2131230857;
+			// aapt resource value: 0x7f090089
+			public const int mr_name = 2131296393;
 			
-			// aapt resource value: 0x7f08008f
-			public const int mr_playback_control = 2131230863;
+			// aapt resource value: 0x7f09008f
+			public const int mr_playback_control = 2131296399;
 			
-			// aapt resource value: 0x7f080088
-			public const int mr_title_bar = 2131230856;
+			// aapt resource value: 0x7f090088
+			public const int mr_title_bar = 2131296392;
 			
-			// aapt resource value: 0x7f080091
-			public const int mr_volume_control = 2131230865;
+			// aapt resource value: 0x7f090091
+			public const int mr_volume_control = 2131296401;
 			
-			// aapt resource value: 0x7f080092
-			public const int mr_volume_group_list = 2131230866;
+			// aapt resource value: 0x7f090092
+			public const int mr_volume_group_list = 2131296402;
 			
-			// aapt resource value: 0x7f080094
-			public const int mr_volume_item_icon = 2131230868;
+			// aapt resource value: 0x7f090094
+			public const int mr_volume_item_icon = 2131296404;
 			
-			// aapt resource value: 0x7f080095
-			public const int mr_volume_slider = 2131230869;
+			// aapt resource value: 0x7f090095
+			public const int mr_volume_slider = 2131296405;
 			
-			// aapt resource value: 0x7f080019
-			public const int multiply = 2131230745;
+			// aapt resource value: 0x7f090019
+			public const int multiply = 2131296281;
 			
-			// aapt resource value: 0x7f08007b
-			public const int navigation_header_container = 2131230843;
+			// aapt resource value: 0x7f09007b
+			public const int navigation_header_container = 2131296379;
 			
-			// aapt resource value: 0x7f080026
-			public const int never = 2131230758;
+			// aapt resource value: 0x7f090026
+			public const int never = 2131296294;
 			
-			// aapt resource value: 0x7f080014
-			public const int none = 2131230740;
+			// aapt resource value: 0x7f090014
+			public const int none = 2131296276;
 			
-			// aapt resource value: 0x7f080010
-			public const int normal = 2131230736;
+			// aapt resource value: 0x7f090010
+			public const int normal = 2131296272;
 			
-			// aapt resource value: 0x7f0800aa
-			public const int notification_background = 2131230890;
+			// aapt resource value: 0x7f0900aa
+			public const int notification_background = 2131296426;
 			
-			// aapt resource value: 0x7f0800a4
-			public const int notification_main_column = 2131230884;
+			// aapt resource value: 0x7f0900a4
+			public const int notification_main_column = 2131296420;
 			
-			// aapt resource value: 0x7f0800a3
-			public const int notification_main_column_container = 2131230883;
+			// aapt resource value: 0x7f0900a3
+			public const int notification_main_column_container = 2131296419;
 			
-			// aapt resource value: 0x7f080037
-			public const int parallax = 2131230775;
+			// aapt resource value: 0x7f090037
+			public const int parallax = 2131296311;
 			
-			// aapt resource value: 0x7f08004d
-			public const int parentPanel = 2131230797;
+			// aapt resource value: 0x7f09004d
+			public const int parentPanel = 2131296333;
 			
-			// aapt resource value: 0x7f080038
-			public const int pin = 2131230776;
+			// aapt resource value: 0x7f090038
+			public const int pin = 2131296312;
 			
-			// aapt resource value: 0x7f080006
-			public const int progress_circular = 2131230726;
+			// aapt resource value: 0x7f090006
+			public const int progress_circular = 2131296262;
 			
-			// aapt resource value: 0x7f080007
-			public const int progress_horizontal = 2131230727;
+			// aapt resource value: 0x7f090007
+			public const int progress_horizontal = 2131296263;
 			
-			// aapt resource value: 0x7f08005d
-			public const int radio = 2131230813;
+			// aapt resource value: 0x7f09005d
+			public const int radio = 2131296349;
 			
-			// aapt resource value: 0x7f080035
-			public const int right = 2131230773;
+			// aapt resource value: 0x7f090035
+			public const int right = 2131296309;
 			
-			// aapt resource value: 0x7f0800a9
-			public const int right_icon = 2131230889;
+			// aapt resource value: 0x7f0900a9
+			public const int right_icon = 2131296425;
 			
-			// aapt resource value: 0x7f0800a5
-			public const int right_side = 2131230885;
+			// aapt resource value: 0x7f0900a5
+			public const int right_side = 2131296421;
 			
-			// aapt resource value: 0x7f08001a
-			public const int screen = 2131230746;
+			// aapt resource value: 0x7f09001a
+			public const int screen = 2131296282;
 			
-			// aapt resource value: 0x7f08002d
-			public const int scroll = 2131230765;
+			// aapt resource value: 0x7f09002d
+			public const int scroll = 2131296301;
 			
-			// aapt resource value: 0x7f080053
-			public const int scrollIndicatorDown = 2131230803;
+			// aapt resource value: 0x7f090053
+			public const int scrollIndicatorDown = 2131296339;
 			
-			// aapt resource value: 0x7f08004f
-			public const int scrollIndicatorUp = 2131230799;
+			// aapt resource value: 0x7f09004f
+			public const int scrollIndicatorUp = 2131296335;
 			
-			// aapt resource value: 0x7f080050
-			public const int scrollView = 2131230800;
+			// aapt resource value: 0x7f090050
+			public const int scrollView = 2131296336;
 			
-			// aapt resource value: 0x7f080040
-			public const int scrollable = 2131230784;
+			// aapt resource value: 0x7f090040
+			public const int scrollable = 2131296320;
 			
-			// aapt resource value: 0x7f080068
-			public const int search_badge = 2131230824;
+			// aapt resource value: 0x7f090068
+			public const int search_badge = 2131296360;
 			
-			// aapt resource value: 0x7f080067
-			public const int search_bar = 2131230823;
+			// aapt resource value: 0x7f090067
+			public const int search_bar = 2131296359;
 			
-			// aapt resource value: 0x7f080069
-			public const int search_button = 2131230825;
+			// aapt resource value: 0x7f090069
+			public const int search_button = 2131296361;
 			
-			// aapt resource value: 0x7f08006e
-			public const int search_close_btn = 2131230830;
+			// aapt resource value: 0x7f09006e
+			public const int search_close_btn = 2131296366;
 			
-			// aapt resource value: 0x7f08006a
-			public const int search_edit_frame = 2131230826;
+			// aapt resource value: 0x7f09006a
+			public const int search_edit_frame = 2131296362;
 			
-			// aapt resource value: 0x7f080070
-			public const int search_go_btn = 2131230832;
+			// aapt resource value: 0x7f090070
+			public const int search_go_btn = 2131296368;
 			
-			// aapt resource value: 0x7f08006b
-			public const int search_mag_icon = 2131230827;
+			// aapt resource value: 0x7f09006b
+			public const int search_mag_icon = 2131296363;
 			
-			// aapt resource value: 0x7f08006c
-			public const int search_plate = 2131230828;
+			// aapt resource value: 0x7f09006c
+			public const int search_plate = 2131296364;
 			
-			// aapt resource value: 0x7f08006d
-			public const int search_src_text = 2131230829;
+			// aapt resource value: 0x7f09006d
+			public const int search_src_text = 2131296365;
 			
-			// aapt resource value: 0x7f080071
-			public const int search_voice_btn = 2131230833;
+			// aapt resource value: 0x7f090071
+			public const int search_voice_btn = 2131296369;
 			
-			// aapt resource value: 0x7f080072
-			public const int select_dialog_listview = 2131230834;
+			// aapt resource value: 0x7f090072
+			public const int select_dialog_listview = 2131296370;
 			
-			// aapt resource value: 0x7f08005c
-			public const int shortcut = 2131230812;
+			// aapt resource value: 0x7f09005c
+			public const int shortcut = 2131296348;
 			
-			// aapt resource value: 0x7f080015
-			public const int showCustom = 2131230741;
+			// aapt resource value: 0x7f090015
+			public const int showCustom = 2131296277;
 			
-			// aapt resource value: 0x7f080016
-			public const int showHome = 2131230742;
+			// aapt resource value: 0x7f090016
+			public const int showHome = 2131296278;
 			
-			// aapt resource value: 0x7f080017
-			public const int showTitle = 2131230743;
+			// aapt resource value: 0x7f090017
+			public const int showTitle = 2131296279;
 			
-			// aapt resource value: 0x7f080073
-			public const int smallLabel = 2131230835;
+			// aapt resource value: 0x7f090073
+			public const int smallLabel = 2131296371;
 			
-			// aapt resource value: 0x7f08007a
-			public const int snackbar_action = 2131230842;
+			// aapt resource value: 0x7f09007a
+			public const int snackbar_action = 2131296378;
 			
-			// aapt resource value: 0x7f080079
-			public const int snackbar_text = 2131230841;
+			// aapt resource value: 0x7f090079
+			public const int snackbar_text = 2131296377;
 			
-			// aapt resource value: 0x7f08002e
-			public const int snap = 2131230766;
+			// aapt resource value: 0x7f09002e
+			public const int snap = 2131296302;
 			
-			// aapt resource value: 0x7f08004c
-			public const int spacer = 2131230796;
+			// aapt resource value: 0x7f09004c
+			public const int spacer = 2131296332;
 			
-			// aapt resource value: 0x7f080008
-			public const int split_action_bar = 2131230728;
+			// aapt resource value: 0x7f090008
+			public const int split_action_bar = 2131296264;
 			
-			// aapt resource value: 0x7f08001b
-			public const int src_atop = 2131230747;
+			// aapt resource value: 0x7f09001b
+			public const int src_atop = 2131296283;
 			
-			// aapt resource value: 0x7f08001c
-			public const int src_in = 2131230748;
+			// aapt resource value: 0x7f09001c
+			public const int src_in = 2131296284;
 			
-			// aapt resource value: 0x7f08001d
-			public const int src_over = 2131230749;
+			// aapt resource value: 0x7f09001d
+			public const int src_over = 2131296285;
 			
-			// aapt resource value: 0x7f080036
-			public const int start = 2131230774;
+			// aapt resource value: 0x7f090036
+			public const int start = 2131296310;
 			
-			// aapt resource value: 0x7f0800a0
-			public const int status_bar_latest_event_content = 2131230880;
+			// aapt resource value: 0x7f0900a0
+			public const int status_bar_latest_event_content = 2131296416;
 			
-			// aapt resource value: 0x7f08005e
-			public const int submenuarrow = 2131230814;
+			// aapt resource value: 0x7f09005e
+			public const int submenuarrow = 2131296350;
 			
-			// aapt resource value: 0x7f08006f
-			public const int submit_area = 2131230831;
+			// aapt resource value: 0x7f09006f
+			public const int submit_area = 2131296367;
 			
-			// aapt resource value: 0x7f080011
-			public const int tabMode = 2131230737;
+			// aapt resource value: 0x7f090011
+			public const int tabMode = 2131296273;
 			
-			// aapt resource value: 0x7f0800b0
-			public const int text = 2131230896;
+			// aapt resource value: 0x7f0900b0
+			public const int text = 2131296432;
 			
-			// aapt resource value: 0x7f0800ae
-			public const int text2 = 2131230894;
+			// aapt resource value: 0x7f0900ae
+			public const int text2 = 2131296430;
 			
-			// aapt resource value: 0x7f080052
-			public const int textSpacerNoButtons = 2131230802;
+			// aapt resource value: 0x7f090052
+			public const int textSpacerNoButtons = 2131296338;
 			
-			// aapt resource value: 0x7f080051
-			public const int textSpacerNoTitle = 2131230801;
+			// aapt resource value: 0x7f090051
+			public const int textSpacerNoTitle = 2131296337;
 			
-			// aapt resource value: 0x7f080080
-			public const int text_input_password_toggle = 2131230848;
+			// aapt resource value: 0x7f090080
+			public const int text_input_password_toggle = 2131296384;
 			
-			// aapt resource value: 0x7f08000c
-			public const int textinput_counter = 2131230732;
+			// aapt resource value: 0x7f09000c
+			public const int textinput_counter = 2131296268;
 			
-			// aapt resource value: 0x7f08000d
-			public const int textinput_error = 2131230733;
+			// aapt resource value: 0x7f09000d
+			public const int textinput_error = 2131296269;
 			
-			// aapt resource value: 0x7f0800a6
-			public const int time = 2131230886;
+			// aapt resource value: 0x7f0900a6
+			public const int time = 2131296422;
 			
-			// aapt resource value: 0x7f08004a
-			public const int title = 2131230794;
+			// aapt resource value: 0x7f09004a
+			public const int title = 2131296330;
 			
-			// aapt resource value: 0x7f080059
-			public const int titleDividerNoCustom = 2131230809;
+			// aapt resource value: 0x7f090059
+			public const int titleDividerNoCustom = 2131296345;
 			
-			// aapt resource value: 0x7f080057
-			public const int title_template = 2131230807;
+			// aapt resource value: 0x7f090057
+			public const int title_template = 2131296343;
 			
-			// aapt resource value: 0x7f080029
-			public const int top = 2131230761;
+			// aapt resource value: 0x7f090029
+			public const int top = 2131296297;
 			
-			// aapt resource value: 0x7f080056
-			public const int topPanel = 2131230806;
+			// aapt resource value: 0x7f090056
+			public const int topPanel = 2131296342;
 			
-			// aapt resource value: 0x7f080077
-			public const int touch_outside = 2131230839;
+			// aapt resource value: 0x7f090077
+			public const int touch_outside = 2131296375;
 			
-			// aapt resource value: 0x7f08000a
-			public const int transition_current_scene = 2131230730;
+			// aapt resource value: 0x7f09000a
+			public const int transition_current_scene = 2131296266;
 			
-			// aapt resource value: 0x7f08000b
-			public const int transition_scene_layoutid_cache = 2131230731;
+			// aapt resource value: 0x7f09000b
+			public const int transition_scene_layoutid_cache = 2131296267;
 			
-			// aapt resource value: 0x7f080009
-			public const int up = 2131230729;
+			// aapt resource value: 0x7f090009
+			public const int up = 2131296265;
 			
-			// aapt resource value: 0x7f080018
-			public const int useLogo = 2131230744;
+			// aapt resource value: 0x7f090018
+			public const int useLogo = 2131296280;
 			
-			// aapt resource value: 0x7f08000e
-			public const int view_offset_helper = 2131230734;
+			// aapt resource value: 0x7f09000e
+			public const int view_offset_helper = 2131296270;
 			
-			// aapt resource value: 0x7f0800b3
-			public const int visible = 2131230899;
+			// aapt resource value: 0x7f0900b3
+			public const int visible = 2131296435;
 			
-			// aapt resource value: 0x7f080093
-			public const int volume_item_container = 2131230867;
+			// aapt resource value: 0x7f090093
+			public const int volume_item_container = 2131296403;
 			
-			// aapt resource value: 0x7f080027
-			public const int withText = 2131230759;
+			// aapt resource value: 0x7f090027
+			public const int withText = 2131296295;
 			
-			// aapt resource value: 0x7f08001f
-			public const int wrap_content = 2131230751;
+			// aapt resource value: 0x7f09001f
+			public const int wrap_content = 2131296287;
 			
 			static Id()
 			{
@@ -3622,194 +3622,194 @@ namespace XFormsApp.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f09003e
-			public const int ApplicationName = 2131296318;
+			// aapt resource value: 0x7f070000
+			public const int ApplicationName = 2131165184;
 			
-			// aapt resource value: 0x7f090015
-			public const int abc_action_bar_home_description = 2131296277;
+			// aapt resource value: 0x7f070016
+			public const int abc_action_bar_home_description = 2131165206;
 			
-			// aapt resource value: 0x7f090016
-			public const int abc_action_bar_home_description_format = 2131296278;
+			// aapt resource value: 0x7f070017
+			public const int abc_action_bar_home_description_format = 2131165207;
 			
-			// aapt resource value: 0x7f090017
-			public const int abc_action_bar_home_subtitle_description_format = 2131296279;
+			// aapt resource value: 0x7f070018
+			public const int abc_action_bar_home_subtitle_description_format = 2131165208;
 			
-			// aapt resource value: 0x7f090018
-			public const int abc_action_bar_up_description = 2131296280;
+			// aapt resource value: 0x7f070019
+			public const int abc_action_bar_up_description = 2131165209;
 			
-			// aapt resource value: 0x7f090019
-			public const int abc_action_menu_overflow_description = 2131296281;
+			// aapt resource value: 0x7f07001a
+			public const int abc_action_menu_overflow_description = 2131165210;
 			
-			// aapt resource value: 0x7f09001a
-			public const int abc_action_mode_done = 2131296282;
+			// aapt resource value: 0x7f07001b
+			public const int abc_action_mode_done = 2131165211;
 			
-			// aapt resource value: 0x7f09001b
-			public const int abc_activity_chooser_view_see_all = 2131296283;
+			// aapt resource value: 0x7f07001c
+			public const int abc_activity_chooser_view_see_all = 2131165212;
 			
-			// aapt resource value: 0x7f09001c
-			public const int abc_activitychooserview_choose_application = 2131296284;
+			// aapt resource value: 0x7f07001d
+			public const int abc_activitychooserview_choose_application = 2131165213;
 			
-			// aapt resource value: 0x7f09001d
-			public const int abc_capital_off = 2131296285;
+			// aapt resource value: 0x7f07001e
+			public const int abc_capital_off = 2131165214;
 			
-			// aapt resource value: 0x7f09001e
-			public const int abc_capital_on = 2131296286;
+			// aapt resource value: 0x7f07001f
+			public const int abc_capital_on = 2131165215;
 			
-			// aapt resource value: 0x7f09002a
-			public const int abc_font_family_body_1_material = 2131296298;
+			// aapt resource value: 0x7f07002b
+			public const int abc_font_family_body_1_material = 2131165227;
 			
-			// aapt resource value: 0x7f09002b
-			public const int abc_font_family_body_2_material = 2131296299;
+			// aapt resource value: 0x7f07002c
+			public const int abc_font_family_body_2_material = 2131165228;
 			
-			// aapt resource value: 0x7f09002c
-			public const int abc_font_family_button_material = 2131296300;
+			// aapt resource value: 0x7f07002d
+			public const int abc_font_family_button_material = 2131165229;
 			
-			// aapt resource value: 0x7f09002d
-			public const int abc_font_family_caption_material = 2131296301;
+			// aapt resource value: 0x7f07002e
+			public const int abc_font_family_caption_material = 2131165230;
 			
-			// aapt resource value: 0x7f09002e
-			public const int abc_font_family_display_1_material = 2131296302;
+			// aapt resource value: 0x7f07002f
+			public const int abc_font_family_display_1_material = 2131165231;
 			
-			// aapt resource value: 0x7f09002f
-			public const int abc_font_family_display_2_material = 2131296303;
+			// aapt resource value: 0x7f070030
+			public const int abc_font_family_display_2_material = 2131165232;
 			
-			// aapt resource value: 0x7f090030
-			public const int abc_font_family_display_3_material = 2131296304;
+			// aapt resource value: 0x7f070031
+			public const int abc_font_family_display_3_material = 2131165233;
 			
-			// aapt resource value: 0x7f090031
-			public const int abc_font_family_display_4_material = 2131296305;
+			// aapt resource value: 0x7f070032
+			public const int abc_font_family_display_4_material = 2131165234;
 			
-			// aapt resource value: 0x7f090032
-			public const int abc_font_family_headline_material = 2131296306;
+			// aapt resource value: 0x7f070033
+			public const int abc_font_family_headline_material = 2131165235;
 			
-			// aapt resource value: 0x7f090033
-			public const int abc_font_family_menu_material = 2131296307;
+			// aapt resource value: 0x7f070034
+			public const int abc_font_family_menu_material = 2131165236;
 			
-			// aapt resource value: 0x7f090034
-			public const int abc_font_family_subhead_material = 2131296308;
+			// aapt resource value: 0x7f070035
+			public const int abc_font_family_subhead_material = 2131165237;
 			
-			// aapt resource value: 0x7f090035
-			public const int abc_font_family_title_material = 2131296309;
+			// aapt resource value: 0x7f070036
+			public const int abc_font_family_title_material = 2131165238;
 			
-			// aapt resource value: 0x7f09001f
-			public const int abc_search_hint = 2131296287;
+			// aapt resource value: 0x7f070020
+			public const int abc_search_hint = 2131165216;
 			
-			// aapt resource value: 0x7f090020
-			public const int abc_searchview_description_clear = 2131296288;
+			// aapt resource value: 0x7f070021
+			public const int abc_searchview_description_clear = 2131165217;
 			
-			// aapt resource value: 0x7f090021
-			public const int abc_searchview_description_query = 2131296289;
+			// aapt resource value: 0x7f070022
+			public const int abc_searchview_description_query = 2131165218;
 			
-			// aapt resource value: 0x7f090022
-			public const int abc_searchview_description_search = 2131296290;
+			// aapt resource value: 0x7f070023
+			public const int abc_searchview_description_search = 2131165219;
 			
-			// aapt resource value: 0x7f090023
-			public const int abc_searchview_description_submit = 2131296291;
+			// aapt resource value: 0x7f070024
+			public const int abc_searchview_description_submit = 2131165220;
 			
-			// aapt resource value: 0x7f090024
-			public const int abc_searchview_description_voice = 2131296292;
+			// aapt resource value: 0x7f070025
+			public const int abc_searchview_description_voice = 2131165221;
 			
-			// aapt resource value: 0x7f090025
-			public const int abc_shareactionprovider_share_with = 2131296293;
+			// aapt resource value: 0x7f070026
+			public const int abc_shareactionprovider_share_with = 2131165222;
 			
-			// aapt resource value: 0x7f090026
-			public const int abc_shareactionprovider_share_with_application = 2131296294;
+			// aapt resource value: 0x7f070027
+			public const int abc_shareactionprovider_share_with_application = 2131165223;
 			
-			// aapt resource value: 0x7f090027
-			public const int abc_toolbar_collapse_description = 2131296295;
+			// aapt resource value: 0x7f070028
+			public const int abc_toolbar_collapse_description = 2131165224;
 			
-			// aapt resource value: 0x7f090036
-			public const int appbar_scrolling_view_behavior = 2131296310;
+			// aapt resource value: 0x7f070037
+			public const int appbar_scrolling_view_behavior = 2131165239;
 			
-			// aapt resource value: 0x7f090037
-			public const int bottom_sheet_behavior = 2131296311;
+			// aapt resource value: 0x7f070038
+			public const int bottom_sheet_behavior = 2131165240;
 			
-			// aapt resource value: 0x7f090038
-			public const int character_counter_pattern = 2131296312;
+			// aapt resource value: 0x7f070039
+			public const int character_counter_pattern = 2131165241;
 			
-			// aapt resource value: 0x7f090000
-			public const int mr_button_content_description = 2131296256;
+			// aapt resource value: 0x7f070001
+			public const int mr_button_content_description = 2131165185;
 			
-			// aapt resource value: 0x7f090001
-			public const int mr_cast_button_connected = 2131296257;
+			// aapt resource value: 0x7f070002
+			public const int mr_cast_button_connected = 2131165186;
 			
-			// aapt resource value: 0x7f090002
-			public const int mr_cast_button_connecting = 2131296258;
+			// aapt resource value: 0x7f070003
+			public const int mr_cast_button_connecting = 2131165187;
 			
-			// aapt resource value: 0x7f090003
-			public const int mr_cast_button_disconnected = 2131296259;
+			// aapt resource value: 0x7f070004
+			public const int mr_cast_button_disconnected = 2131165188;
 			
-			// aapt resource value: 0x7f090004
-			public const int mr_chooser_searching = 2131296260;
+			// aapt resource value: 0x7f070005
+			public const int mr_chooser_searching = 2131165189;
 			
-			// aapt resource value: 0x7f090005
-			public const int mr_chooser_title = 2131296261;
+			// aapt resource value: 0x7f070006
+			public const int mr_chooser_title = 2131165190;
 			
-			// aapt resource value: 0x7f090006
-			public const int mr_controller_album_art = 2131296262;
+			// aapt resource value: 0x7f070007
+			public const int mr_controller_album_art = 2131165191;
 			
-			// aapt resource value: 0x7f090007
-			public const int mr_controller_casting_screen = 2131296263;
+			// aapt resource value: 0x7f070008
+			public const int mr_controller_casting_screen = 2131165192;
 			
-			// aapt resource value: 0x7f090008
-			public const int mr_controller_close_description = 2131296264;
+			// aapt resource value: 0x7f070009
+			public const int mr_controller_close_description = 2131165193;
 			
-			// aapt resource value: 0x7f090009
-			public const int mr_controller_collapse_group = 2131296265;
+			// aapt resource value: 0x7f07000a
+			public const int mr_controller_collapse_group = 2131165194;
 			
-			// aapt resource value: 0x7f09000a
-			public const int mr_controller_disconnect = 2131296266;
+			// aapt resource value: 0x7f07000b
+			public const int mr_controller_disconnect = 2131165195;
 			
-			// aapt resource value: 0x7f09000b
-			public const int mr_controller_expand_group = 2131296267;
+			// aapt resource value: 0x7f07000c
+			public const int mr_controller_expand_group = 2131165196;
 			
-			// aapt resource value: 0x7f09000c
-			public const int mr_controller_no_info_available = 2131296268;
+			// aapt resource value: 0x7f07000d
+			public const int mr_controller_no_info_available = 2131165197;
 			
-			// aapt resource value: 0x7f09000d
-			public const int mr_controller_no_media_selected = 2131296269;
+			// aapt resource value: 0x7f07000e
+			public const int mr_controller_no_media_selected = 2131165198;
 			
-			// aapt resource value: 0x7f09000e
-			public const int mr_controller_pause = 2131296270;
+			// aapt resource value: 0x7f07000f
+			public const int mr_controller_pause = 2131165199;
 			
-			// aapt resource value: 0x7f09000f
-			public const int mr_controller_play = 2131296271;
+			// aapt resource value: 0x7f070010
+			public const int mr_controller_play = 2131165200;
 			
-			// aapt resource value: 0x7f090014
-			public const int mr_controller_stop = 2131296276;
+			// aapt resource value: 0x7f070015
+			public const int mr_controller_stop = 2131165205;
 			
-			// aapt resource value: 0x7f090010
-			public const int mr_controller_stop_casting = 2131296272;
+			// aapt resource value: 0x7f070011
+			public const int mr_controller_stop_casting = 2131165201;
 			
-			// aapt resource value: 0x7f090011
-			public const int mr_controller_volume_slider = 2131296273;
+			// aapt resource value: 0x7f070012
+			public const int mr_controller_volume_slider = 2131165202;
 			
-			// aapt resource value: 0x7f090012
-			public const int mr_system_route_name = 2131296274;
+			// aapt resource value: 0x7f070013
+			public const int mr_system_route_name = 2131165203;
 			
-			// aapt resource value: 0x7f090013
-			public const int mr_user_route_category_name = 2131296275;
+			// aapt resource value: 0x7f070014
+			public const int mr_user_route_category_name = 2131165204;
 			
-			// aapt resource value: 0x7f090039
-			public const int password_toggle_content_description = 2131296313;
+			// aapt resource value: 0x7f07003a
+			public const int password_toggle_content_description = 2131165242;
 			
-			// aapt resource value: 0x7f09003a
-			public const int path_password_eye = 2131296314;
+			// aapt resource value: 0x7f07003b
+			public const int path_password_eye = 2131165243;
 			
-			// aapt resource value: 0x7f09003b
-			public const int path_password_eye_mask_strike_through = 2131296315;
+			// aapt resource value: 0x7f07003c
+			public const int path_password_eye_mask_strike_through = 2131165244;
 			
-			// aapt resource value: 0x7f09003c
-			public const int path_password_eye_mask_visible = 2131296316;
+			// aapt resource value: 0x7f07003d
+			public const int path_password_eye_mask_visible = 2131165245;
 			
-			// aapt resource value: 0x7f09003d
-			public const int path_password_strike_through = 2131296317;
+			// aapt resource value: 0x7f07003e
+			public const int path_password_strike_through = 2131165246;
 			
-			// aapt resource value: 0x7f090028
-			public const int search_menu_title = 2131296296;
+			// aapt resource value: 0x7f070029
+			public const int search_menu_title = 2131165225;
 			
-			// aapt resource value: 0x7f090029
-			public const int status_bar_notification_info_overflow = 2131296297;
+			// aapt resource value: 0x7f07002a
+			public const int status_bar_notification_info_overflow = 2131165226;
 			
 			static String()
 			{

--- a/devApps/XFormsApp.Droid/Resources/Resource.Designer.cs
+++ b/devApps/XFormsApp.Droid/Resources/Resource.Designer.cs
@@ -1486,449 +1486,449 @@ namespace XFormsApp.Droid
 		public partial class Dimension
 		{
 			
-			// aapt resource value: 0x7f080018
-			public const int abc_action_bar_content_inset_material = 2131230744;
+			// aapt resource value: 0x7f070018
+			public const int abc_action_bar_content_inset_material = 2131165208;
 			
-			// aapt resource value: 0x7f080019
-			public const int abc_action_bar_content_inset_with_nav = 2131230745;
+			// aapt resource value: 0x7f070019
+			public const int abc_action_bar_content_inset_with_nav = 2131165209;
 			
-			// aapt resource value: 0x7f08000d
-			public const int abc_action_bar_default_height_material = 2131230733;
+			// aapt resource value: 0x7f07000d
+			public const int abc_action_bar_default_height_material = 2131165197;
 			
-			// aapt resource value: 0x7f08001a
-			public const int abc_action_bar_default_padding_end_material = 2131230746;
+			// aapt resource value: 0x7f07001a
+			public const int abc_action_bar_default_padding_end_material = 2131165210;
 			
-			// aapt resource value: 0x7f08001b
-			public const int abc_action_bar_default_padding_start_material = 2131230747;
+			// aapt resource value: 0x7f07001b
+			public const int abc_action_bar_default_padding_start_material = 2131165211;
 			
-			// aapt resource value: 0x7f080021
-			public const int abc_action_bar_elevation_material = 2131230753;
+			// aapt resource value: 0x7f070021
+			public const int abc_action_bar_elevation_material = 2131165217;
 			
-			// aapt resource value: 0x7f080022
-			public const int abc_action_bar_icon_vertical_padding_material = 2131230754;
+			// aapt resource value: 0x7f070022
+			public const int abc_action_bar_icon_vertical_padding_material = 2131165218;
 			
-			// aapt resource value: 0x7f080023
-			public const int abc_action_bar_overflow_padding_end_material = 2131230755;
+			// aapt resource value: 0x7f070023
+			public const int abc_action_bar_overflow_padding_end_material = 2131165219;
 			
-			// aapt resource value: 0x7f080024
-			public const int abc_action_bar_overflow_padding_start_material = 2131230756;
+			// aapt resource value: 0x7f070024
+			public const int abc_action_bar_overflow_padding_start_material = 2131165220;
 			
-			// aapt resource value: 0x7f08000e
-			public const int abc_action_bar_progress_bar_size = 2131230734;
+			// aapt resource value: 0x7f07000e
+			public const int abc_action_bar_progress_bar_size = 2131165198;
 			
-			// aapt resource value: 0x7f080025
-			public const int abc_action_bar_stacked_max_height = 2131230757;
+			// aapt resource value: 0x7f070025
+			public const int abc_action_bar_stacked_max_height = 2131165221;
 			
-			// aapt resource value: 0x7f080026
-			public const int abc_action_bar_stacked_tab_max_width = 2131230758;
+			// aapt resource value: 0x7f070026
+			public const int abc_action_bar_stacked_tab_max_width = 2131165222;
 			
-			// aapt resource value: 0x7f080027
-			public const int abc_action_bar_subtitle_bottom_margin_material = 2131230759;
+			// aapt resource value: 0x7f070027
+			public const int abc_action_bar_subtitle_bottom_margin_material = 2131165223;
 			
-			// aapt resource value: 0x7f080028
-			public const int abc_action_bar_subtitle_top_margin_material = 2131230760;
+			// aapt resource value: 0x7f070028
+			public const int abc_action_bar_subtitle_top_margin_material = 2131165224;
 			
-			// aapt resource value: 0x7f080029
-			public const int abc_action_button_min_height_material = 2131230761;
+			// aapt resource value: 0x7f070029
+			public const int abc_action_button_min_height_material = 2131165225;
 			
-			// aapt resource value: 0x7f08002a
-			public const int abc_action_button_min_width_material = 2131230762;
+			// aapt resource value: 0x7f07002a
+			public const int abc_action_button_min_width_material = 2131165226;
 			
-			// aapt resource value: 0x7f08002b
-			public const int abc_action_button_min_width_overflow_material = 2131230763;
+			// aapt resource value: 0x7f07002b
+			public const int abc_action_button_min_width_overflow_material = 2131165227;
 			
-			// aapt resource value: 0x7f08000c
-			public const int abc_alert_dialog_button_bar_height = 2131230732;
+			// aapt resource value: 0x7f07000c
+			public const int abc_alert_dialog_button_bar_height = 2131165196;
 			
-			// aapt resource value: 0x7f08002c
-			public const int abc_button_inset_horizontal_material = 2131230764;
+			// aapt resource value: 0x7f07002c
+			public const int abc_button_inset_horizontal_material = 2131165228;
 			
-			// aapt resource value: 0x7f08002d
-			public const int abc_button_inset_vertical_material = 2131230765;
+			// aapt resource value: 0x7f07002d
+			public const int abc_button_inset_vertical_material = 2131165229;
 			
-			// aapt resource value: 0x7f08002e
-			public const int abc_button_padding_horizontal_material = 2131230766;
+			// aapt resource value: 0x7f07002e
+			public const int abc_button_padding_horizontal_material = 2131165230;
 			
-			// aapt resource value: 0x7f08002f
-			public const int abc_button_padding_vertical_material = 2131230767;
+			// aapt resource value: 0x7f07002f
+			public const int abc_button_padding_vertical_material = 2131165231;
 			
-			// aapt resource value: 0x7f080030
-			public const int abc_cascading_menus_min_smallest_width = 2131230768;
+			// aapt resource value: 0x7f070030
+			public const int abc_cascading_menus_min_smallest_width = 2131165232;
 			
-			// aapt resource value: 0x7f080011
-			public const int abc_config_prefDialogWidth = 2131230737;
+			// aapt resource value: 0x7f070011
+			public const int abc_config_prefDialogWidth = 2131165201;
 			
-			// aapt resource value: 0x7f080031
-			public const int abc_control_corner_material = 2131230769;
+			// aapt resource value: 0x7f070031
+			public const int abc_control_corner_material = 2131165233;
 			
-			// aapt resource value: 0x7f080032
-			public const int abc_control_inset_material = 2131230770;
+			// aapt resource value: 0x7f070032
+			public const int abc_control_inset_material = 2131165234;
 			
-			// aapt resource value: 0x7f080033
-			public const int abc_control_padding_material = 2131230771;
+			// aapt resource value: 0x7f070033
+			public const int abc_control_padding_material = 2131165235;
 			
-			// aapt resource value: 0x7f080012
-			public const int abc_dialog_fixed_height_major = 2131230738;
+			// aapt resource value: 0x7f070012
+			public const int abc_dialog_fixed_height_major = 2131165202;
 			
-			// aapt resource value: 0x7f080013
-			public const int abc_dialog_fixed_height_minor = 2131230739;
+			// aapt resource value: 0x7f070013
+			public const int abc_dialog_fixed_height_minor = 2131165203;
 			
-			// aapt resource value: 0x7f080014
-			public const int abc_dialog_fixed_width_major = 2131230740;
+			// aapt resource value: 0x7f070014
+			public const int abc_dialog_fixed_width_major = 2131165204;
 			
-			// aapt resource value: 0x7f080015
-			public const int abc_dialog_fixed_width_minor = 2131230741;
+			// aapt resource value: 0x7f070015
+			public const int abc_dialog_fixed_width_minor = 2131165205;
 			
-			// aapt resource value: 0x7f080034
-			public const int abc_dialog_list_padding_bottom_no_buttons = 2131230772;
+			// aapt resource value: 0x7f070034
+			public const int abc_dialog_list_padding_bottom_no_buttons = 2131165236;
 			
-			// aapt resource value: 0x7f080035
-			public const int abc_dialog_list_padding_top_no_title = 2131230773;
+			// aapt resource value: 0x7f070035
+			public const int abc_dialog_list_padding_top_no_title = 2131165237;
 			
-			// aapt resource value: 0x7f080016
-			public const int abc_dialog_min_width_major = 2131230742;
+			// aapt resource value: 0x7f070016
+			public const int abc_dialog_min_width_major = 2131165206;
 			
-			// aapt resource value: 0x7f080017
-			public const int abc_dialog_min_width_minor = 2131230743;
+			// aapt resource value: 0x7f070017
+			public const int abc_dialog_min_width_minor = 2131165207;
 			
-			// aapt resource value: 0x7f080036
-			public const int abc_dialog_padding_material = 2131230774;
+			// aapt resource value: 0x7f070036
+			public const int abc_dialog_padding_material = 2131165238;
 			
-			// aapt resource value: 0x7f080037
-			public const int abc_dialog_padding_top_material = 2131230775;
+			// aapt resource value: 0x7f070037
+			public const int abc_dialog_padding_top_material = 2131165239;
 			
-			// aapt resource value: 0x7f080038
-			public const int abc_dialog_title_divider_material = 2131230776;
+			// aapt resource value: 0x7f070038
+			public const int abc_dialog_title_divider_material = 2131165240;
 			
-			// aapt resource value: 0x7f080039
-			public const int abc_disabled_alpha_material_dark = 2131230777;
+			// aapt resource value: 0x7f070039
+			public const int abc_disabled_alpha_material_dark = 2131165241;
 			
-			// aapt resource value: 0x7f08003a
-			public const int abc_disabled_alpha_material_light = 2131230778;
+			// aapt resource value: 0x7f07003a
+			public const int abc_disabled_alpha_material_light = 2131165242;
 			
-			// aapt resource value: 0x7f08003b
-			public const int abc_dropdownitem_icon_width = 2131230779;
+			// aapt resource value: 0x7f07003b
+			public const int abc_dropdownitem_icon_width = 2131165243;
 			
-			// aapt resource value: 0x7f08003c
-			public const int abc_dropdownitem_text_padding_left = 2131230780;
+			// aapt resource value: 0x7f07003c
+			public const int abc_dropdownitem_text_padding_left = 2131165244;
 			
-			// aapt resource value: 0x7f08003d
-			public const int abc_dropdownitem_text_padding_right = 2131230781;
+			// aapt resource value: 0x7f07003d
+			public const int abc_dropdownitem_text_padding_right = 2131165245;
 			
-			// aapt resource value: 0x7f08003e
-			public const int abc_edit_text_inset_bottom_material = 2131230782;
+			// aapt resource value: 0x7f07003e
+			public const int abc_edit_text_inset_bottom_material = 2131165246;
 			
-			// aapt resource value: 0x7f08003f
-			public const int abc_edit_text_inset_horizontal_material = 2131230783;
+			// aapt resource value: 0x7f07003f
+			public const int abc_edit_text_inset_horizontal_material = 2131165247;
 			
-			// aapt resource value: 0x7f080040
-			public const int abc_edit_text_inset_top_material = 2131230784;
+			// aapt resource value: 0x7f070040
+			public const int abc_edit_text_inset_top_material = 2131165248;
 			
-			// aapt resource value: 0x7f080041
-			public const int abc_floating_window_z = 2131230785;
+			// aapt resource value: 0x7f070041
+			public const int abc_floating_window_z = 2131165249;
 			
-			// aapt resource value: 0x7f080042
-			public const int abc_list_item_padding_horizontal_material = 2131230786;
+			// aapt resource value: 0x7f070042
+			public const int abc_list_item_padding_horizontal_material = 2131165250;
 			
-			// aapt resource value: 0x7f080043
-			public const int abc_panel_menu_list_width = 2131230787;
+			// aapt resource value: 0x7f070043
+			public const int abc_panel_menu_list_width = 2131165251;
 			
-			// aapt resource value: 0x7f080044
-			public const int abc_progress_bar_height_material = 2131230788;
+			// aapt resource value: 0x7f070044
+			public const int abc_progress_bar_height_material = 2131165252;
 			
-			// aapt resource value: 0x7f080045
-			public const int abc_search_view_preferred_height = 2131230789;
+			// aapt resource value: 0x7f070045
+			public const int abc_search_view_preferred_height = 2131165253;
 			
-			// aapt resource value: 0x7f080046
-			public const int abc_search_view_preferred_width = 2131230790;
+			// aapt resource value: 0x7f070046
+			public const int abc_search_view_preferred_width = 2131165254;
 			
-			// aapt resource value: 0x7f080047
-			public const int abc_seekbar_track_background_height_material = 2131230791;
+			// aapt resource value: 0x7f070047
+			public const int abc_seekbar_track_background_height_material = 2131165255;
 			
-			// aapt resource value: 0x7f080048
-			public const int abc_seekbar_track_progress_height_material = 2131230792;
+			// aapt resource value: 0x7f070048
+			public const int abc_seekbar_track_progress_height_material = 2131165256;
 			
-			// aapt resource value: 0x7f080049
-			public const int abc_select_dialog_padding_start_material = 2131230793;
+			// aapt resource value: 0x7f070049
+			public const int abc_select_dialog_padding_start_material = 2131165257;
 			
-			// aapt resource value: 0x7f08001d
-			public const int abc_switch_padding = 2131230749;
+			// aapt resource value: 0x7f07001d
+			public const int abc_switch_padding = 2131165213;
 			
-			// aapt resource value: 0x7f08004a
-			public const int abc_text_size_body_1_material = 2131230794;
+			// aapt resource value: 0x7f07004a
+			public const int abc_text_size_body_1_material = 2131165258;
 			
-			// aapt resource value: 0x7f08004b
-			public const int abc_text_size_body_2_material = 2131230795;
+			// aapt resource value: 0x7f07004b
+			public const int abc_text_size_body_2_material = 2131165259;
 			
-			// aapt resource value: 0x7f08004c
-			public const int abc_text_size_button_material = 2131230796;
+			// aapt resource value: 0x7f07004c
+			public const int abc_text_size_button_material = 2131165260;
 			
-			// aapt resource value: 0x7f08004d
-			public const int abc_text_size_caption_material = 2131230797;
+			// aapt resource value: 0x7f07004d
+			public const int abc_text_size_caption_material = 2131165261;
 			
-			// aapt resource value: 0x7f08004e
-			public const int abc_text_size_display_1_material = 2131230798;
+			// aapt resource value: 0x7f07004e
+			public const int abc_text_size_display_1_material = 2131165262;
 			
-			// aapt resource value: 0x7f08004f
-			public const int abc_text_size_display_2_material = 2131230799;
+			// aapt resource value: 0x7f07004f
+			public const int abc_text_size_display_2_material = 2131165263;
 			
-			// aapt resource value: 0x7f080050
-			public const int abc_text_size_display_3_material = 2131230800;
+			// aapt resource value: 0x7f070050
+			public const int abc_text_size_display_3_material = 2131165264;
 			
-			// aapt resource value: 0x7f080051
-			public const int abc_text_size_display_4_material = 2131230801;
+			// aapt resource value: 0x7f070051
+			public const int abc_text_size_display_4_material = 2131165265;
 			
-			// aapt resource value: 0x7f080052
-			public const int abc_text_size_headline_material = 2131230802;
+			// aapt resource value: 0x7f070052
+			public const int abc_text_size_headline_material = 2131165266;
 			
-			// aapt resource value: 0x7f080053
-			public const int abc_text_size_large_material = 2131230803;
+			// aapt resource value: 0x7f070053
+			public const int abc_text_size_large_material = 2131165267;
 			
-			// aapt resource value: 0x7f080054
-			public const int abc_text_size_medium_material = 2131230804;
+			// aapt resource value: 0x7f070054
+			public const int abc_text_size_medium_material = 2131165268;
 			
-			// aapt resource value: 0x7f080055
-			public const int abc_text_size_menu_header_material = 2131230805;
+			// aapt resource value: 0x7f070055
+			public const int abc_text_size_menu_header_material = 2131165269;
 			
-			// aapt resource value: 0x7f080056
-			public const int abc_text_size_menu_material = 2131230806;
+			// aapt resource value: 0x7f070056
+			public const int abc_text_size_menu_material = 2131165270;
 			
-			// aapt resource value: 0x7f080057
-			public const int abc_text_size_small_material = 2131230807;
+			// aapt resource value: 0x7f070057
+			public const int abc_text_size_small_material = 2131165271;
 			
-			// aapt resource value: 0x7f080058
-			public const int abc_text_size_subhead_material = 2131230808;
+			// aapt resource value: 0x7f070058
+			public const int abc_text_size_subhead_material = 2131165272;
 			
-			// aapt resource value: 0x7f08000f
-			public const int abc_text_size_subtitle_material_toolbar = 2131230735;
+			// aapt resource value: 0x7f07000f
+			public const int abc_text_size_subtitle_material_toolbar = 2131165199;
 			
-			// aapt resource value: 0x7f080059
-			public const int abc_text_size_title_material = 2131230809;
+			// aapt resource value: 0x7f070059
+			public const int abc_text_size_title_material = 2131165273;
 			
-			// aapt resource value: 0x7f080010
-			public const int abc_text_size_title_material_toolbar = 2131230736;
+			// aapt resource value: 0x7f070010
+			public const int abc_text_size_title_material_toolbar = 2131165200;
 			
-			// aapt resource value: 0x7f080009
-			public const int cardview_compat_inset_shadow = 2131230729;
+			// aapt resource value: 0x7f070009
+			public const int cardview_compat_inset_shadow = 2131165193;
 			
-			// aapt resource value: 0x7f08000a
-			public const int cardview_default_elevation = 2131230730;
+			// aapt resource value: 0x7f07000a
+			public const int cardview_default_elevation = 2131165194;
 			
-			// aapt resource value: 0x7f08000b
-			public const int cardview_default_radius = 2131230731;
+			// aapt resource value: 0x7f07000b
+			public const int cardview_default_radius = 2131165195;
 			
-			// aapt resource value: 0x7f080076
-			public const int design_appbar_elevation = 2131230838;
+			// aapt resource value: 0x7f070076
+			public const int design_appbar_elevation = 2131165302;
 			
-			// aapt resource value: 0x7f080077
-			public const int design_bottom_navigation_active_item_max_width = 2131230839;
+			// aapt resource value: 0x7f070077
+			public const int design_bottom_navigation_active_item_max_width = 2131165303;
 			
-			// aapt resource value: 0x7f080078
-			public const int design_bottom_navigation_active_text_size = 2131230840;
+			// aapt resource value: 0x7f070078
+			public const int design_bottom_navigation_active_text_size = 2131165304;
 			
-			// aapt resource value: 0x7f080079
-			public const int design_bottom_navigation_elevation = 2131230841;
+			// aapt resource value: 0x7f070079
+			public const int design_bottom_navigation_elevation = 2131165305;
 			
-			// aapt resource value: 0x7f08007a
-			public const int design_bottom_navigation_height = 2131230842;
+			// aapt resource value: 0x7f07007a
+			public const int design_bottom_navigation_height = 2131165306;
 			
-			// aapt resource value: 0x7f08007b
-			public const int design_bottom_navigation_item_max_width = 2131230843;
+			// aapt resource value: 0x7f07007b
+			public const int design_bottom_navigation_item_max_width = 2131165307;
 			
-			// aapt resource value: 0x7f08007c
-			public const int design_bottom_navigation_item_min_width = 2131230844;
+			// aapt resource value: 0x7f07007c
+			public const int design_bottom_navigation_item_min_width = 2131165308;
 			
-			// aapt resource value: 0x7f08007d
-			public const int design_bottom_navigation_margin = 2131230845;
+			// aapt resource value: 0x7f07007d
+			public const int design_bottom_navigation_margin = 2131165309;
 			
-			// aapt resource value: 0x7f08007e
-			public const int design_bottom_navigation_shadow_height = 2131230846;
+			// aapt resource value: 0x7f07007e
+			public const int design_bottom_navigation_shadow_height = 2131165310;
 			
-			// aapt resource value: 0x7f08007f
-			public const int design_bottom_navigation_text_size = 2131230847;
+			// aapt resource value: 0x7f07007f
+			public const int design_bottom_navigation_text_size = 2131165311;
 			
-			// aapt resource value: 0x7f080080
-			public const int design_bottom_sheet_modal_elevation = 2131230848;
+			// aapt resource value: 0x7f070080
+			public const int design_bottom_sheet_modal_elevation = 2131165312;
 			
-			// aapt resource value: 0x7f080081
-			public const int design_bottom_sheet_peek_height_min = 2131230849;
+			// aapt resource value: 0x7f070081
+			public const int design_bottom_sheet_peek_height_min = 2131165313;
 			
-			// aapt resource value: 0x7f080082
-			public const int design_fab_border_width = 2131230850;
+			// aapt resource value: 0x7f070082
+			public const int design_fab_border_width = 2131165314;
 			
-			// aapt resource value: 0x7f080083
-			public const int design_fab_elevation = 2131230851;
+			// aapt resource value: 0x7f070083
+			public const int design_fab_elevation = 2131165315;
 			
-			// aapt resource value: 0x7f080084
-			public const int design_fab_image_size = 2131230852;
+			// aapt resource value: 0x7f070084
+			public const int design_fab_image_size = 2131165316;
 			
-			// aapt resource value: 0x7f080085
-			public const int design_fab_size_mini = 2131230853;
+			// aapt resource value: 0x7f070085
+			public const int design_fab_size_mini = 2131165317;
 			
-			// aapt resource value: 0x7f080086
-			public const int design_fab_size_normal = 2131230854;
+			// aapt resource value: 0x7f070086
+			public const int design_fab_size_normal = 2131165318;
 			
-			// aapt resource value: 0x7f080087
-			public const int design_fab_translation_z_pressed = 2131230855;
+			// aapt resource value: 0x7f070087
+			public const int design_fab_translation_z_pressed = 2131165319;
 			
-			// aapt resource value: 0x7f080088
-			public const int design_navigation_elevation = 2131230856;
+			// aapt resource value: 0x7f070088
+			public const int design_navigation_elevation = 2131165320;
 			
-			// aapt resource value: 0x7f080089
-			public const int design_navigation_icon_padding = 2131230857;
+			// aapt resource value: 0x7f070089
+			public const int design_navigation_icon_padding = 2131165321;
 			
-			// aapt resource value: 0x7f08008a
-			public const int design_navigation_icon_size = 2131230858;
+			// aapt resource value: 0x7f07008a
+			public const int design_navigation_icon_size = 2131165322;
 			
-			// aapt resource value: 0x7f08006e
-			public const int design_navigation_max_width = 2131230830;
+			// aapt resource value: 0x7f07006e
+			public const int design_navigation_max_width = 2131165294;
 			
-			// aapt resource value: 0x7f08008b
-			public const int design_navigation_padding_bottom = 2131230859;
+			// aapt resource value: 0x7f07008b
+			public const int design_navigation_padding_bottom = 2131165323;
 			
-			// aapt resource value: 0x7f08008c
-			public const int design_navigation_separator_vertical_padding = 2131230860;
+			// aapt resource value: 0x7f07008c
+			public const int design_navigation_separator_vertical_padding = 2131165324;
 			
-			// aapt resource value: 0x7f08006f
-			public const int design_snackbar_action_inline_max_width = 2131230831;
+			// aapt resource value: 0x7f07006f
+			public const int design_snackbar_action_inline_max_width = 2131165295;
 			
-			// aapt resource value: 0x7f080070
-			public const int design_snackbar_background_corner_radius = 2131230832;
+			// aapt resource value: 0x7f070070
+			public const int design_snackbar_background_corner_radius = 2131165296;
 			
-			// aapt resource value: 0x7f08008d
-			public const int design_snackbar_elevation = 2131230861;
+			// aapt resource value: 0x7f07008d
+			public const int design_snackbar_elevation = 2131165325;
 			
-			// aapt resource value: 0x7f080071
-			public const int design_snackbar_extra_spacing_horizontal = 2131230833;
+			// aapt resource value: 0x7f070071
+			public const int design_snackbar_extra_spacing_horizontal = 2131165297;
 			
-			// aapt resource value: 0x7f080072
-			public const int design_snackbar_max_width = 2131230834;
+			// aapt resource value: 0x7f070072
+			public const int design_snackbar_max_width = 2131165298;
 			
-			// aapt resource value: 0x7f080073
-			public const int design_snackbar_min_width = 2131230835;
+			// aapt resource value: 0x7f070073
+			public const int design_snackbar_min_width = 2131165299;
 			
-			// aapt resource value: 0x7f08008e
-			public const int design_snackbar_padding_horizontal = 2131230862;
+			// aapt resource value: 0x7f07008e
+			public const int design_snackbar_padding_horizontal = 2131165326;
 			
-			// aapt resource value: 0x7f08008f
-			public const int design_snackbar_padding_vertical = 2131230863;
+			// aapt resource value: 0x7f07008f
+			public const int design_snackbar_padding_vertical = 2131165327;
 			
-			// aapt resource value: 0x7f080074
-			public const int design_snackbar_padding_vertical_2lines = 2131230836;
+			// aapt resource value: 0x7f070074
+			public const int design_snackbar_padding_vertical_2lines = 2131165300;
 			
-			// aapt resource value: 0x7f080090
-			public const int design_snackbar_text_size = 2131230864;
+			// aapt resource value: 0x7f070090
+			public const int design_snackbar_text_size = 2131165328;
 			
-			// aapt resource value: 0x7f080091
-			public const int design_tab_max_width = 2131230865;
+			// aapt resource value: 0x7f070091
+			public const int design_tab_max_width = 2131165329;
 			
-			// aapt resource value: 0x7f080075
-			public const int design_tab_scrollable_min_width = 2131230837;
+			// aapt resource value: 0x7f070075
+			public const int design_tab_scrollable_min_width = 2131165301;
 			
-			// aapt resource value: 0x7f080092
-			public const int design_tab_text_size = 2131230866;
+			// aapt resource value: 0x7f070092
+			public const int design_tab_text_size = 2131165330;
 			
-			// aapt resource value: 0x7f080093
-			public const int design_tab_text_size_2line = 2131230867;
+			// aapt resource value: 0x7f070093
+			public const int design_tab_text_size_2line = 2131165331;
 			
-			// aapt resource value: 0x7f08005a
-			public const int disabled_alpha_material_dark = 2131230810;
+			// aapt resource value: 0x7f07005a
+			public const int disabled_alpha_material_dark = 2131165274;
 			
-			// aapt resource value: 0x7f08005b
-			public const int disabled_alpha_material_light = 2131230811;
+			// aapt resource value: 0x7f07005b
+			public const int disabled_alpha_material_light = 2131165275;
 			
-			// aapt resource value: 0x7f08005c
-			public const int highlight_alpha_material_colored = 2131230812;
+			// aapt resource value: 0x7f07005c
+			public const int highlight_alpha_material_colored = 2131165276;
 			
-			// aapt resource value: 0x7f08005d
-			public const int highlight_alpha_material_dark = 2131230813;
+			// aapt resource value: 0x7f07005d
+			public const int highlight_alpha_material_dark = 2131165277;
 			
-			// aapt resource value: 0x7f08005e
-			public const int highlight_alpha_material_light = 2131230814;
+			// aapt resource value: 0x7f07005e
+			public const int highlight_alpha_material_light = 2131165278;
 			
-			// aapt resource value: 0x7f08005f
-			public const int hint_alpha_material_dark = 2131230815;
+			// aapt resource value: 0x7f07005f
+			public const int hint_alpha_material_dark = 2131165279;
 			
-			// aapt resource value: 0x7f080060
-			public const int hint_alpha_material_light = 2131230816;
+			// aapt resource value: 0x7f070060
+			public const int hint_alpha_material_light = 2131165280;
 			
-			// aapt resource value: 0x7f080061
-			public const int hint_pressed_alpha_material_dark = 2131230817;
+			// aapt resource value: 0x7f070061
+			public const int hint_pressed_alpha_material_dark = 2131165281;
 			
-			// aapt resource value: 0x7f080062
-			public const int hint_pressed_alpha_material_light = 2131230818;
+			// aapt resource value: 0x7f070062
+			public const int hint_pressed_alpha_material_light = 2131165282;
 			
-			// aapt resource value: 0x7f080000
-			public const int item_touch_helper_max_drag_scroll_per_frame = 2131230720;
+			// aapt resource value: 0x7f070000
+			public const int item_touch_helper_max_drag_scroll_per_frame = 2131165184;
 			
-			// aapt resource value: 0x7f080001
-			public const int item_touch_helper_swipe_escape_max_velocity = 2131230721;
+			// aapt resource value: 0x7f070001
+			public const int item_touch_helper_swipe_escape_max_velocity = 2131165185;
 			
-			// aapt resource value: 0x7f080002
-			public const int item_touch_helper_swipe_escape_velocity = 2131230722;
+			// aapt resource value: 0x7f070002
+			public const int item_touch_helper_swipe_escape_velocity = 2131165186;
 			
-			// aapt resource value: 0x7f080003
-			public const int mr_controller_volume_group_list_item_height = 2131230723;
+			// aapt resource value: 0x7f070003
+			public const int mr_controller_volume_group_list_item_height = 2131165187;
 			
-			// aapt resource value: 0x7f080004
-			public const int mr_controller_volume_group_list_item_icon_size = 2131230724;
+			// aapt resource value: 0x7f070004
+			public const int mr_controller_volume_group_list_item_icon_size = 2131165188;
 			
-			// aapt resource value: 0x7f080005
-			public const int mr_controller_volume_group_list_max_height = 2131230725;
+			// aapt resource value: 0x7f070005
+			public const int mr_controller_volume_group_list_max_height = 2131165189;
 			
-			// aapt resource value: 0x7f080008
-			public const int mr_controller_volume_group_list_padding_top = 2131230728;
+			// aapt resource value: 0x7f070008
+			public const int mr_controller_volume_group_list_padding_top = 2131165192;
 			
-			// aapt resource value: 0x7f080006
-			public const int mr_dialog_fixed_width_major = 2131230726;
+			// aapt resource value: 0x7f070006
+			public const int mr_dialog_fixed_width_major = 2131165190;
 			
-			// aapt resource value: 0x7f080007
-			public const int mr_dialog_fixed_width_minor = 2131230727;
+			// aapt resource value: 0x7f070007
+			public const int mr_dialog_fixed_width_minor = 2131165191;
 			
-			// aapt resource value: 0x7f080063
-			public const int notification_action_icon_size = 2131230819;
+			// aapt resource value: 0x7f070063
+			public const int notification_action_icon_size = 2131165283;
 			
-			// aapt resource value: 0x7f080064
-			public const int notification_action_text_size = 2131230820;
+			// aapt resource value: 0x7f070064
+			public const int notification_action_text_size = 2131165284;
 			
-			// aapt resource value: 0x7f080065
-			public const int notification_big_circle_margin = 2131230821;
+			// aapt resource value: 0x7f070065
+			public const int notification_big_circle_margin = 2131165285;
 			
-			// aapt resource value: 0x7f08001e
-			public const int notification_content_margin_start = 2131230750;
+			// aapt resource value: 0x7f07001e
+			public const int notification_content_margin_start = 2131165214;
 			
-			// aapt resource value: 0x7f080066
-			public const int notification_large_icon_height = 2131230822;
+			// aapt resource value: 0x7f070066
+			public const int notification_large_icon_height = 2131165286;
 			
-			// aapt resource value: 0x7f080067
-			public const int notification_large_icon_width = 2131230823;
+			// aapt resource value: 0x7f070067
+			public const int notification_large_icon_width = 2131165287;
 			
-			// aapt resource value: 0x7f08001f
-			public const int notification_main_column_padding_top = 2131230751;
+			// aapt resource value: 0x7f07001f
+			public const int notification_main_column_padding_top = 2131165215;
 			
-			// aapt resource value: 0x7f080020
-			public const int notification_media_narrow_margin = 2131230752;
+			// aapt resource value: 0x7f070020
+			public const int notification_media_narrow_margin = 2131165216;
 			
-			// aapt resource value: 0x7f080068
-			public const int notification_right_icon_size = 2131230824;
+			// aapt resource value: 0x7f070068
+			public const int notification_right_icon_size = 2131165288;
 			
-			// aapt resource value: 0x7f08001c
-			public const int notification_right_side_padding_top = 2131230748;
+			// aapt resource value: 0x7f07001c
+			public const int notification_right_side_padding_top = 2131165212;
 			
-			// aapt resource value: 0x7f080069
-			public const int notification_small_icon_background_padding = 2131230825;
+			// aapt resource value: 0x7f070069
+			public const int notification_small_icon_background_padding = 2131165289;
 			
-			// aapt resource value: 0x7f08006a
-			public const int notification_small_icon_size_as_large = 2131230826;
+			// aapt resource value: 0x7f07006a
+			public const int notification_small_icon_size_as_large = 2131165290;
 			
-			// aapt resource value: 0x7f08006b
-			public const int notification_subtext_size = 2131230827;
+			// aapt resource value: 0x7f07006b
+			public const int notification_subtext_size = 2131165291;
 			
-			// aapt resource value: 0x7f08006c
-			public const int notification_top_pad = 2131230828;
+			// aapt resource value: 0x7f07006c
+			public const int notification_top_pad = 2131165292;
 			
-			// aapt resource value: 0x7f08006d
-			public const int notification_top_pad_large_text = 2131230829;
+			// aapt resource value: 0x7f07006d
+			public const int notification_top_pad_large_text = 2131165293;
 			
 			static Dimension()
 			{
@@ -2784,548 +2784,548 @@ namespace XFormsApp.Droid
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f09009e
-			public const int action0 = 2131296414;
+			// aapt resource value: 0x7f08009e
+			public const int action0 = 2131230878;
 			
-			// aapt resource value: 0x7f090064
-			public const int action_bar = 2131296356;
+			// aapt resource value: 0x7f080064
+			public const int action_bar = 2131230820;
 			
-			// aapt resource value: 0x7f090001
-			public const int action_bar_activity_content = 2131296257;
+			// aapt resource value: 0x7f080001
+			public const int action_bar_activity_content = 2131230721;
 			
-			// aapt resource value: 0x7f090063
-			public const int action_bar_container = 2131296355;
+			// aapt resource value: 0x7f080063
+			public const int action_bar_container = 2131230819;
 			
-			// aapt resource value: 0x7f09005f
-			public const int action_bar_root = 2131296351;
+			// aapt resource value: 0x7f08005f
+			public const int action_bar_root = 2131230815;
 			
-			// aapt resource value: 0x7f090002
-			public const int action_bar_spinner = 2131296258;
+			// aapt resource value: 0x7f080002
+			public const int action_bar_spinner = 2131230722;
 			
-			// aapt resource value: 0x7f090042
-			public const int action_bar_subtitle = 2131296322;
+			// aapt resource value: 0x7f080042
+			public const int action_bar_subtitle = 2131230786;
 			
-			// aapt resource value: 0x7f090041
-			public const int action_bar_title = 2131296321;
+			// aapt resource value: 0x7f080041
+			public const int action_bar_title = 2131230785;
 			
-			// aapt resource value: 0x7f09009b
-			public const int action_container = 2131296411;
+			// aapt resource value: 0x7f08009b
+			public const int action_container = 2131230875;
 			
-			// aapt resource value: 0x7f090065
-			public const int action_context_bar = 2131296357;
+			// aapt resource value: 0x7f080065
+			public const int action_context_bar = 2131230821;
 			
-			// aapt resource value: 0x7f0900a2
-			public const int action_divider = 2131296418;
+			// aapt resource value: 0x7f0800a2
+			public const int action_divider = 2131230882;
 			
-			// aapt resource value: 0x7f09009c
-			public const int action_image = 2131296412;
+			// aapt resource value: 0x7f08009c
+			public const int action_image = 2131230876;
 			
-			// aapt resource value: 0x7f090003
-			public const int action_menu_divider = 2131296259;
+			// aapt resource value: 0x7f080003
+			public const int action_menu_divider = 2131230723;
 			
-			// aapt resource value: 0x7f090004
-			public const int action_menu_presenter = 2131296260;
+			// aapt resource value: 0x7f080004
+			public const int action_menu_presenter = 2131230724;
 			
-			// aapt resource value: 0x7f090061
-			public const int action_mode_bar = 2131296353;
+			// aapt resource value: 0x7f080061
+			public const int action_mode_bar = 2131230817;
 			
-			// aapt resource value: 0x7f090060
-			public const int action_mode_bar_stub = 2131296352;
+			// aapt resource value: 0x7f080060
+			public const int action_mode_bar_stub = 2131230816;
 			
-			// aapt resource value: 0x7f090043
-			public const int action_mode_close_button = 2131296323;
+			// aapt resource value: 0x7f080043
+			public const int action_mode_close_button = 2131230787;
 			
-			// aapt resource value: 0x7f09009d
-			public const int action_text = 2131296413;
+			// aapt resource value: 0x7f08009d
+			public const int action_text = 2131230877;
 			
-			// aapt resource value: 0x7f0900ab
-			public const int actions = 2131296427;
+			// aapt resource value: 0x7f0800ab
+			public const int actions = 2131230891;
 			
-			// aapt resource value: 0x7f090044
-			public const int activity_chooser_view_content = 2131296324;
+			// aapt resource value: 0x7f080044
+			public const int activity_chooser_view_content = 2131230788;
 			
-			// aapt resource value: 0x7f09001e
-			public const int add = 2131296286;
+			// aapt resource value: 0x7f08001e
+			public const int add = 2131230750;
 			
-			// aapt resource value: 0x7f0900b2
-			public const int agentWebView = 2131296434;
+			// aapt resource value: 0x7f0800b2
+			public const int agentWebView = 2131230898;
 			
-			// aapt resource value: 0x7f090058
-			public const int alertTitle = 2131296344;
+			// aapt resource value: 0x7f080058
+			public const int alertTitle = 2131230808;
 			
-			// aapt resource value: 0x7f09003d
-			public const int all = 2131296317;
+			// aapt resource value: 0x7f08003d
+			public const int all = 2131230781;
 			
-			// aapt resource value: 0x7f090023
-			public const int always = 2131296291;
+			// aapt resource value: 0x7f080023
+			public const int always = 2131230755;
 			
-			// aapt resource value: 0x7f09002f
-			public const int auto = 2131296303;
+			// aapt resource value: 0x7f08002f
+			public const int auto = 2131230767;
 			
-			// aapt resource value: 0x7f090020
-			public const int beginning = 2131296288;
+			// aapt resource value: 0x7f080020
+			public const int beginning = 2131230752;
 			
-			// aapt resource value: 0x7f090028
-			public const int bottom = 2131296296;
+			// aapt resource value: 0x7f080028
+			public const int bottom = 2131230760;
 			
-			// aapt resource value: 0x7f09004b
-			public const int buttonPanel = 2131296331;
+			// aapt resource value: 0x7f08004b
+			public const int buttonPanel = 2131230795;
 			
-			// aapt resource value: 0x7f09009f
-			public const int cancel_action = 2131296415;
+			// aapt resource value: 0x7f08009f
+			public const int cancel_action = 2131230879;
 			
-			// aapt resource value: 0x7f090030
-			public const int center = 2131296304;
+			// aapt resource value: 0x7f080030
+			public const int center = 2131230768;
 			
-			// aapt resource value: 0x7f090031
-			public const int center_horizontal = 2131296305;
+			// aapt resource value: 0x7f080031
+			public const int center_horizontal = 2131230769;
 			
-			// aapt resource value: 0x7f090032
-			public const int center_vertical = 2131296306;
+			// aapt resource value: 0x7f080032
+			public const int center_vertical = 2131230770;
 			
-			// aapt resource value: 0x7f09005b
-			public const int checkbox = 2131296347;
+			// aapt resource value: 0x7f08005b
+			public const int checkbox = 2131230811;
 			
-			// aapt resource value: 0x7f0900a7
-			public const int chronometer = 2131296423;
+			// aapt resource value: 0x7f0800a7
+			public const int chronometer = 2131230887;
 			
-			// aapt resource value: 0x7f090039
-			public const int clip_horizontal = 2131296313;
+			// aapt resource value: 0x7f080039
+			public const int clip_horizontal = 2131230777;
 			
-			// aapt resource value: 0x7f09003a
-			public const int clip_vertical = 2131296314;
+			// aapt resource value: 0x7f08003a
+			public const int clip_vertical = 2131230778;
 			
-			// aapt resource value: 0x7f090024
-			public const int collapseActionView = 2131296292;
+			// aapt resource value: 0x7f080024
+			public const int collapseActionView = 2131230756;
 			
-			// aapt resource value: 0x7f090075
-			public const int container = 2131296373;
+			// aapt resource value: 0x7f080075
+			public const int container = 2131230837;
 			
-			// aapt resource value: 0x7f09004e
-			public const int contentPanel = 2131296334;
+			// aapt resource value: 0x7f08004e
+			public const int contentPanel = 2131230798;
 			
-			// aapt resource value: 0x7f090076
-			public const int coordinator = 2131296374;
+			// aapt resource value: 0x7f080076
+			public const int coordinator = 2131230838;
 			
-			// aapt resource value: 0x7f090055
-			public const int custom = 2131296341;
+			// aapt resource value: 0x7f080055
+			public const int custom = 2131230805;
 			
-			// aapt resource value: 0x7f090054
-			public const int customPanel = 2131296340;
+			// aapt resource value: 0x7f080054
+			public const int customPanel = 2131230804;
 			
-			// aapt resource value: 0x7f090062
-			public const int decor_content_parent = 2131296354;
+			// aapt resource value: 0x7f080062
+			public const int decor_content_parent = 2131230818;
 			
-			// aapt resource value: 0x7f090047
-			public const int default_activity_button = 2131296327;
+			// aapt resource value: 0x7f080047
+			public const int default_activity_button = 2131230791;
 			
-			// aapt resource value: 0x7f090078
-			public const int design_bottom_sheet = 2131296376;
+			// aapt resource value: 0x7f080078
+			public const int design_bottom_sheet = 2131230840;
 			
-			// aapt resource value: 0x7f09007f
-			public const int design_menu_item_action_area = 2131296383;
+			// aapt resource value: 0x7f08007f
+			public const int design_menu_item_action_area = 2131230847;
 			
-			// aapt resource value: 0x7f09007e
-			public const int design_menu_item_action_area_stub = 2131296382;
+			// aapt resource value: 0x7f08007e
+			public const int design_menu_item_action_area_stub = 2131230846;
 			
-			// aapt resource value: 0x7f09007d
-			public const int design_menu_item_text = 2131296381;
+			// aapt resource value: 0x7f08007d
+			public const int design_menu_item_text = 2131230845;
 			
-			// aapt resource value: 0x7f09007c
-			public const int design_navigation_view = 2131296380;
+			// aapt resource value: 0x7f08007c
+			public const int design_navigation_view = 2131230844;
 			
-			// aapt resource value: 0x7f090012
-			public const int disableHome = 2131296274;
+			// aapt resource value: 0x7f080012
+			public const int disableHome = 2131230738;
 			
-			// aapt resource value: 0x7f090066
-			public const int edit_query = 2131296358;
+			// aapt resource value: 0x7f080066
+			public const int edit_query = 2131230822;
 			
-			// aapt resource value: 0x7f090021
-			public const int end = 2131296289;
+			// aapt resource value: 0x7f080021
+			public const int end = 2131230753;
 			
-			// aapt resource value: 0x7f0900b1
-			public const int end_padder = 2131296433;
+			// aapt resource value: 0x7f0800b1
+			public const int end_padder = 2131230897;
 			
-			// aapt resource value: 0x7f09002a
-			public const int enterAlways = 2131296298;
+			// aapt resource value: 0x7f08002a
+			public const int enterAlways = 2131230762;
 			
-			// aapt resource value: 0x7f09002b
-			public const int enterAlwaysCollapsed = 2131296299;
+			// aapt resource value: 0x7f08002b
+			public const int enterAlwaysCollapsed = 2131230763;
 			
-			// aapt resource value: 0x7f09002c
-			public const int exitUntilCollapsed = 2131296300;
+			// aapt resource value: 0x7f08002c
+			public const int exitUntilCollapsed = 2131230764;
 			
-			// aapt resource value: 0x7f090045
-			public const int expand_activities_button = 2131296325;
+			// aapt resource value: 0x7f080045
+			public const int expand_activities_button = 2131230789;
 			
-			// aapt resource value: 0x7f09005a
-			public const int expanded_menu = 2131296346;
+			// aapt resource value: 0x7f08005a
+			public const int expanded_menu = 2131230810;
 			
-			// aapt resource value: 0x7f09003b
-			public const int fill = 2131296315;
+			// aapt resource value: 0x7f08003b
+			public const int fill = 2131230779;
 			
-			// aapt resource value: 0x7f09003c
-			public const int fill_horizontal = 2131296316;
+			// aapt resource value: 0x7f08003c
+			public const int fill_horizontal = 2131230780;
 			
-			// aapt resource value: 0x7f090033
-			public const int fill_vertical = 2131296307;
+			// aapt resource value: 0x7f080033
+			public const int fill_vertical = 2131230771;
 			
-			// aapt resource value: 0x7f09003f
-			public const int @fixed = 2131296319;
+			// aapt resource value: 0x7f08003f
+			public const int @fixed = 2131230783;
 			
-			// aapt resource value: 0x7f090005
-			public const int home = 2131296261;
+			// aapt resource value: 0x7f080005
+			public const int home = 2131230725;
 			
-			// aapt resource value: 0x7f090013
-			public const int homeAsUp = 2131296275;
+			// aapt resource value: 0x7f080013
+			public const int homeAsUp = 2131230739;
 			
-			// aapt resource value: 0x7f090049
-			public const int icon = 2131296329;
+			// aapt resource value: 0x7f080049
+			public const int icon = 2131230793;
 			
-			// aapt resource value: 0x7f0900ac
-			public const int icon_group = 2131296428;
+			// aapt resource value: 0x7f0800ac
+			public const int icon_group = 2131230892;
 			
-			// aapt resource value: 0x7f090025
-			public const int ifRoom = 2131296293;
+			// aapt resource value: 0x7f080025
+			public const int ifRoom = 2131230757;
 			
-			// aapt resource value: 0x7f090046
-			public const int image = 2131296326;
+			// aapt resource value: 0x7f080046
+			public const int image = 2131230790;
 			
-			// aapt resource value: 0x7f0900a8
-			public const int info = 2131296424;
+			// aapt resource value: 0x7f0800a8
+			public const int info = 2131230888;
 			
-			// aapt resource value: 0x7f090000
-			public const int item_touch_helper_previous_elevation = 2131296256;
+			// aapt resource value: 0x7f080000
+			public const int item_touch_helper_previous_elevation = 2131230720;
 			
-			// aapt resource value: 0x7f090074
-			public const int largeLabel = 2131296372;
+			// aapt resource value: 0x7f080074
+			public const int largeLabel = 2131230836;
 			
-			// aapt resource value: 0x7f090034
-			public const int left = 2131296308;
+			// aapt resource value: 0x7f080034
+			public const int left = 2131230772;
 			
-			// aapt resource value: 0x7f0900ad
-			public const int line1 = 2131296429;
+			// aapt resource value: 0x7f0800ad
+			public const int line1 = 2131230893;
 			
-			// aapt resource value: 0x7f0900af
-			public const int line3 = 2131296431;
+			// aapt resource value: 0x7f0800af
+			public const int line3 = 2131230895;
 			
-			// aapt resource value: 0x7f09000f
-			public const int listMode = 2131296271;
+			// aapt resource value: 0x7f08000f
+			public const int listMode = 2131230735;
 			
-			// aapt resource value: 0x7f090048
-			public const int list_item = 2131296328;
+			// aapt resource value: 0x7f080048
+			public const int list_item = 2131230792;
 			
-			// aapt resource value: 0x7f0900b4
-			public const int masked = 2131296436;
+			// aapt resource value: 0x7f0800b4
+			public const int masked = 2131230900;
 			
-			// aapt resource value: 0x7f0900a1
-			public const int media_actions = 2131296417;
+			// aapt resource value: 0x7f0800a1
+			public const int media_actions = 2131230881;
 			
-			// aapt resource value: 0x7f090022
-			public const int middle = 2131296290;
+			// aapt resource value: 0x7f080022
+			public const int middle = 2131230754;
 			
-			// aapt resource value: 0x7f09003e
-			public const int mini = 2131296318;
+			// aapt resource value: 0x7f08003e
+			public const int mini = 2131230782;
 			
-			// aapt resource value: 0x7f09008d
-			public const int mr_art = 2131296397;
+			// aapt resource value: 0x7f08008d
+			public const int mr_art = 2131230861;
 			
-			// aapt resource value: 0x7f090082
-			public const int mr_chooser_list = 2131296386;
+			// aapt resource value: 0x7f080082
+			public const int mr_chooser_list = 2131230850;
 			
-			// aapt resource value: 0x7f090085
-			public const int mr_chooser_route_desc = 2131296389;
+			// aapt resource value: 0x7f080085
+			public const int mr_chooser_route_desc = 2131230853;
 			
-			// aapt resource value: 0x7f090083
-			public const int mr_chooser_route_icon = 2131296387;
+			// aapt resource value: 0x7f080083
+			public const int mr_chooser_route_icon = 2131230851;
 			
-			// aapt resource value: 0x7f090084
-			public const int mr_chooser_route_name = 2131296388;
+			// aapt resource value: 0x7f080084
+			public const int mr_chooser_route_name = 2131230852;
 			
-			// aapt resource value: 0x7f090081
-			public const int mr_chooser_title = 2131296385;
+			// aapt resource value: 0x7f080081
+			public const int mr_chooser_title = 2131230849;
 			
-			// aapt resource value: 0x7f09008a
-			public const int mr_close = 2131296394;
+			// aapt resource value: 0x7f08008a
+			public const int mr_close = 2131230858;
 			
-			// aapt resource value: 0x7f090090
-			public const int mr_control_divider = 2131296400;
+			// aapt resource value: 0x7f080090
+			public const int mr_control_divider = 2131230864;
 			
-			// aapt resource value: 0x7f090096
-			public const int mr_control_playback_ctrl = 2131296406;
+			// aapt resource value: 0x7f080096
+			public const int mr_control_playback_ctrl = 2131230870;
 			
-			// aapt resource value: 0x7f090099
-			public const int mr_control_subtitle = 2131296409;
+			// aapt resource value: 0x7f080099
+			public const int mr_control_subtitle = 2131230873;
 			
-			// aapt resource value: 0x7f090098
-			public const int mr_control_title = 2131296408;
+			// aapt resource value: 0x7f080098
+			public const int mr_control_title = 2131230872;
 			
-			// aapt resource value: 0x7f090097
-			public const int mr_control_title_container = 2131296407;
+			// aapt resource value: 0x7f080097
+			public const int mr_control_title_container = 2131230871;
 			
-			// aapt resource value: 0x7f09008b
-			public const int mr_custom_control = 2131296395;
+			// aapt resource value: 0x7f08008b
+			public const int mr_custom_control = 2131230859;
 			
-			// aapt resource value: 0x7f09008c
-			public const int mr_default_control = 2131296396;
+			// aapt resource value: 0x7f08008c
+			public const int mr_default_control = 2131230860;
 			
-			// aapt resource value: 0x7f090087
-			public const int mr_dialog_area = 2131296391;
+			// aapt resource value: 0x7f080087
+			public const int mr_dialog_area = 2131230855;
 			
-			// aapt resource value: 0x7f090086
-			public const int mr_expandable_area = 2131296390;
+			// aapt resource value: 0x7f080086
+			public const int mr_expandable_area = 2131230854;
 			
-			// aapt resource value: 0x7f09009a
-			public const int mr_group_expand_collapse = 2131296410;
+			// aapt resource value: 0x7f08009a
+			public const int mr_group_expand_collapse = 2131230874;
 			
-			// aapt resource value: 0x7f09008e
-			public const int mr_media_main_control = 2131296398;
+			// aapt resource value: 0x7f08008e
+			public const int mr_media_main_control = 2131230862;
 			
-			// aapt resource value: 0x7f090089
-			public const int mr_name = 2131296393;
+			// aapt resource value: 0x7f080089
+			public const int mr_name = 2131230857;
 			
-			// aapt resource value: 0x7f09008f
-			public const int mr_playback_control = 2131296399;
+			// aapt resource value: 0x7f08008f
+			public const int mr_playback_control = 2131230863;
 			
-			// aapt resource value: 0x7f090088
-			public const int mr_title_bar = 2131296392;
+			// aapt resource value: 0x7f080088
+			public const int mr_title_bar = 2131230856;
 			
-			// aapt resource value: 0x7f090091
-			public const int mr_volume_control = 2131296401;
+			// aapt resource value: 0x7f080091
+			public const int mr_volume_control = 2131230865;
 			
-			// aapt resource value: 0x7f090092
-			public const int mr_volume_group_list = 2131296402;
+			// aapt resource value: 0x7f080092
+			public const int mr_volume_group_list = 2131230866;
 			
-			// aapt resource value: 0x7f090094
-			public const int mr_volume_item_icon = 2131296404;
+			// aapt resource value: 0x7f080094
+			public const int mr_volume_item_icon = 2131230868;
 			
-			// aapt resource value: 0x7f090095
-			public const int mr_volume_slider = 2131296405;
+			// aapt resource value: 0x7f080095
+			public const int mr_volume_slider = 2131230869;
 			
-			// aapt resource value: 0x7f090019
-			public const int multiply = 2131296281;
+			// aapt resource value: 0x7f080019
+			public const int multiply = 2131230745;
 			
-			// aapt resource value: 0x7f09007b
-			public const int navigation_header_container = 2131296379;
+			// aapt resource value: 0x7f08007b
+			public const int navigation_header_container = 2131230843;
 			
-			// aapt resource value: 0x7f090026
-			public const int never = 2131296294;
+			// aapt resource value: 0x7f080026
+			public const int never = 2131230758;
 			
-			// aapt resource value: 0x7f090014
-			public const int none = 2131296276;
+			// aapt resource value: 0x7f080014
+			public const int none = 2131230740;
 			
-			// aapt resource value: 0x7f090010
-			public const int normal = 2131296272;
+			// aapt resource value: 0x7f080010
+			public const int normal = 2131230736;
 			
-			// aapt resource value: 0x7f0900aa
-			public const int notification_background = 2131296426;
+			// aapt resource value: 0x7f0800aa
+			public const int notification_background = 2131230890;
 			
-			// aapt resource value: 0x7f0900a4
-			public const int notification_main_column = 2131296420;
+			// aapt resource value: 0x7f0800a4
+			public const int notification_main_column = 2131230884;
 			
-			// aapt resource value: 0x7f0900a3
-			public const int notification_main_column_container = 2131296419;
+			// aapt resource value: 0x7f0800a3
+			public const int notification_main_column_container = 2131230883;
 			
-			// aapt resource value: 0x7f090037
-			public const int parallax = 2131296311;
+			// aapt resource value: 0x7f080037
+			public const int parallax = 2131230775;
 			
-			// aapt resource value: 0x7f09004d
-			public const int parentPanel = 2131296333;
+			// aapt resource value: 0x7f08004d
+			public const int parentPanel = 2131230797;
 			
-			// aapt resource value: 0x7f090038
-			public const int pin = 2131296312;
+			// aapt resource value: 0x7f080038
+			public const int pin = 2131230776;
 			
-			// aapt resource value: 0x7f090006
-			public const int progress_circular = 2131296262;
+			// aapt resource value: 0x7f080006
+			public const int progress_circular = 2131230726;
 			
-			// aapt resource value: 0x7f090007
-			public const int progress_horizontal = 2131296263;
+			// aapt resource value: 0x7f080007
+			public const int progress_horizontal = 2131230727;
 			
-			// aapt resource value: 0x7f09005d
-			public const int radio = 2131296349;
+			// aapt resource value: 0x7f08005d
+			public const int radio = 2131230813;
 			
-			// aapt resource value: 0x7f090035
-			public const int right = 2131296309;
+			// aapt resource value: 0x7f080035
+			public const int right = 2131230773;
 			
-			// aapt resource value: 0x7f0900a9
-			public const int right_icon = 2131296425;
+			// aapt resource value: 0x7f0800a9
+			public const int right_icon = 2131230889;
 			
-			// aapt resource value: 0x7f0900a5
-			public const int right_side = 2131296421;
+			// aapt resource value: 0x7f0800a5
+			public const int right_side = 2131230885;
 			
-			// aapt resource value: 0x7f09001a
-			public const int screen = 2131296282;
+			// aapt resource value: 0x7f08001a
+			public const int screen = 2131230746;
 			
-			// aapt resource value: 0x7f09002d
-			public const int scroll = 2131296301;
+			// aapt resource value: 0x7f08002d
+			public const int scroll = 2131230765;
 			
-			// aapt resource value: 0x7f090053
-			public const int scrollIndicatorDown = 2131296339;
+			// aapt resource value: 0x7f080053
+			public const int scrollIndicatorDown = 2131230803;
 			
-			// aapt resource value: 0x7f09004f
-			public const int scrollIndicatorUp = 2131296335;
+			// aapt resource value: 0x7f08004f
+			public const int scrollIndicatorUp = 2131230799;
 			
-			// aapt resource value: 0x7f090050
-			public const int scrollView = 2131296336;
+			// aapt resource value: 0x7f080050
+			public const int scrollView = 2131230800;
 			
-			// aapt resource value: 0x7f090040
-			public const int scrollable = 2131296320;
+			// aapt resource value: 0x7f080040
+			public const int scrollable = 2131230784;
 			
-			// aapt resource value: 0x7f090068
-			public const int search_badge = 2131296360;
+			// aapt resource value: 0x7f080068
+			public const int search_badge = 2131230824;
 			
-			// aapt resource value: 0x7f090067
-			public const int search_bar = 2131296359;
+			// aapt resource value: 0x7f080067
+			public const int search_bar = 2131230823;
 			
-			// aapt resource value: 0x7f090069
-			public const int search_button = 2131296361;
+			// aapt resource value: 0x7f080069
+			public const int search_button = 2131230825;
 			
-			// aapt resource value: 0x7f09006e
-			public const int search_close_btn = 2131296366;
+			// aapt resource value: 0x7f08006e
+			public const int search_close_btn = 2131230830;
 			
-			// aapt resource value: 0x7f09006a
-			public const int search_edit_frame = 2131296362;
+			// aapt resource value: 0x7f08006a
+			public const int search_edit_frame = 2131230826;
 			
-			// aapt resource value: 0x7f090070
-			public const int search_go_btn = 2131296368;
+			// aapt resource value: 0x7f080070
+			public const int search_go_btn = 2131230832;
 			
-			// aapt resource value: 0x7f09006b
-			public const int search_mag_icon = 2131296363;
+			// aapt resource value: 0x7f08006b
+			public const int search_mag_icon = 2131230827;
 			
-			// aapt resource value: 0x7f09006c
-			public const int search_plate = 2131296364;
+			// aapt resource value: 0x7f08006c
+			public const int search_plate = 2131230828;
 			
-			// aapt resource value: 0x7f09006d
-			public const int search_src_text = 2131296365;
+			// aapt resource value: 0x7f08006d
+			public const int search_src_text = 2131230829;
 			
-			// aapt resource value: 0x7f090071
-			public const int search_voice_btn = 2131296369;
+			// aapt resource value: 0x7f080071
+			public const int search_voice_btn = 2131230833;
 			
-			// aapt resource value: 0x7f090072
-			public const int select_dialog_listview = 2131296370;
+			// aapt resource value: 0x7f080072
+			public const int select_dialog_listview = 2131230834;
 			
-			// aapt resource value: 0x7f09005c
-			public const int shortcut = 2131296348;
+			// aapt resource value: 0x7f08005c
+			public const int shortcut = 2131230812;
 			
-			// aapt resource value: 0x7f090015
-			public const int showCustom = 2131296277;
+			// aapt resource value: 0x7f080015
+			public const int showCustom = 2131230741;
 			
-			// aapt resource value: 0x7f090016
-			public const int showHome = 2131296278;
+			// aapt resource value: 0x7f080016
+			public const int showHome = 2131230742;
 			
-			// aapt resource value: 0x7f090017
-			public const int showTitle = 2131296279;
+			// aapt resource value: 0x7f080017
+			public const int showTitle = 2131230743;
 			
-			// aapt resource value: 0x7f090073
-			public const int smallLabel = 2131296371;
+			// aapt resource value: 0x7f080073
+			public const int smallLabel = 2131230835;
 			
-			// aapt resource value: 0x7f09007a
-			public const int snackbar_action = 2131296378;
+			// aapt resource value: 0x7f08007a
+			public const int snackbar_action = 2131230842;
 			
-			// aapt resource value: 0x7f090079
-			public const int snackbar_text = 2131296377;
+			// aapt resource value: 0x7f080079
+			public const int snackbar_text = 2131230841;
 			
-			// aapt resource value: 0x7f09002e
-			public const int snap = 2131296302;
+			// aapt resource value: 0x7f08002e
+			public const int snap = 2131230766;
 			
-			// aapt resource value: 0x7f09004c
-			public const int spacer = 2131296332;
+			// aapt resource value: 0x7f08004c
+			public const int spacer = 2131230796;
 			
-			// aapt resource value: 0x7f090008
-			public const int split_action_bar = 2131296264;
+			// aapt resource value: 0x7f080008
+			public const int split_action_bar = 2131230728;
 			
-			// aapt resource value: 0x7f09001b
-			public const int src_atop = 2131296283;
+			// aapt resource value: 0x7f08001b
+			public const int src_atop = 2131230747;
 			
-			// aapt resource value: 0x7f09001c
-			public const int src_in = 2131296284;
+			// aapt resource value: 0x7f08001c
+			public const int src_in = 2131230748;
 			
-			// aapt resource value: 0x7f09001d
-			public const int src_over = 2131296285;
+			// aapt resource value: 0x7f08001d
+			public const int src_over = 2131230749;
 			
-			// aapt resource value: 0x7f090036
-			public const int start = 2131296310;
+			// aapt resource value: 0x7f080036
+			public const int start = 2131230774;
 			
-			// aapt resource value: 0x7f0900a0
-			public const int status_bar_latest_event_content = 2131296416;
+			// aapt resource value: 0x7f0800a0
+			public const int status_bar_latest_event_content = 2131230880;
 			
-			// aapt resource value: 0x7f09005e
-			public const int submenuarrow = 2131296350;
+			// aapt resource value: 0x7f08005e
+			public const int submenuarrow = 2131230814;
 			
-			// aapt resource value: 0x7f09006f
-			public const int submit_area = 2131296367;
+			// aapt resource value: 0x7f08006f
+			public const int submit_area = 2131230831;
 			
-			// aapt resource value: 0x7f090011
-			public const int tabMode = 2131296273;
+			// aapt resource value: 0x7f080011
+			public const int tabMode = 2131230737;
 			
-			// aapt resource value: 0x7f0900b0
-			public const int text = 2131296432;
+			// aapt resource value: 0x7f0800b0
+			public const int text = 2131230896;
 			
-			// aapt resource value: 0x7f0900ae
-			public const int text2 = 2131296430;
+			// aapt resource value: 0x7f0800ae
+			public const int text2 = 2131230894;
 			
-			// aapt resource value: 0x7f090052
-			public const int textSpacerNoButtons = 2131296338;
+			// aapt resource value: 0x7f080052
+			public const int textSpacerNoButtons = 2131230802;
 			
-			// aapt resource value: 0x7f090051
-			public const int textSpacerNoTitle = 2131296337;
+			// aapt resource value: 0x7f080051
+			public const int textSpacerNoTitle = 2131230801;
 			
-			// aapt resource value: 0x7f090080
-			public const int text_input_password_toggle = 2131296384;
+			// aapt resource value: 0x7f080080
+			public const int text_input_password_toggle = 2131230848;
 			
-			// aapt resource value: 0x7f09000c
-			public const int textinput_counter = 2131296268;
+			// aapt resource value: 0x7f08000c
+			public const int textinput_counter = 2131230732;
 			
-			// aapt resource value: 0x7f09000d
-			public const int textinput_error = 2131296269;
+			// aapt resource value: 0x7f08000d
+			public const int textinput_error = 2131230733;
 			
-			// aapt resource value: 0x7f0900a6
-			public const int time = 2131296422;
+			// aapt resource value: 0x7f0800a6
+			public const int time = 2131230886;
 			
-			// aapt resource value: 0x7f09004a
-			public const int title = 2131296330;
+			// aapt resource value: 0x7f08004a
+			public const int title = 2131230794;
 			
-			// aapt resource value: 0x7f090059
-			public const int titleDividerNoCustom = 2131296345;
+			// aapt resource value: 0x7f080059
+			public const int titleDividerNoCustom = 2131230809;
 			
-			// aapt resource value: 0x7f090057
-			public const int title_template = 2131296343;
+			// aapt resource value: 0x7f080057
+			public const int title_template = 2131230807;
 			
-			// aapt resource value: 0x7f090029
-			public const int top = 2131296297;
+			// aapt resource value: 0x7f080029
+			public const int top = 2131230761;
 			
-			// aapt resource value: 0x7f090056
-			public const int topPanel = 2131296342;
+			// aapt resource value: 0x7f080056
+			public const int topPanel = 2131230806;
 			
-			// aapt resource value: 0x7f090077
-			public const int touch_outside = 2131296375;
+			// aapt resource value: 0x7f080077
+			public const int touch_outside = 2131230839;
 			
-			// aapt resource value: 0x7f09000a
-			public const int transition_current_scene = 2131296266;
+			// aapt resource value: 0x7f08000a
+			public const int transition_current_scene = 2131230730;
 			
-			// aapt resource value: 0x7f09000b
-			public const int transition_scene_layoutid_cache = 2131296267;
+			// aapt resource value: 0x7f08000b
+			public const int transition_scene_layoutid_cache = 2131230731;
 			
-			// aapt resource value: 0x7f090009
-			public const int up = 2131296265;
+			// aapt resource value: 0x7f080009
+			public const int up = 2131230729;
 			
-			// aapt resource value: 0x7f090018
-			public const int useLogo = 2131296280;
+			// aapt resource value: 0x7f080018
+			public const int useLogo = 2131230744;
 			
-			// aapt resource value: 0x7f09000e
-			public const int view_offset_helper = 2131296270;
+			// aapt resource value: 0x7f08000e
+			public const int view_offset_helper = 2131230734;
 			
-			// aapt resource value: 0x7f0900b3
-			public const int visible = 2131296435;
+			// aapt resource value: 0x7f0800b3
+			public const int visible = 2131230899;
 			
-			// aapt resource value: 0x7f090093
-			public const int volume_item_container = 2131296403;
+			// aapt resource value: 0x7f080093
+			public const int volume_item_container = 2131230867;
 			
-			// aapt resource value: 0x7f090027
-			public const int withText = 2131296295;
+			// aapt resource value: 0x7f080027
+			public const int withText = 2131230759;
 			
-			// aapt resource value: 0x7f09001f
-			public const int wrap_content = 2131296287;
+			// aapt resource value: 0x7f08001f
+			public const int wrap_content = 2131230751;
 			
 			static Id()
 			{
@@ -3622,194 +3622,194 @@ namespace XFormsApp.Droid
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f070000
-			public const int ApplicationName = 2131165184;
+			// aapt resource value: 0x7f09003e
+			public const int ApplicationName = 2131296318;
 			
-			// aapt resource value: 0x7f070016
-			public const int abc_action_bar_home_description = 2131165206;
+			// aapt resource value: 0x7f090015
+			public const int abc_action_bar_home_description = 2131296277;
 			
-			// aapt resource value: 0x7f070017
-			public const int abc_action_bar_home_description_format = 2131165207;
+			// aapt resource value: 0x7f090016
+			public const int abc_action_bar_home_description_format = 2131296278;
 			
-			// aapt resource value: 0x7f070018
-			public const int abc_action_bar_home_subtitle_description_format = 2131165208;
+			// aapt resource value: 0x7f090017
+			public const int abc_action_bar_home_subtitle_description_format = 2131296279;
 			
-			// aapt resource value: 0x7f070019
-			public const int abc_action_bar_up_description = 2131165209;
+			// aapt resource value: 0x7f090018
+			public const int abc_action_bar_up_description = 2131296280;
 			
-			// aapt resource value: 0x7f07001a
-			public const int abc_action_menu_overflow_description = 2131165210;
+			// aapt resource value: 0x7f090019
+			public const int abc_action_menu_overflow_description = 2131296281;
 			
-			// aapt resource value: 0x7f07001b
-			public const int abc_action_mode_done = 2131165211;
+			// aapt resource value: 0x7f09001a
+			public const int abc_action_mode_done = 2131296282;
 			
-			// aapt resource value: 0x7f07001c
-			public const int abc_activity_chooser_view_see_all = 2131165212;
+			// aapt resource value: 0x7f09001b
+			public const int abc_activity_chooser_view_see_all = 2131296283;
 			
-			// aapt resource value: 0x7f07001d
-			public const int abc_activitychooserview_choose_application = 2131165213;
+			// aapt resource value: 0x7f09001c
+			public const int abc_activitychooserview_choose_application = 2131296284;
 			
-			// aapt resource value: 0x7f07001e
-			public const int abc_capital_off = 2131165214;
+			// aapt resource value: 0x7f09001d
+			public const int abc_capital_off = 2131296285;
 			
-			// aapt resource value: 0x7f07001f
-			public const int abc_capital_on = 2131165215;
+			// aapt resource value: 0x7f09001e
+			public const int abc_capital_on = 2131296286;
 			
-			// aapt resource value: 0x7f07002b
-			public const int abc_font_family_body_1_material = 2131165227;
+			// aapt resource value: 0x7f09002a
+			public const int abc_font_family_body_1_material = 2131296298;
 			
-			// aapt resource value: 0x7f07002c
-			public const int abc_font_family_body_2_material = 2131165228;
+			// aapt resource value: 0x7f09002b
+			public const int abc_font_family_body_2_material = 2131296299;
 			
-			// aapt resource value: 0x7f07002d
-			public const int abc_font_family_button_material = 2131165229;
+			// aapt resource value: 0x7f09002c
+			public const int abc_font_family_button_material = 2131296300;
 			
-			// aapt resource value: 0x7f07002e
-			public const int abc_font_family_caption_material = 2131165230;
+			// aapt resource value: 0x7f09002d
+			public const int abc_font_family_caption_material = 2131296301;
 			
-			// aapt resource value: 0x7f07002f
-			public const int abc_font_family_display_1_material = 2131165231;
+			// aapt resource value: 0x7f09002e
+			public const int abc_font_family_display_1_material = 2131296302;
 			
-			// aapt resource value: 0x7f070030
-			public const int abc_font_family_display_2_material = 2131165232;
+			// aapt resource value: 0x7f09002f
+			public const int abc_font_family_display_2_material = 2131296303;
 			
-			// aapt resource value: 0x7f070031
-			public const int abc_font_family_display_3_material = 2131165233;
+			// aapt resource value: 0x7f090030
+			public const int abc_font_family_display_3_material = 2131296304;
 			
-			// aapt resource value: 0x7f070032
-			public const int abc_font_family_display_4_material = 2131165234;
+			// aapt resource value: 0x7f090031
+			public const int abc_font_family_display_4_material = 2131296305;
 			
-			// aapt resource value: 0x7f070033
-			public const int abc_font_family_headline_material = 2131165235;
+			// aapt resource value: 0x7f090032
+			public const int abc_font_family_headline_material = 2131296306;
 			
-			// aapt resource value: 0x7f070034
-			public const int abc_font_family_menu_material = 2131165236;
+			// aapt resource value: 0x7f090033
+			public const int abc_font_family_menu_material = 2131296307;
 			
-			// aapt resource value: 0x7f070035
-			public const int abc_font_family_subhead_material = 2131165237;
+			// aapt resource value: 0x7f090034
+			public const int abc_font_family_subhead_material = 2131296308;
 			
-			// aapt resource value: 0x7f070036
-			public const int abc_font_family_title_material = 2131165238;
+			// aapt resource value: 0x7f090035
+			public const int abc_font_family_title_material = 2131296309;
 			
-			// aapt resource value: 0x7f070020
-			public const int abc_search_hint = 2131165216;
+			// aapt resource value: 0x7f09001f
+			public const int abc_search_hint = 2131296287;
 			
-			// aapt resource value: 0x7f070021
-			public const int abc_searchview_description_clear = 2131165217;
+			// aapt resource value: 0x7f090020
+			public const int abc_searchview_description_clear = 2131296288;
 			
-			// aapt resource value: 0x7f070022
-			public const int abc_searchview_description_query = 2131165218;
+			// aapt resource value: 0x7f090021
+			public const int abc_searchview_description_query = 2131296289;
 			
-			// aapt resource value: 0x7f070023
-			public const int abc_searchview_description_search = 2131165219;
+			// aapt resource value: 0x7f090022
+			public const int abc_searchview_description_search = 2131296290;
 			
-			// aapt resource value: 0x7f070024
-			public const int abc_searchview_description_submit = 2131165220;
+			// aapt resource value: 0x7f090023
+			public const int abc_searchview_description_submit = 2131296291;
 			
-			// aapt resource value: 0x7f070025
-			public const int abc_searchview_description_voice = 2131165221;
+			// aapt resource value: 0x7f090024
+			public const int abc_searchview_description_voice = 2131296292;
 			
-			// aapt resource value: 0x7f070026
-			public const int abc_shareactionprovider_share_with = 2131165222;
+			// aapt resource value: 0x7f090025
+			public const int abc_shareactionprovider_share_with = 2131296293;
 			
-			// aapt resource value: 0x7f070027
-			public const int abc_shareactionprovider_share_with_application = 2131165223;
+			// aapt resource value: 0x7f090026
+			public const int abc_shareactionprovider_share_with_application = 2131296294;
 			
-			// aapt resource value: 0x7f070028
-			public const int abc_toolbar_collapse_description = 2131165224;
+			// aapt resource value: 0x7f090027
+			public const int abc_toolbar_collapse_description = 2131296295;
 			
-			// aapt resource value: 0x7f070037
-			public const int appbar_scrolling_view_behavior = 2131165239;
+			// aapt resource value: 0x7f090036
+			public const int appbar_scrolling_view_behavior = 2131296310;
 			
-			// aapt resource value: 0x7f070038
-			public const int bottom_sheet_behavior = 2131165240;
+			// aapt resource value: 0x7f090037
+			public const int bottom_sheet_behavior = 2131296311;
 			
-			// aapt resource value: 0x7f070039
-			public const int character_counter_pattern = 2131165241;
+			// aapt resource value: 0x7f090038
+			public const int character_counter_pattern = 2131296312;
 			
-			// aapt resource value: 0x7f070001
-			public const int mr_button_content_description = 2131165185;
+			// aapt resource value: 0x7f090000
+			public const int mr_button_content_description = 2131296256;
 			
-			// aapt resource value: 0x7f070002
-			public const int mr_cast_button_connected = 2131165186;
+			// aapt resource value: 0x7f090001
+			public const int mr_cast_button_connected = 2131296257;
 			
-			// aapt resource value: 0x7f070003
-			public const int mr_cast_button_connecting = 2131165187;
+			// aapt resource value: 0x7f090002
+			public const int mr_cast_button_connecting = 2131296258;
 			
-			// aapt resource value: 0x7f070004
-			public const int mr_cast_button_disconnected = 2131165188;
+			// aapt resource value: 0x7f090003
+			public const int mr_cast_button_disconnected = 2131296259;
 			
-			// aapt resource value: 0x7f070005
-			public const int mr_chooser_searching = 2131165189;
+			// aapt resource value: 0x7f090004
+			public const int mr_chooser_searching = 2131296260;
 			
-			// aapt resource value: 0x7f070006
-			public const int mr_chooser_title = 2131165190;
+			// aapt resource value: 0x7f090005
+			public const int mr_chooser_title = 2131296261;
 			
-			// aapt resource value: 0x7f070007
-			public const int mr_controller_album_art = 2131165191;
+			// aapt resource value: 0x7f090006
+			public const int mr_controller_album_art = 2131296262;
 			
-			// aapt resource value: 0x7f070008
-			public const int mr_controller_casting_screen = 2131165192;
+			// aapt resource value: 0x7f090007
+			public const int mr_controller_casting_screen = 2131296263;
 			
-			// aapt resource value: 0x7f070009
-			public const int mr_controller_close_description = 2131165193;
+			// aapt resource value: 0x7f090008
+			public const int mr_controller_close_description = 2131296264;
 			
-			// aapt resource value: 0x7f07000a
-			public const int mr_controller_collapse_group = 2131165194;
+			// aapt resource value: 0x7f090009
+			public const int mr_controller_collapse_group = 2131296265;
 			
-			// aapt resource value: 0x7f07000b
-			public const int mr_controller_disconnect = 2131165195;
+			// aapt resource value: 0x7f09000a
+			public const int mr_controller_disconnect = 2131296266;
 			
-			// aapt resource value: 0x7f07000c
-			public const int mr_controller_expand_group = 2131165196;
+			// aapt resource value: 0x7f09000b
+			public const int mr_controller_expand_group = 2131296267;
 			
-			// aapt resource value: 0x7f07000d
-			public const int mr_controller_no_info_available = 2131165197;
+			// aapt resource value: 0x7f09000c
+			public const int mr_controller_no_info_available = 2131296268;
 			
-			// aapt resource value: 0x7f07000e
-			public const int mr_controller_no_media_selected = 2131165198;
+			// aapt resource value: 0x7f09000d
+			public const int mr_controller_no_media_selected = 2131296269;
 			
-			// aapt resource value: 0x7f07000f
-			public const int mr_controller_pause = 2131165199;
+			// aapt resource value: 0x7f09000e
+			public const int mr_controller_pause = 2131296270;
 			
-			// aapt resource value: 0x7f070010
-			public const int mr_controller_play = 2131165200;
+			// aapt resource value: 0x7f09000f
+			public const int mr_controller_play = 2131296271;
 			
-			// aapt resource value: 0x7f070015
-			public const int mr_controller_stop = 2131165205;
+			// aapt resource value: 0x7f090014
+			public const int mr_controller_stop = 2131296276;
 			
-			// aapt resource value: 0x7f070011
-			public const int mr_controller_stop_casting = 2131165201;
+			// aapt resource value: 0x7f090010
+			public const int mr_controller_stop_casting = 2131296272;
 			
-			// aapt resource value: 0x7f070012
-			public const int mr_controller_volume_slider = 2131165202;
+			// aapt resource value: 0x7f090011
+			public const int mr_controller_volume_slider = 2131296273;
 			
-			// aapt resource value: 0x7f070013
-			public const int mr_system_route_name = 2131165203;
+			// aapt resource value: 0x7f090012
+			public const int mr_system_route_name = 2131296274;
 			
-			// aapt resource value: 0x7f070014
-			public const int mr_user_route_category_name = 2131165204;
+			// aapt resource value: 0x7f090013
+			public const int mr_user_route_category_name = 2131296275;
 			
-			// aapt resource value: 0x7f07003a
-			public const int password_toggle_content_description = 2131165242;
+			// aapt resource value: 0x7f090039
+			public const int password_toggle_content_description = 2131296313;
 			
-			// aapt resource value: 0x7f07003b
-			public const int path_password_eye = 2131165243;
+			// aapt resource value: 0x7f09003a
+			public const int path_password_eye = 2131296314;
 			
-			// aapt resource value: 0x7f07003c
-			public const int path_password_eye_mask_strike_through = 2131165244;
+			// aapt resource value: 0x7f09003b
+			public const int path_password_eye_mask_strike_through = 2131296315;
 			
-			// aapt resource value: 0x7f07003d
-			public const int path_password_eye_mask_visible = 2131165245;
+			// aapt resource value: 0x7f09003c
+			public const int path_password_eye_mask_visible = 2131296316;
 			
-			// aapt resource value: 0x7f07003e
-			public const int path_password_strike_through = 2131165246;
+			// aapt resource value: 0x7f09003d
+			public const int path_password_strike_through = 2131296317;
 			
-			// aapt resource value: 0x7f070029
-			public const int search_menu_title = 2131165225;
+			// aapt resource value: 0x7f090028
+			public const int search_menu_title = 2131296296;
 			
-			// aapt resource value: 0x7f07002a
-			public const int status_bar_notification_info_overflow = 2131165226;
+			// aapt resource value: 0x7f090029
+			public const int status_bar_notification_info_overflow = 2131296297;
 			
 			static String()
 			{

--- a/src/Microsoft.Identity.Core/Cache/AdalResult.cs
+++ b/src/Microsoft.Identity.Core/Cache/AdalResult.cs
@@ -30,18 +30,16 @@ using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using System.Text;
-using Microsoft.Identity.Core.Cache;
 
-namespace Microsoft.IdentityModel.Clients.ActiveDirectory
+namespace Microsoft.Identity.Core.Cache
 {
     /// <summary>
     /// Contains the results of one token acquisition operation. 
     /// </summary>
     [DataContract]
-    public sealed class AuthenticationResult
+    public sealed class AdalResult
     {
         private const string Oauth2AuthorizationHeader = "Bearer ";
-        private readonly AdalResult _adalResult;
 
         /// <summary>
         /// Creates result returned from AcquireToken. Except in advanced scenarios related to token caching, you do not need to create any instance of AuthenticationResult.
@@ -49,66 +47,84 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="accessTokenType">Type of the Access Token returned</param>
         /// <param name="accessToken">The Access Token requested</param>
         /// <param name="expiresOn">The point in time in which the Access Token returned in the AccessToken property ceases to be valid</param>
-        internal AuthenticationResult(AdalResult adalResult)
+        internal AdalResult(string accessTokenType, string accessToken, DateTimeOffset expiresOn)
         {
-            _adalResult = adalResult ?? throw new ArgumentNullException();
-            UserInfo = new UserInfo(_adalResult.UserInfo);
+            this.AccessTokenType = accessTokenType;
+            this.AccessToken = accessToken;
+            this.ExpiresOn = DateTime.SpecifyKind(expiresOn.DateTime, DateTimeKind.Utc);
+            this.ExtendedExpiresOn = DateTime.SpecifyKind(expiresOn.DateTime, DateTimeKind.Utc);
+        }
+
+        /// <summary>
+        /// Creates result returned from AcquireToken. Except in advanced scenarios related to token caching, you do not need to create any instance of AuthenticationResult.
+        /// </summary>
+        /// <param name="accessTokenType">Type of the Access Token returned</param>
+        /// <param name="accessToken">The Access Token requested</param>
+        /// <param name="expiresOn">The point in time in which the Access Token returned in the AccessToken property ceases to be valid</param>
+        /// <param name="extendedExpiresOn">The point in time in which the Access Token returned in the AccessToken property ceases to be valid</param>
+        internal AdalResult(string accessTokenType, string accessToken, DateTimeOffset expiresOn,
+            DateTimeOffset extendedExpiresOn)
+        {
+            this.AccessTokenType = accessTokenType;
+            this.AccessToken = accessToken;
+            this.ExpiresOn = DateTime.SpecifyKind(expiresOn.DateTime, DateTimeKind.Utc);
+            this.ExtendedExpiresOn = DateTime.SpecifyKind(extendedExpiresOn.DateTime, DateTimeKind.Utc);
         }
 
         /// <summary>
         /// Gets the type of the Access Token returned. 
         /// </summary>
         [DataMember]
-        public string AccessTokenType => _adalResult.AccessTokenType;
+        public string AccessTokenType { get; private set; }
 
         /// <summary>
         /// Gets the Access Token requested.
         /// </summary>
         [DataMember]
-        public string AccessToken => _adalResult.AccessToken;
+        public string AccessToken { get; internal set; }
 
         /// <summary>
         /// Gets the point in time in which the Access Token returned in the AccessToken property ceases to be valid.
         /// This value is calculated based on current UTC time measured locally and the value expiresIn received from the service.
         /// </summary>
         [DataMember]
-        public DateTimeOffset ExpiresOn => _adalResult.ExpiresOn;
+        public DateTimeOffset ExpiresOn { get; internal set; }
 
         /// <summary>
         /// Gets the point in time in which the Access Token returned in the AccessToken property ceases to be valid in ADAL's extended LifeTime.
         /// This value is calculated based on current UTC time measured locally and the value ext_expiresIn received from the service.
         /// </summary>
         [DataMember]
-        internal DateTimeOffset ExtendedExpiresOn => _adalResult.ExtendedExpiresOn;
+        internal DateTimeOffset ExtendedExpiresOn { get; set; }
 
         /// <summary>
         /// Gives information to the developer whether token returned is during normal or extended lifetime.
         /// </summary>
         [DataMember]
-        public bool ExtendedLifeTimeToken => _adalResult.ExtendedLifeTimeToken;
+        public bool ExtendedLifeTimeToken { get; internal set; }
 
         /// <summary>
         /// Gets an identifier for the tenant the token was acquired from. This property will be null if tenant information is not returned by the service.
         /// </summary>
         [DataMember]
-        public string TenantId => _adalResult.TenantId;
+        public string TenantId { get; internal set; }
 
         /// <summary>
         /// Gets user information including user Id. Some elements in UserInfo might be null if not returned by the service.
         /// </summary>
         [DataMember]
-        public UserInfo UserInfo { get; internal set; }
+        public AdalUserInfo UserInfo { get; internal set; }
 
         /// <summary>
         /// Gets the entire Id Token if returned by the service or null if no Id Token is returned.
         /// </summary>
         [DataMember]
-        public string IdToken => _adalResult.IdToken;
+        public string IdToken { get; internal set; }
 
         /// <summary>
         /// Gets the authority that has issued the token.
         /// </summary>
-        public string Authority => _adalResult.Authority;
+        public string Authority { get; internal set; }
 
         /// <summary>
         /// Creates authorization header from authentication result.
@@ -119,13 +135,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return Oauth2AuthorizationHeader + this.AccessToken;
         }
 
-        internal void UpdateTenantAndUserInfo(string tenantId, string idToken, UserInfo userInfo)
+        internal void UpdateTenantAndUserInfo(string tenantId, string idToken, AdalUserInfo userInfo)
         {
-            _adalResult.TenantId = tenantId;
-            _adalResult.IdToken = idToken;
+            this.TenantId = tenantId;
+            this.IdToken = idToken;
             if (userInfo != null)
             {
-                this.UserInfo = new UserInfo(userInfo);
+                this.UserInfo = new AdalUserInfo(userInfo);
             }
         }
     }

--- a/src/Microsoft.Identity.Core/Cache/AdalResultWrapper.cs
+++ b/src/Microsoft.Identity.Core/Cache/AdalResultWrapper.cs
@@ -35,13 +35,13 @@ using System.Security;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
+namespace Microsoft.Identity.Core.Cache
 {
     [DataContract]
-    internal class AuthenticationResultEx
+    internal class AdalResultWrapper
     {
         [DataMember]
-        public AuthenticationResult Result { get; set; }
+        public AdalResult Result { get; set; }
 
         /// <summary>
         /// Gets the Refresh Token associated with the requested Access Token. Note: not all operations will return a Refresh Token.
@@ -70,14 +70,14 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         /// Serializes the object to a JSON string
         /// </summary>
         /// <returns>Deserialized authentication result</returns>
-        public static AuthenticationResultEx Deserialize(string serializedObject)
+        public static AdalResultWrapper Deserialize(string serializedObject)
         {
-            AuthenticationResultEx resultEx;
-            var serializer = new DataContractJsonSerializer(typeof(AuthenticationResultEx));
+            AdalResultWrapper resultEx;
+            var serializer = new DataContractJsonSerializer(typeof(AdalResultWrapper));
             byte[] serializedObjectBytes = Encoding.UTF8.GetBytes(serializedObject);
             using (var stream = new MemoryStream(serializedObjectBytes))
             {
-                resultEx = (AuthenticationResultEx)serializer.ReadObject(stream);
+                resultEx = (AdalResultWrapper)serializer.ReadObject(stream);
             }
 
             return resultEx;
@@ -90,7 +90,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         public string Serialize()
         {
             string serializedObject;
-            var serializer = new DataContractJsonSerializer(typeof(AuthenticationResultEx));
+            var serializer = new DataContractJsonSerializer(typeof(AdalResultWrapper));
             using (MemoryStream stream = new MemoryStream())
             {
                 serializer.WriteObject(stream, this);
@@ -105,9 +105,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         [DataMember]
         public string UserAssertionHash { get; set; }
 
-        internal AuthenticationResultEx Clone()
+        internal AdalResultWrapper Clone()
         {
-            return new AuthenticationResultEx
+            return Deserialize(Serialize());
+
+/*            return new AdalResultWrapper
             {
                 UserAssertionHash = this.UserAssertionHash,
                 Exception = this.Exception,
@@ -120,7 +122,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
                     TenantId = this.Result.TenantId,
                     UserInfo = new UserInfo(this.Result.UserInfo)
                 }
-            };
+            };*/
         }
     }
 }

--- a/src/Microsoft.Identity.Core/Cache/AdalUserInfo.cs
+++ b/src/Microsoft.Identity.Core/Cache/AdalUserInfo.cs
@@ -27,44 +27,26 @@
 
 using System;
 using System.Runtime.Serialization;
-using Microsoft.Identity.Core.Cache;
 
-namespace Microsoft.IdentityModel.Clients.ActiveDirectory
+namespace Microsoft.Identity.Core.Cache
 {
     /// <summary>
     /// Contains information of a single user. This information is used for token cache lookup. Also if created with userId, userId is sent to the service when login_hint is accepted.
     /// </summary>
     [DataContract]
-    public sealed class UserInfo
+    public sealed class AdalUserInfo
     {
         /// <summary>
         /// Create user information for token cache lookup
         /// </summary>
-        public UserInfo()
+        public AdalUserInfo()
         {
-        }
-
-        /// <summary>
-        /// Create user information for token cache lookup
-        /// </summary>
-        internal UserInfo(AdalUserInfo adalUserInfo)
-        {
-            if (adalUserInfo != null)
-            {
-                this.UniqueId = adalUserInfo.UniqueId;
-                this.DisplayableId = adalUserInfo.DisplayableId;
-                this.GivenName = adalUserInfo.GivenName;
-                this.FamilyName = adalUserInfo.FamilyName;
-                this.IdentityProvider = adalUserInfo.IdentityProvider;
-                this.PasswordChangeUrl = adalUserInfo.PasswordChangeUrl;
-                this.PasswordExpiresOn = adalUserInfo.PasswordExpiresOn;
-            }
         }
 
         /// <summary>
         /// Create user information copied from another UserInfo object
         /// </summary>
-        public UserInfo(UserInfo other)
+        public AdalUserInfo(AdalUserInfo other)
         {
             if (other != null)
             {

--- a/src/Microsoft.Identity.Core/Cache/CoreTokenCacheItem.cs
+++ b/src/Microsoft.Identity.Core/Cache/CoreTokenCacheItem.cs
@@ -25,30 +25,24 @@
 //
 //------------------------------------------------------------------------------
 
-using Microsoft.Identity.Core;
-using Microsoft.Identity.Core.Cache;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
+namespace Microsoft.Identity.Core.Cache
 {
-    internal class BrokerHelper
+    /// <summary>
+    /// This class is intended to wrap ADAL's AdalResultWrapper and MSAL's TokenCacheItem.
+    /// 2 libraries have funamentally different representation and storage concept of the data.
+    /// Instead of creating multiple levels of translation, it would be simpler to have this class that holds both ADAL and MSAL cache representation objects.
+    /// Translation of data should be done in core.
+    /// </summary>
+    internal class CoreTokenCacheItem
     {
-        public RequestContext RequestContext { get; set; }
+        public AdalResultWrapper AdalResultWrapper { get; set; }
 
-        public IPlatformParameters PlatformParameters { get; set; }
-
-        public bool CanInvokeBroker {
-            get { return false; } 
-        }
-
-        public Task<AdalResultWrapper> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
-        {
-            throw new NotImplementedException();
-        }
-        
+        //MSAL cache items should be added here.
     }
 }

--- a/src/Microsoft.Identity.Core/Microsoft.Identity.Core.VS2015.csproj
+++ b/src/Microsoft.Identity.Core/Microsoft.Identity.Core.VS2015.csproj
@@ -107,6 +107,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="*.cs" />
+    <Compile Include="Cache\**\*.cs" />
     <Compile Include="Properties\**\*.cs" />
     <Compile Include="Internal\**\*.cs" />
     <Compile Include="Platforms\winrt\**\*.cs" />

--- a/src/Microsoft.Identity.Core/Microsoft.Identity.Core.csproj
+++ b/src/Microsoft.Identity.Core/Microsoft.Identity.Core.csproj
@@ -51,6 +51,9 @@
     <None Include="**\*.cs;**\*.xml;**\*.axml" Exclude="obj\**\*.*;bin\**\*.*" />
     <Compile Remove="Platforms\**\*.*" />
     <Compile Remove="Resources\**\*.*" />
+    <None Remove="Cache\AdalResult.cs" />
+    <None Remove="Cache\AdalResultWrapper.cs" />
+    <None Remove="Cache\AdalUserInfo.cs" />
     <EmbeddedResource Include="Properties\Microsoft.Identity.Core.rd.xml" />
   </ItemGroup>
   

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationResult.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationResult.cs
@@ -51,7 +51,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="expiresOn">The point in time in which the Access Token returned in the AccessToken property ceases to be valid</param>
         internal AuthenticationResult(AdalResult adalResult)
         {
-            _adalResult = adalResult ?? throw new ArgumentNullException();
+            if (adalResult == null)
+            {
+                throw new ArgumentNullException(nameof(adalResult));
+            }
+
+            _adalResult = adalResult;
             UserInfo = new UserInfo(_adalResult.UserInfo);
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Cache/TokenCacheKey.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Cache/TokenCacheKey.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Identity.Core.Cache;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache
 {
@@ -53,8 +54,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache
     /// </summary>
     internal sealed class TokenCacheKey
     {
-        internal TokenCacheKey(string authority, string resource, string clientId, TokenSubjectType tokenSubjectType, UserInfo userInfo)
-            : this(authority, resource, clientId, tokenSubjectType, (userInfo != null) ? userInfo.UniqueId : null, (userInfo != null) ? userInfo.DisplayableId : null)
+        internal TokenCacheKey(string authority, string resource, string clientId, TokenSubjectType tokenSubjectType, AdalUserInfo adalUserInfo)
+            : this(authority, resource, clientId, tokenSubjectType, (adalUserInfo != null) ? adalUserInfo.UniqueId : null, (adalUserInfo != null) ? adalUserInfo.DisplayableId : null)
         {
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenByAuthorizationCodeHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenByAuthorizationCodeHandler.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
@@ -71,12 +72,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
             requestParameters[OAuthParameter.RedirectUri] = this.redirectUri.OriginalString;
         }
 
-        protected override async Task PostTokenRequest(AuthenticationResultEx resultEx)
+        protected override async Task PostTokenRequest(AdalResultWrapper resultEx)
         {
             await base.PostTokenRequest(resultEx).ConfigureAwait(false);
-            UserInfo userInfo = resultEx.Result.UserInfo;
-            this.UniqueId = (userInfo == null) ? null : userInfo.UniqueId;
-            this.DisplayableId = (userInfo == null) ? null : userInfo.DisplayableId;
+            AdalUserInfo adalUserInfo = resultEx.Result.UserInfo;
+            this.UniqueId = (adalUserInfo == null) ? null : adalUserInfo.UniqueId;
+            this.DisplayableId = (adalUserInfo == null) ? null : adalUserInfo.DisplayableId;
             if (resultEx.ResourceInResponse != null)
             {
                 this.Resource = resultEx.ResourceInResponse;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenByDeviceCodeHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenByDeviceCodeHandler.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
@@ -44,10 +45,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
             this.deviceCodeResult = deviceCodeResult;
         }
 
-        protected override async Task<AuthenticationResultEx> SendTokenRequestAsync()
+        protected override async Task<AdalResultWrapper> SendTokenRequestAsync()
         {
             TimeSpan timeRemaining = deviceCodeResult.ExpiresOn - DateTimeOffset.UtcNow;
-            AuthenticationResultEx resultEx = null;
+            AdalResultWrapper resultEx = null;
             //the interval is added so that the while loop does not end before aquiring the last response from the STS stating that the code has expired.
             //Without it, resultEx will end up being null.
             while (timeRemaining.TotalSeconds + deviceCodeResult.Interval > 0)

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenInteractiveHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenInteractiveHandler.cs
@@ -29,6 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading.Tasks;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Helpers;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform;
@@ -159,7 +160,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
             requestParameters[OAuthParameter.RedirectUri] = this.redirectUriRequestParameter;
         }
 
-        protected override async Task PostTokenRequest(AuthenticationResultEx resultEx)
+        protected override async Task PostTokenRequest(AdalResultWrapper resultEx)
         {
             await base.PostTokenRequest(resultEx).ConfigureAwait(false);
             if ((this.DisplayableId == null && this.UniqueId == null) || this.UserIdentifierType == UserIdentifierType.OptionalDisplayableId)

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenOnBehalfHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenOnBehalfHandler.cs
@@ -29,6 +29,7 @@ using System;
 using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform;
 
@@ -58,9 +59,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
             this.SupportADFS = true;
         }
 
-        protected override async Task<AuthenticationResultEx> SendTokenRequestAsync()
+        protected override async Task<AdalResultWrapper> SendTokenRequestAsync()
         {
-            AuthenticationResultEx resultEx = await base.SendTokenRequestAsync().ConfigureAwait(false);
+            AdalResultWrapper resultEx = await base.SendTokenRequestAsync().ConfigureAwait(false);
             if (resultEx != null)
             {
                 resultEx.UserAssertionHash = CacheQueryData.AssertionHash;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenSilentHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenSilentHandler.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Threading.Tasks;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
@@ -54,7 +55,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
             this.brokerParameters[BrokerParameter.SilentBrokerFlow] = null; //add key
         }
 
-        protected override Task<AuthenticationResultEx> SendTokenRequestAsync()
+        protected override Task<AdalResultWrapper> SendTokenRequestAsync()
         {
             if (ResultEx == null)
             {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/OAuth2/TokenResponse.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/OAuth2/TokenResponse.cs
@@ -34,6 +34,7 @@ using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
 using System.Text;
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Helpers;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Instance;
@@ -186,7 +187,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2
             return tokenResponse;
         }
 
-        public AuthenticationResultEx GetResult()
+        public AdalResultWrapper GetResult()
         {
             // extendedExpiresOn can be less than expiresOn if
             // the server did not return extendedExpiresOn in the
@@ -204,13 +205,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2
                 DateTime.UtcNow + TimeSpan.FromSeconds(this.ExtendedExpiresIn));
         }
 
-        public AuthenticationResultEx GetResult(DateTimeOffset expiresOn, DateTimeOffset extendedExpiresOn)
+        public AdalResultWrapper GetResult(DateTimeOffset expiresOn, DateTimeOffset extendedExpiresOn)
         {
-            AuthenticationResultEx resultEx;
+            AdalResultWrapper resultEx;
 
             if (this.AccessToken != null)
             {
-                var result = new AuthenticationResult(this.TokenType, this.AccessToken, expiresOn, extendedExpiresOn);
+                var result = new AdalResult(this.TokenType, this.AccessToken, expiresOn, extendedExpiresOn);
 
                 IdToken idToken = IdToken.Parse(this.IdTokenString);
                 if (idToken != null)
@@ -253,7 +254,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2
                     }
 
                     result.UpdateTenantAndUserInfo(tenantId, this.IdTokenString,
-                        new UserInfo
+                        new AdalUserInfo
                         {
                             UniqueId = uniqueId,
                             DisplayableId = displayableId,
@@ -267,7 +268,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2
                     result.Authority = Authority;
                 }
 
-                resultEx = new AuthenticationResultEx
+                resultEx = new AdalResultWrapper
                 {
                     Result = result,
                     RefreshToken = this.RefreshToken,

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerHelper.cs
@@ -35,6 +35,7 @@ using Android.Content;
 using Java.IO;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows;
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Helpers;
 
@@ -44,7 +45,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
     internal class BrokerHelper
     {
         private static SemaphoreSlim readyForResponse = null;
-        private static AuthenticationResultEx resultEx = null;
+        private static AdalResultWrapper resultEx = null;
 
         private readonly BrokerProxy mBrokerProxy = new BrokerProxy(Application.Context);
 
@@ -73,7 +74,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         }
 
 
-        public async Task<AuthenticationResultEx> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
+        public async Task<AdalResultWrapper> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
         {
             mBrokerProxy.RequestContext = RequestContext;
 
@@ -221,7 +222,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         {
             if (resultCode != BrokerResponseCode.ResponseReceived)
             {
-                resultEx = new AuthenticationResultEx
+                resultEx = new AdalResultWrapper
                 {
                     Exception =
                         new AdalException(data.GetStringExtra(BrokerConstants.ResponseErrorCode),

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/BrokerHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/BrokerHelper.cs
@@ -38,6 +38,7 @@ using UIKit;
 using Microsoft.Identity.Core;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Helpers;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2;
+using Microsoft.Identity.Core.Cache;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 {
@@ -73,7 +74,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
             }
         }
 
-        public async Task<AuthenticationResultEx> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
+        public async Task<AdalResultWrapper> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
         {
             if (brokerPayload.ContainsKey(BrokerParameter.SilentBrokerFlow))
             {
@@ -123,7 +124,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
             return ProcessBrokerResponse();
         }
 
-        private AuthenticationResultEx ProcessBrokerResponse()
+        private AdalResultWrapper ProcessBrokerResponse()
         {
             string[] keyValuePairs = brokerResponse.Query.Split('&');
 
@@ -141,7 +142,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
             return ResultFromBrokerResponse(responseDictionary);
         }
 
-        private AuthenticationResultEx ResultFromBrokerResponse(IDictionary<string, string> responseDictionary)
+        private AdalResultWrapper ResultFromBrokerResponse(IDictionary<string, string> responseDictionary)
         {
             TokenResponse response;
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/netstandard1.1/BrokerHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/netstandard1.1/BrokerHelper.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -44,7 +45,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
             get { return false; } 
         }
 
-        public Task<AuthenticationResultEx> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
+        public Task<AdalResultWrapper> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/netstandard1.3/BrokerHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/netstandard1.3/BrokerHelper.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -39,7 +40,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
         public bool CanInvokeBroker { get { return false; } }
 
-        public Task<AuthenticationResultEx> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
+        public Task<AdalResultWrapper> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
         {
             throw new System.NotImplementedException();
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/winrt/BrokerHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/winrt/BrokerHelper.cs
@@ -41,7 +41,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
         public bool CanInvokeBroker { get { return false; } }
 
-        public Task<AuthenticationResultEx> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
+        public Task<AdalResultWrapper> AcquireTokenUsingBroker(IDictionary<string, string> brokerPayload)
         {
             throw new NotImplementedException();
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/winrt/BrokerHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/winrt/BrokerHelper.cs
@@ -31,6 +31,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCacheItem.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCacheItem.cs
@@ -36,91 +36,79 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// </summary>
     public sealed class TokenCacheItem
     {
+        private readonly TokenCacheKey _key;
+        private readonly AdalResult _result;
+
         /// <summary>
         /// Default constructor.
         /// </summary>
         internal TokenCacheItem(TokenCacheKey key, AdalResult result)
         {
-            this.Authority = key.Authority;
-            this.Resource = key.Resource;
-            this.ClientId = key.ClientId;
-            this.TokenSubjectType = key.TokenSubjectType;
-            this.UniqueId = key.UniqueId;
-            this.DisplayableId = key.DisplayableId;
-            this.TenantId = result.TenantId;
-            this.ExpiresOn = result.ExpiresOn;
-            this.AccessToken = result.AccessToken;
-            this.IdToken = result.IdToken;
-
-            if (result.UserInfo != null)
-            {
-                this.FamilyName = result.UserInfo.FamilyName;
-                this.GivenName = result.UserInfo.GivenName;
-                this.IdentityProvider = result.UserInfo.IdentityProvider;
-            }
+            _key = key;
+            _result = result;
         }
 
         /// <summary>
         /// Gets the Authority.
         /// </summary>
-        public string Authority { get; private set; }
+        public string Authority => _key.Authority;
 
         /// <summary>
         /// Gets the ClientId.
         /// </summary>
-        public string ClientId { get; internal set; }
+        public string ClientId => _key.ClientId;
 
         /// <summary>
         /// Gets the Expiration.
         /// </summary>
-        public DateTimeOffset ExpiresOn { get; internal set; }
+        public DateTimeOffset ExpiresOn => _result.ExpiresOn;
 
         /// <summary>
         /// Gets the FamilyName.
         /// </summary>
-        public string FamilyName { get; internal set; }
+        public string FamilyName => _result.UserInfo?.FamilyName;
 
         /// <summary>
         /// Gets the GivenName.
         /// </summary>
-        public string GivenName { get; internal set; }
+        public string GivenName => _result.UserInfo?.GivenName;
 
         /// <summary>
         /// Gets the IdentityProviderName.
         /// </summary>
-        public string IdentityProvider { get; internal set; }
+        public string IdentityProvider => _result.UserInfo?.IdentityProvider;
 
         /// <summary>
         /// Gets the Resource.
         /// </summary>
-        public string Resource { get; internal set; }
+        public string Resource => _key.Resource;
 
         /// <summary>
         /// Gets the TenantId.
         /// </summary>
-        public string TenantId { get; internal set; }
+        public string TenantId => _result.TenantId;
 
         /// <summary>
         /// Gets the user's unique Id.
         /// </summary>
-        public string UniqueId { get; internal set; }
+        public string UniqueId => _key.UniqueId;
 
         /// <summary>
         /// Gets the user's displayable Id.
         /// </summary>
-        public string DisplayableId { get; internal set; }
+        public string DisplayableId => _key.DisplayableId;
 
         /// <summary>
         /// Gets the Access Token requested.
         /// </summary>
-        public string AccessToken { get; internal set; }
+        public string AccessToken => _result.AccessToken;
 
         /// <summary>
         /// Gets the entire Id Token if returned by the service or null if no Id Token is returned.
         /// </summary>
-        public string IdToken { get; internal set; }
+        public string IdToken => _result.IdToken;
 
-        internal TokenSubjectType TokenSubjectType { get; set; }
+        internal TokenSubjectType TokenSubjectType => _key.TokenSubjectType;
 
         internal bool Match(TokenCacheKey key)
         {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCacheItem.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCacheItem.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
@@ -38,7 +39,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Default constructor.
         /// </summary>
-        internal TokenCacheItem(TokenCacheKey key, AuthenticationResult result)
+        internal TokenCacheItem(TokenCacheKey key, AdalResult result)
         {
             this.Authority = key.Authority;
             this.Resource = key.Resource;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/UserInfo.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/UserInfo.cs
@@ -47,35 +47,30 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <summary>
         /// Create user information for token cache lookup
         /// </summary>
-        internal UserInfo(AdalUserInfo adalUserInfo)
+        internal UserInfo(AdalUserInfo adalUserInfo) : this(adalUserInfo?.UniqueId, adalUserInfo?.DisplayableId,
+            adalUserInfo?.GivenName, adalUserInfo?.FamilyName, adalUserInfo?.IdentityProvider,
+            adalUserInfo?.PasswordChangeUrl, adalUserInfo?.PasswordExpiresOn)
         {
-            if (adalUserInfo != null)
-            {
-                this.UniqueId = adalUserInfo.UniqueId;
-                this.DisplayableId = adalUserInfo.DisplayableId;
-                this.GivenName = adalUserInfo.GivenName;
-                this.FamilyName = adalUserInfo.FamilyName;
-                this.IdentityProvider = adalUserInfo.IdentityProvider;
-                this.PasswordChangeUrl = adalUserInfo.PasswordChangeUrl;
-                this.PasswordExpiresOn = adalUserInfo.PasswordExpiresOn;
-            }
         }
 
         /// <summary>
         /// Create user information copied from another UserInfo object
         /// </summary>
-        public UserInfo(UserInfo other)
+        public UserInfo(UserInfo other) : this(other?.UniqueId, other?.DisplayableId, other?.GivenName,
+            other?.FamilyName, other?.IdentityProvider, other?.PasswordChangeUrl, other?.PasswordExpiresOn)
         {
-            if (other != null)
-            {
-                this.UniqueId = other.UniqueId;
-                this.DisplayableId = other.DisplayableId;
-                this.GivenName = other.GivenName;
-                this.FamilyName = other.FamilyName;
-                this.IdentityProvider = other.IdentityProvider;
-                this.PasswordChangeUrl = other.PasswordChangeUrl;
-                this.PasswordExpiresOn = other.PasswordExpiresOn;
-            }
+        }
+
+        private UserInfo(string uniqueId, string displayableId, string givenName, string familyName,
+            string identityProvider, Uri passwordChangeUrl, DateTimeOffset? passwordExpiresOn)
+        {
+            this.UniqueId = uniqueId;
+            this.DisplayableId = displayableId;
+            this.GivenName = givenName;
+            this.FamilyName = familyName;
+            this.IdentityProvider = identityProvider;
+            this.PasswordChangeUrl = passwordChangeUrl;
+            this.PasswordExpiresOn = passwordExpiresOn;
         }
 
         /// <summary>

--- a/tests/Test.ADAL.NET.Integration/AcquireTokenSilentTests.cs
+++ b/tests/Test.ADAL.NET.Integration/AcquireTokenSilentTests.cs
@@ -32,6 +32,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http;
@@ -60,11 +61,11 @@ namespace Test.ADAL.NET.Integration
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User, "unique_id",
                 "displayable@id.com");
-            cache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            cache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "something-invalid",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow)
             };
 
             AuthenticationContext context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, cache);
@@ -99,11 +100,11 @@ namespace Test.ADAL.NET.Integration
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token",
+                Result = new AdalResult("Bearer", "existing-access-token",
                     DateTimeOffset.UtcNow + TimeSpan.FromMinutes(100))
             };
 
@@ -156,11 +157,11 @@ namespace Test.ADAL.NET.Integration
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
 
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some_rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token",
+                Result = new AdalResult("Bearer", "existing-access-token",
                     DateTimeOffset.UtcNow)
             };
 

--- a/tests/Test.ADAL.NET.Integration/FederatedUserCredentialTests.cs
+++ b/tests/Test.ADAL.NET.Integration/FederatedUserCredentialTests.cs
@@ -36,6 +36,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using Test.ADAL.Common;
 using Test.ADAL.NET.Common;
 using Test.ADAL.NET.Common.Mocks;
@@ -259,11 +260,11 @@ namespace Test.ADAL.NET.Integration
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token",
+                Result = new AdalResult("Bearer", "existing-access-token",
                     DateTimeOffset.UtcNow + TimeSpan.FromMinutes(100))
             };
 
@@ -295,14 +296,14 @@ namespace Test.ADAL.NET.Integration
             AuthenticationContext context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             await context.Authenticator.UpdateFromTemplateAsync(null);
 
-            await context.TokenCache.StoreToCache(new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
                 {
                     UserInfo =
-                        new UserInfo()
+                        new AdalUserInfo()
                         {
                             DisplayableId = TestConstants.DefaultDisplayableId,
                             UniqueId = TestConstants.DefaultUniqueId

--- a/tests/Test.ADAL.NET.Integration/ManagedUsercredentialTests.cs
+++ b/tests/Test.ADAL.NET.Integration/ManagedUsercredentialTests.cs
@@ -34,6 +34,7 @@ using System.Net;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http;
 using Test.ADAL.Common;
 using Test.ADAL.NET.Common;
@@ -121,11 +122,11 @@ namespace Test.ADAL.NET.Integration
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token",
+                Result = new AdalResult("Bearer", "existing-access-token",
                     DateTimeOffset.UtcNow + TimeSpan.FromMinutes(100))
             };
 
@@ -179,15 +180,15 @@ namespace Test.ADAL.NET.Integration
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
             TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            var setupResult = new AuthenticationResultEx
+            var setupResult = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token",
+                Result = new AdalResult("Bearer", "existing-access-token",
                     DateTimeOffset.UtcNow + +TimeSpan.FromMinutes(100))
             };
 
-            setupResult.Result.UserInfo = new UserInfo();
+            setupResult.Result.UserInfo = new AdalUserInfo();
             setupResult.Result.UserInfo.DisplayableId = TestConstants.DefaultDisplayableId;
             context.TokenCache.tokenCacheDictionary[key] = setupResult;
 
@@ -219,14 +220,14 @@ namespace Test.ADAL.NET.Integration
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            await context.TokenCache.StoreToCache(new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
                 {
                     UserInfo =
-                        new UserInfo()
+                        new AdalUserInfo()
                         {
                             DisplayableId = TestConstants.DefaultDisplayableId,
                             UniqueId = TestConstants.DefaultUniqueId

--- a/tests/Test.ADAL.NET.Integration/PromptBehaviorTests.cs
+++ b/tests/Test.ADAL.NET.Integration/PromptBehaviorTests.cs
@@ -34,6 +34,7 @@ using System.Net.Http;
 using Test.ADAL.Common;
 using System.Net;
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http;
@@ -101,11 +102,11 @@ namespace Test.ADAL.NET.Integration
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token",
+                Result = new AdalResult("Bearer", "existing-access-token",
                     DateTimeOffset.UtcNow + TimeSpan.FromMinutes(100))
             };
 
@@ -130,14 +131,14 @@ namespace Test.ADAL.NET.Integration
 
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            await context.TokenCache.StoreToCache(new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
                 {
                     UserInfo =
-                        new UserInfo()
+                        new AdalUserInfo()
                         {
                             DisplayableId = TestConstants.DefaultDisplayableId,
                             UniqueId = TestConstants.DefaultUniqueId
@@ -180,14 +181,14 @@ namespace Test.ADAL.NET.Integration
 
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            await context.TokenCache.StoreToCache(new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
                 {
                     UserInfo =
-                        new UserInfo()
+                        new AdalUserInfo()
                         {
                             DisplayableId = TestConstants.DefaultDisplayableId,
                             UniqueId = TestConstants.DefaultUniqueId
@@ -231,15 +232,15 @@ namespace Test.ADAL.NET.Integration
 
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            await context.TokenCache.StoreToCache(new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token",
+                Result = new AdalResult("Bearer", "existing-access-token",
                     DateTimeOffset.UtcNow + TimeSpan.FromMinutes(100))
                 {
                     UserInfo =
-                        new UserInfo()
+                        new AdalUserInfo()
                         {
                             DisplayableId = TestConstants.DefaultDisplayableId,
                             UniqueId = TestConstants.DefaultUniqueId
@@ -285,11 +286,11 @@ namespace Test.ADAL.NET.Integration
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
             };
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
@@ -318,14 +319,14 @@ namespace Test.ADAL.NET.Integration
 
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            await context.TokenCache.StoreToCache(new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "existing-access-token", DateTimeOffset.UtcNow)
                 {
                     UserInfo =
-                        new UserInfo()
+                        new AdalUserInfo()
                         {
                             DisplayableId = TestConstants.DefaultDisplayableId,
                             UniqueId = TestConstants.DefaultUniqueId

--- a/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
+++ b/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
@@ -34,6 +34,7 @@ using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.ClientCreds;
@@ -153,11 +154,11 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, (DateTimeOffset.UtcNow + TimeSpan.FromMinutes(180)))
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, (DateTimeOffset.UtcNow + TimeSpan.FromMinutes(180)))
             };
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
@@ -188,11 +189,11 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
             };
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityCommonTenant))
@@ -228,11 +229,11 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, (DateTimeOffset.UtcNow + TimeSpan.FromMinutes(180)))
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, (DateTimeOffset.UtcNow + TimeSpan.FromMinutes(180)))
             };
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
@@ -272,11 +273,11 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, (DateTimeOffset.UtcNow + TimeSpan.FromMinutes(180)))
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, (DateTimeOffset.UtcNow + TimeSpan.FromMinutes(180)))
             };
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityHomeTenant))
@@ -394,10 +395,10 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.Client,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, (DateTimeOffset.UtcNow + TimeSpan.FromMinutes(180)))
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, (DateTimeOffset.UtcNow + TimeSpan.FromMinutes(180)))
             };
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.DefaultAuthorityCommonTenant)
@@ -458,10 +459,10 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
             };
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityCommonTenant))
@@ -520,10 +521,10 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
             };
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityCommonTenant))
@@ -583,10 +584,10 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow, DateTimeOffset.UtcNow)
             };
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityCommonTenant))
@@ -733,11 +734,11 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow)
             };
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityCommonTenant))
@@ -802,10 +803,10 @@ namespace Test.ADAL.NET.Unit
             //add simple RT to cache
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAdfsAuthorityTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User, null, null);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow)
             };
 
             //token request for some other resource should fail.
@@ -1098,11 +1099,11 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", accessToken, DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", accessToken, DateTimeOffset.UtcNow)
             };
 
             ClientCredential clientCredential = new ClientCredential(TestConstants.DefaultClientId, TestConstants.DefaultClientSecret);
@@ -1156,11 +1157,11 @@ namespace Test.ADAL.NET.Unit
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", accessToken, DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", accessToken, DateTimeOffset.UtcNow)
             };
 
             ClientAssertionCertificate clientCredential = new ClientAssertionCertificate(TestConstants.DefaultClientId, new X509Certificate2("valid_cert.pfx", TestConstants.DefaultPassword));
@@ -1264,7 +1265,7 @@ namespace Test.ADAL.NET.Unit
         public void UserAssertionValidationTest()
         {
             TokenCache cache = new TokenCache();
-            AuthenticationResultEx resultEx = TokenCacheTests.CreateCacheValue("id", "user1");
+            AdalResultWrapper resultEx = TokenCacheTests.CreateCacheValue("id", "user1");
             resultEx.UserAssertionHash = "hash1";
             cache.tokenCacheDictionary.Add(
             new TokenCacheKey("https://login.microsoftonline.com/common/", "resource1", "client1",
@@ -1297,11 +1298,11 @@ namespace Test.ADAL.NET.Unit
         {
             TokenCache cache = new TokenCache();
             TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User, "unique_id", "displayable@id.com");
-            cache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            cache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "something-invalid",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-access-token", DateTimeOffset.UtcNow)
+                Result = new AdalResult("Bearer", "some-access-token", DateTimeOffset.UtcNow)
             };
 
             AuthenticationContext context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, cache);

--- a/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
+++ b/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
@@ -31,6 +31,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;
@@ -81,14 +82,14 @@ namespace Test.ADAL.NET.Unit
             foreach (var cachenoise in _cacheNoise)
             {
                 //cache entry has no user assertion hash
-                await context.TokenCache.StoreToCache(new AuthenticationResultEx
+                await context.TokenCache.StoreToCache(new AdalResultWrapper
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
-                    Result = new AuthenticationResult("Bearer", cachenoise + "some-token-in-cache", _expirationTime)
+                    Result = new AdalResult("Bearer", cachenoise + "some-token-in-cache", _expirationTime)
                     {
                         UserInfo =
-                            new UserInfo()
+                            new AdalUserInfo()
                             {
                                 DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
                                 UniqueId = cachenoise + TestConstants.DefaultUniqueId
@@ -142,14 +143,14 @@ namespace Test.ADAL.NET.Unit
             foreach (var cachenoise in _cacheNoise)
             {
                 //cache entry has no user assertion hash
-                await context.TokenCache.StoreToCache(new AuthenticationResultEx
+                await context.TokenCache.StoreToCache(new AdalResultWrapper
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
-                    Result = new AuthenticationResult("Bearer", cachenoise + "some-token-in-cache", _expirationTime)
+                    Result = new AdalResult("Bearer", cachenoise + "some-token-in-cache", _expirationTime)
                     {
                         UserInfo =
-                            new UserInfo()
+                            new AdalUserInfo()
                             {
                                 DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
                                 UniqueId = cachenoise + TestConstants.DefaultUniqueId
@@ -207,14 +208,14 @@ namespace Test.ADAL.NET.Unit
                     TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                     cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
                 //cache entry has no user assertion hash
-                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
-                    Result = new AuthenticationResult("Bearer", cachenoise + "some-token-in-cache", _expirationTime)
+                    Result = new AdalResult("Bearer", cachenoise + "some-token-in-cache", _expirationTime)
                     {
                         UserInfo =
-                            new UserInfo()
+                            new AdalUserInfo()
                             {
                                 DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
                                 UniqueId = cachenoise + TestConstants.DefaultUniqueId
@@ -278,15 +279,15 @@ namespace Test.ADAL.NET.Unit
                     TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                     cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
 
-                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
                     Result =
-                        new AuthenticationResult("Bearer", cachenoise + tokenInCache, _expirationTime)
+                        new AdalResult("Bearer", cachenoise + tokenInCache, _expirationTime)
                         {
                             UserInfo =
-                                new UserInfo()
+                                new AdalUserInfo()
                                 {
                                     DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
                                     UniqueId = cachenoise + TestConstants.DefaultUniqueId
@@ -324,15 +325,15 @@ namespace Test.ADAL.NET.Unit
 
             foreach (var cachenoise in _cacheNoise)
             {
-                await context.TokenCache.StoreToCache(new AuthenticationResultEx
+                await context.TokenCache.StoreToCache(new AdalResultWrapper
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
                     Result =
-                        new AuthenticationResult("Bearer", cachenoise + tokenInCache, _expirationTime)
+                        new AdalResult("Bearer", cachenoise + tokenInCache, _expirationTime)
                         {
                             UserInfo =
-                                new UserInfo()
+                                new AdalUserInfo()
                                 {
                                     DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
                                     UniqueId = cachenoise + TestConstants.DefaultUniqueId
@@ -389,15 +390,15 @@ namespace Test.ADAL.NET.Unit
                     TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                     cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
 
-                context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+                context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
                     Result =
-                        new AuthenticationResult("Bearer", cachenoise + tokenInCache, _expirationTime)
+                        new AdalResult("Bearer", cachenoise + tokenInCache, _expirationTime)
                         {
                             UserInfo =
-                                new UserInfo()
+                                new AdalUserInfo()
                                 {
                                     DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
                                     UniqueId = cachenoise + TestConstants.DefaultUniqueId
@@ -438,15 +439,15 @@ namespace Test.ADAL.NET.Unit
             string tokenInCache = "obo-access-token";
             foreach (var cachenoise in _cacheNoise)
             {
-                await context.TokenCache.StoreToCache(new AuthenticationResultEx
+                await context.TokenCache.StoreToCache(new AdalResultWrapper
                 {
                     RefreshToken = cachenoise + "some-rt",
                     ResourceInResponse = TestConstants.DefaultResource,
                     Result =
-                        new AuthenticationResult("Bearer", cachenoise + tokenInCache, _expirationTime)
+                        new AdalResult("Bearer", cachenoise + tokenInCache, _expirationTime)
                         {
                             UserInfo =
-                                new UserInfo()
+                                new AdalUserInfo()
                                 {
                                     DisplayableId = cachenoise + TestConstants.DefaultDisplayableId,
                                     UniqueId = cachenoise + TestConstants.DefaultUniqueId
@@ -495,14 +496,14 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
-            await context.TokenCache.StoreToCache(new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-token-in-cache", _expirationTime)
+                Result = new AdalResult("Bearer", "some-token-in-cache", _expirationTime)
                 {
                     UserInfo =
-                        new UserInfo()
+                        new AdalUserInfo()
                         {
                             DisplayableId = TestConstants.DefaultDisplayableId,
                             UniqueId = TestConstants.DefaultUniqueId
@@ -552,14 +553,14 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
-            await context.TokenCache.StoreToCache(new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-token-in-cache", _expirationTime)
+                Result = new AdalResult("Bearer", "some-token-in-cache", _expirationTime)
                 {
                     UserInfo =
-                        new UserInfo()
+                        new AdalUserInfo()
                         {
                             DisplayableId = TestConstants.DefaultDisplayableId,
                             UniqueId = TestConstants.DefaultUniqueId
@@ -614,14 +615,14 @@ namespace Test.ADAL.NET.Unit
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             //cache entry has no user assertion hash
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
-                Result = new AuthenticationResult("Bearer", "some-token-in-cache", _expirationTime)
+                Result = new AdalResult("Bearer", "some-token-in-cache", _expirationTime)
                 {
                     UserInfo =
-                        new UserInfo()
+                        new AdalUserInfo()
                         {
                             DisplayableId = TestConstants.DefaultDisplayableId,
                             UniqueId = TestConstants.DefaultUniqueId
@@ -682,15 +683,15 @@ namespace Test.ADAL.NET.Unit
 
             //cache entry has user assertion hash
             string tokenInCache = "obo-access-token";
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
                 Result =
-                    new AuthenticationResult("Bearer", tokenInCache, _expirationTime)
+                    new AdalResult("Bearer", tokenInCache, _expirationTime)
                     {
                         UserInfo =
-                            new UserInfo()
+                            new AdalUserInfo()
                             {
                                 DisplayableId = TestConstants.DefaultDisplayableId,
                                 UniqueId = TestConstants.DefaultUniqueId
@@ -727,15 +728,15 @@ namespace Test.ADAL.NET.Unit
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
             string tokenInCache = "obo-access-token";
-            await context.TokenCache.StoreToCache(new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
                 Result =
-                    new AuthenticationResult("Bearer", tokenInCache, _expirationTime)
+                    new AdalResult("Bearer", tokenInCache, _expirationTime)
                     {
                         UserInfo =
-                            new UserInfo()
+                            new AdalUserInfo()
                             {
                                 DisplayableId = TestConstants.DefaultDisplayableId,
                                 UniqueId = TestConstants.DefaultUniqueId
@@ -793,15 +794,15 @@ namespace Test.ADAL.NET.Unit
 
             //cache entry has user assertion hash
             string tokenInCache = "obo-access-token";
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
                 Result =
-                    new AuthenticationResult("Bearer", tokenInCache, _expirationTime)
+                    new AdalResult("Bearer", tokenInCache, _expirationTime)
                     {
                         UserInfo =
-                            new UserInfo()
+                            new AdalUserInfo()
                             {
                                 DisplayableId = TestConstants.DefaultDisplayableId,
                                 UniqueId = TestConstants.DefaultUniqueId
@@ -838,15 +839,15 @@ namespace Test.ADAL.NET.Unit
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
             string tokenInCache = "obo-access-token";
-            await context.TokenCache.StoreToCache(new AuthenticationResultEx
+            await context.TokenCache.StoreToCache(new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
                 Result =
-                    new AuthenticationResult("Bearer", tokenInCache, _expirationTime)
+                    new AdalResult("Bearer", tokenInCache, _expirationTime)
                     {
                         UserInfo =
-                            new UserInfo()
+                            new AdalUserInfo()
                             {
                                 DisplayableId = TestConstants.DefaultDisplayableId,
                                 UniqueId = TestConstants.DefaultUniqueId
@@ -903,15 +904,15 @@ namespace Test.ADAL.NET.Unit
 
             //cache entry has user assertion hash
             string tokenInCache = "obo-access-token";
-            context.TokenCache.tokenCacheDictionary[key] = new AuthenticationResultEx
+            context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "some-rt",
                 ResourceInResponse = TestConstants.DefaultResource,
                 Result =
-                    new AuthenticationResult("Bearer", tokenInCache, _expirationTime)
+                    new AdalResult("Bearer", tokenInCache, _expirationTime)
                     {
                         UserInfo =
-                            new UserInfo()
+                            new AdalUserInfo()
                             {
                                 DisplayableId = TestConstants.DefaultDisplayableId,
                                 UniqueId = TestConstants.DefaultUniqueId

--- a/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/TokenCacheUnitTests.cs
@@ -112,7 +112,7 @@ namespace Test.ADAL.NET.Unit
         }
 
         [TestMethod]
-        [Description("Test for Token Cache backwasrd compatiblity where new attribute is added in AuthenticationResultEx")]
+        [Description("Test for Token Cache backwasrd compatiblity where new attribute is added in AdalResultWrapper")]
         [TestCategory("AdalDotNetUnit")]
         public void TokenCacheBackCompatTest()
         {

--- a/tests/Test.ADAL.NET.Unit/UnitTests.cs
+++ b/tests/Test.ADAL.NET.Unit/UnitTests.cs
@@ -34,6 +34,7 @@ using System.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.ClientCreds;
@@ -232,7 +233,7 @@ namespace Test.ADAL.NET.Unit
         {
             TokenResponse tr = CreateTokenResponse();
             tr.IdTokenString = "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiI5MDgzY2NiOC04YTQ2LTQzZTctODQzOS0xZDY5NmRmOTg0YWUiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwiaWF0IjoxNDAwNTQxMzk1LCJuYmYiOjE0MDA1NDEzOTUsImV4cCI6MTQwMDU0NTU5NSwidmVyIjoiMS4wIiwidGlkIjoiMzBiYWE2NjYtOGRmOC00OGU3LTk3ZTYtNzdjZmQwOTk1OTYzIiwib2lkIjoiNGY4NTk5ODktYTJmZi00MTFlLTkwNDgtYzMyMjI0N2FjNjJjIiwidXBuIjoiYWRtaW5AYWFsdGVzdHMub25taWNyb3NvZnQuY29tIiwidW5pcXVlX25hbWUiOiJhZG1pbkBhYWx0ZXN0cy5vbm1pY3Jvc29mdC5jb20iLCJzdWIiOiJCczVxVG4xQ3YtNC10VXIxTGxBb3pOS1NRd0Fjbm4ydHcyQjlmelduNlpJIiwiZmFtaWx5X25hbWUiOiJBZG1pbiIsImdpdmVuX25hbWUiOiJBREFMVGVzdHMiLCJwd2RfZXhwIjoiMzYwMDAiLCJwd2RfdXJsIjoiaHR0cHM6Ly9jaGFuZ2VfcHdkLmNvbSJ9.";
-            AuthenticationResultEx result = tr.GetResult();
+            AdalResultWrapper result = tr.GetResult();
             Assert.AreEqual(result.Result.UserInfo.PasswordChangeUrl, "https://change_pwd.com");
             Assert.IsNotNull(result.Result.UserInfo.PasswordExpiresOn);
         }
@@ -243,7 +244,7 @@ namespace Test.ADAL.NET.Unit
         {
             TokenResponse tr = CreateTokenResponse();
             tr.IdTokenString = "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiI5MDgzY2NiOC04YTQ2LTQzZTctODQzOS0xZDY5NmRmOTg0YWUiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC8zMGJhYTY2Ni04ZGY4LTQ4ZTctOTdlNi03N2NmZDA5OTU5NjMvIiwiaWF0IjoxNDAwNTQxMzk1LCJuYmYiOjE0MDA1NDEzOTUsImV4cCI6MTQwMDU0NTU5NSwidmVyIjoiMS4wIiwidGlkIjoiMzBiYWE2NjYtOGRmOC00OGU3LTk3ZTYtNzdjZmQwOTk1OTYzIiwib2lkIjoiNGY4NTk5ODktYTJmZi00MTFlLTkwNDgtYzMyMjI0N2FjNjJjIiwidXBuIjoiYWRtaW5AYWFsdGVzdHMub25taWNyb3NvZnQuY29tIiwidW5pcXVlX25hbWUiOiJhZG1pbkBhYWx0ZXN0cy5vbm1pY3Jvc29mdC5jb20iLCJzdWIiOiJCczVxVG4xQ3YtNC10VXIxTGxBb3pOS1NRd0Fjbm4ydHcyQjlmelduNlpJIiwiZmFtaWx5X25hbWUiOiJBZG1pbiIsImdpdmVuX25hbWUiOiJBREFMVGVzdHMifQ.";
-            AuthenticationResultEx result = tr.GetResult();
+            AdalResultWrapper result = tr.GetResult();
             Assert.IsNull(result.Result.UserInfo.PasswordChangeUrl);
             Assert.IsNull(result.Result.UserInfo.PasswordExpiresOn);
         }


### PR DESCRIPTION
per #929, Move AuthenticationResultEx to common core. This is needed for cache code to work in core. The work includes

Moving AuthenticationResultEx with rename.
Create equivalent classes for AuthenicationResult and UserInfo because they are public and cannot be moved without issues of confusion and conflict with MSAL class with the same name.
Update public AuthenticationResult class to return values from new equivalent class.
Introcude CoreCacheItem class that contains both MSAL and ADAL cache objed representation. This is just an idea, but not finalized with approach.