### PR TITLE
Dual Write RTs when persisting cache

### DIFF
--- a/adal/automation/WinFormsAutomationApp/AuthenticationHelper.cs
+++ b/adal/automation/WinFormsAutomationApp/AuthenticationHelper.cs
@@ -110,10 +110,10 @@ namespace WinFormsAutomationApp
             Task<string> myTask = Task.Run(async () =>
             {
                 TokenCache.DefaultShared.ReadItems();
-                List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> CacheItems = QueryCache(input["authority"],
+                List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> CacheItems = QueryCache(input["authority"],
                     input["client_id"], input["user_identifier"]);
 
-                foreach (KeyValuePair<TokenCacheKey, AdalResultWrapper> item in CacheItems)
+                foreach (KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> item in CacheItems)
                 {
                     // if resource was passed to cache lookup, then only expire token for that resource.
                     // otherwise expire all matching access tokens.
@@ -142,10 +142,10 @@ namespace WinFormsAutomationApp
                 try
                 {
                     TokenCache.DefaultShared.ReadItems();
-                    List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> CacheItems = QueryCache(input["authority"],
+                    List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> CacheItems = QueryCache(input["authority"],
                     input["client_id"], input["user_identifier"]);
 
-                    foreach (KeyValuePair<TokenCacheKey, AdalResultWrapper> item in CacheItems)
+                    foreach (KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> item in CacheItems)
                     {
                         var updated = item;
                         updated.Value.RefreshToken = "bad_refresh_token";
@@ -374,7 +374,7 @@ namespace WinFormsAutomationApp
             });
         }
 
-        private static async Task UpdateCache(KeyValuePair<TokenCacheKey, AdalResultWrapper> item, KeyValuePair<TokenCacheKey, AdalResultWrapper> updated)
+        private static async Task UpdateCache(KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> item, KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> updated)
         {
             NotifyBeforeAccessCache(item.Key.Resource, item.Key.ClientId, item.Value.Result.UserInfo.UniqueId, item.Value.Result.UserInfo.DisplayableId);
             TokenCache.DefaultShared.tokenCacheDictionary[updated.Key] = updated.Value;
@@ -384,7 +384,7 @@ namespace WinFormsAutomationApp
             NotifyAfterAccessCache(updated.Key.Resource, updated.Key.ClientId, updated.Value.Result.UserInfo.UniqueId, updated.Value.Result.UserInfo.DisplayableId);
         }
 
-        private static List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> QueryCache(string authority,
+        private static List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> QueryCache(string authority,
             string clientId, string displayableId)
         {
             return TokenCache.DefaultShared.tokenCacheDictionary.Where(

--- a/adal/devApps/AdalAndroidTestApp/Resources/Resource.Designer.cs
+++ b/adal/devApps/AdalAndroidTestApp/Resources/Resource.Designer.cs
@@ -26,8 +26,6 @@ namespace AdalAndroidTestApp
 		
 		public static void UpdateIdValues()
 		{
-			global::Microsoft.IdentityModel.Clients.ActiveDirectory.Resource.Id.agentWebView = global::AdalAndroidTestApp.Resource.Id.agentWebView;
-			global::Microsoft.IdentityModel.Clients.ActiveDirectory.Resource.Layout.WebAuthenticationBroker = global::AdalAndroidTestApp.Resource.Layout.WebAuthenticationBroker;
 			global::Microsoft.IdentityModel.Clients.ActiveDirectory.Resource.String.ApplicationName = global::AdalAndroidTestApp.Resource.String.ApplicationName;
 		}
 		
@@ -72,9 +70,6 @@ namespace AdalAndroidTestApp
 			// aapt resource value: 0x7f050002
 			public const int acquireTokenSilentButton = 2131034114;
 			
-			// aapt resource value: 0x7f050006
-			public const int agentWebView = 2131034118;
-			
 			// aapt resource value: 0x7f050003
 			public const int clearCacheButton = 2131034115;
 			
@@ -100,9 +95,6 @@ namespace AdalAndroidTestApp
 			// aapt resource value: 0x7f030000
 			public const int Main = 2130903040;
 			
-			// aapt resource value: 0x7f030001
-			public const int WebAuthenticationBroker = 2130903041;
-			
 			static Layout()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
@@ -116,11 +108,11 @@ namespace AdalAndroidTestApp
 		public partial class String
 		{
 			
-			// aapt resource value: 0x7f040000
-			public const int ApplicationName = 2130968576;
-			
 			// aapt resource value: 0x7f040001
-			public const int Hello = 2130968577;
+			public const int ApplicationName = 2130968577;
+			
+			// aapt resource value: 0x7f040000
+			public const int Hello = 2130968576;
 			
 			static String()
 			{

--- a/adal/devApps/XFormsApp.Droid/Resources/Resource.Designer.cs
+++ b/adal/devApps/XFormsApp.Droid/Resources/Resource.Designer.cs
@@ -26,9 +26,6 @@ namespace XFormsApp.Droid
 		
 		public static void UpdateIdValues()
 		{
-			global::Microsoft.IdentityModel.Clients.ActiveDirectory.Resource.Id.agentWebView = global::XFormsApp.Droid.Resource.Id.agentWebView;
-			global::Microsoft.IdentityModel.Clients.ActiveDirectory.Resource.Layout.WebAuthenticationBroker = global::XFormsApp.Droid.Resource.Layout.WebAuthenticationBroker;
-			global::Microsoft.IdentityModel.Clients.ActiveDirectory.Resource.String.ApplicationName = global::XFormsApp.Droid.Resource.String.ApplicationName;
 			global::Xamarin.Forms.Platform.Android.Resource.Attribute.actionBarSize = global::XFormsApp.Droid.Resource.Attribute.actionBarSize;
 		}
 		
@@ -2847,9 +2844,6 @@ namespace XFormsApp.Droid
 			// aapt resource value: 0x7f08001e
 			public const int add = 2131230750;
 			
-			// aapt resource value: 0x7f0800b2
-			public const int agentWebView = 2131230898;
-			
 			// aapt resource value: 0x7f080058
 			public const int alertTitle = 2131230808;
 			
@@ -3015,8 +3009,8 @@ namespace XFormsApp.Droid
 			// aapt resource value: 0x7f080048
 			public const int list_item = 2131230792;
 			
-			// aapt resource value: 0x7f0800b4
-			public const int masked = 2131230900;
+			// aapt resource value: 0x7f0800b3
+			public const int masked = 2131230899;
 			
 			// aapt resource value: 0x7f0800a1
 			public const int media_actions = 2131230881;
@@ -3315,8 +3309,8 @@ namespace XFormsApp.Droid
 			// aapt resource value: 0x7f08000e
 			public const int view_offset_helper = 2131230734;
 			
-			// aapt resource value: 0x7f0800b3
-			public const int visible = 2131230899;
+			// aapt resource value: 0x7f0800b2
+			public const int visible = 2131230898;
 			
 			// aapt resource value: 0x7f080093
 			public const int volume_item_container = 2131230867;
@@ -3606,9 +3600,6 @@ namespace XFormsApp.Droid
 			// aapt resource value: 0x7f030041
 			public const int support_simple_spinner_dropdown_item = 2130903105;
 			
-			// aapt resource value: 0x7f030042
-			public const int WebAuthenticationBroker = 2130903106;
-			
 			static Layout()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
@@ -3621,9 +3612,6 @@ namespace XFormsApp.Droid
 		
 		public partial class String
 		{
-			
-			// aapt resource value: 0x7f09003e
-			public const int ApplicationName = 2131296318;
 			
 			// aapt resource value: 0x7f090015
 			public const int abc_action_bar_home_description = 2131296277;

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -28,6 +28,7 @@
 using System;
 using System.Globalization;
 using System.Threading.Tasks;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.ClientCreds;

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Cache/CacheQueryData.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Cache/CacheQueryData.cs
@@ -25,6 +25,8 @@
 //
 //------------------------------------------------------------------------------
 
+using Microsoft.Identity.Core.Cache;
+
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache
 {
     class CacheQueryData

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/StorageDelegates.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/StorageDelegates.cs
@@ -51,20 +51,18 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         public static void BeforeAccess(TokenCacheNotificationArgs args)
         {
 #if ANDROID || iOS || WINDOWS_APP
-            if (args != null && args.TokenCache != null && args.TokenCache.Count > 0)
+            if (args != null && args.TokenCache != null)
             {
-                // We assume that the cache has not changed since last write
-                return;
+                args.TokenCache.Deserialize(LegacyCachePersistance.LoadCache());
             }
 
-            args.TokenCache.Deserialize(LegacyCachePersistance.LoadCache());
 #endif
         }
 
         public static void AfterAccess(TokenCacheNotificationArgs args)
         {
 #if ANDROID || iOS || WINDOWS_APP
-            if (args != null && args.TokenCache != null && args.TokenCache.HasStateChanged && args.TokenCache.Count > 0)
+            if (args != null && args.TokenCache != null && args.TokenCache.HasStateChanged)
             {
                 LegacyCachePersistance.WriteCache(args.TokenCache.Serialize());
                 args.TokenCache.HasStateChanged = false;

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
@@ -56,7 +56,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         private const string Delimiter = ":::";
 
-        internal readonly IDictionary<TokenCacheKey, AdalResultWrapper> tokenCacheDictionary;
+        internal readonly IDictionary<AdalTokenCacheKey, AdalResultWrapper> tokenCacheDictionary;
 
         // We do not want to return near expiry tokens, this is why we use this hard coded setting to refresh tokens which are close to expiration.
         private const int ExpirationMarginInMinutes = 5;
@@ -79,7 +79,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// </summary>
         public TokenCache()
         {
-            this.tokenCacheDictionary = new ConcurrentDictionary<TokenCacheKey, AdalResultWrapper>();
+            this.tokenCacheDictionary = new ConcurrentDictionary<AdalTokenCacheKey, AdalResultWrapper>();
         }
 
         /// <summary>
@@ -159,25 +159,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             lock (cacheLock)
             {
-                using (Stream stream = new MemoryStream())
-                {
-                    BinaryWriter writer = new BinaryWriter(stream);
-                    writer.Write(SchemaVersion);
-                    CoreLoggerBase.Default.Info(string.Format(CultureInfo.CurrentCulture, "Serializing token cache with {0} items.",
-                            this.tokenCacheDictionary.Count));
-                    writer.Write(this.tokenCacheDictionary.Count);
-                    foreach (KeyValuePair<TokenCacheKey, AdalResultWrapper> kvp in this.tokenCacheDictionary)
-                    {
-                        writer.Write(string.Format(CultureInfo.InvariantCulture, "{1}{0}{2}{0}{3}{0}{4}", Delimiter,
-                            kvp.Key.Authority, kvp.Key.Resource, kvp.Key.ClientId, (int) kvp.Key.TokenSubjectType));
-                        writer.Write(kvp.Value.Serialize());
-                    }
-
-                    int length = (int) stream.Position;
-                    stream.Position = 0;
-                    BinaryReader reader = new BinaryReader(stream);
-                    return reader.ReadBytes(length);
-                }
+                return AdalCacheOperations.Serialize(tokenCacheDictionary, SchemaVersion, Delimiter);
             }
         }
 
@@ -189,43 +171,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         {
             lock (cacheLock)
             {
-                if (state == null)
+                tokenCacheDictionary.Clear();
+                foreach (var entry in AdalCacheOperations.Deserialize(state, SchemaVersion, Delimiter))
                 {
-                    this.tokenCacheDictionary.Clear();
-                    return;
-                }
-
-                using (Stream stream = new MemoryStream())
-                {
-                    BinaryWriter writer = new BinaryWriter(stream);
-                    writer.Write(state);
-                    writer.Flush();
-                    stream.Position = 0;
-
-                    BinaryReader reader = new BinaryReader(stream);
-                    int schemaVersion = reader.ReadInt32();
-                    if (schemaVersion != SchemaVersion)
-                    {
-                        CoreLoggerBase.Default.Warning("The version of the persistent state of the cache does not match the current schema, so skipping deserialization.");
-                        return;
-                    }
-
-                    this.tokenCacheDictionary.Clear();
-                    int count = reader.ReadInt32();
-                    for (int n = 0; n < count; n++)
-                    {
-                        string keyString = reader.ReadString();
-
-                        string[] kvpElements = keyString.Split(new[] {Delimiter}, StringSplitOptions.None);
-                        AdalResultWrapper resultEx = AdalResultWrapper.Deserialize(reader.ReadString());
-                        TokenCacheKey key = new TokenCacheKey(kvpElements[0], kvpElements[1], kvpElements[2],
-                            (TokenSubjectType) int.Parse(kvpElements[3], CultureInfo.CurrentCulture),
-                            resultEx.Result.UserInfo);
-
-                        this.tokenCacheDictionary.Add(key, resultEx);
-                    }
-
-                    CoreLoggerBase.Default.Info(string.Format(CultureInfo.CurrentCulture, "Deserialized {0} items to token cache.", count));
+                    tokenCacheDictionary.Add(entry.Key, entry.Value);
                 }
             }
         }
@@ -275,7 +224,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 this.OnBeforeAccess(args);
                 this.OnBeforeWrite(args);
 
-                TokenCacheKey toRemoveKey = this.tokenCacheDictionary.Keys.FirstOrDefault(item.Match);
+                AdalTokenCacheKey toRemoveKey = this.tokenCacheDictionary.Keys.FirstOrDefault(item.Match);
                 if (toRemoveKey != null)
                 {
                     this.tokenCacheDictionary.Remove(toRemoveKey);
@@ -397,12 +346,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 requestContext.Logger.VerbosePii(msg);
 
                 AdalResultWrapper resultEx = null;
-                KeyValuePair<TokenCacheKey, AdalResultWrapper>? kvp =
+                KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>? kvp =
                     this.LoadSingleItemFromCache(cacheQueryData, requestContext);
 
                 if (kvp.HasValue)
                 {
-                    TokenCacheKey cacheKey = kvp.Value.Key;
+                    AdalTokenCacheKey cacheKey = kvp.Value.Key;
                     resultEx = kvp.Value.Value.Clone();
 
                     bool tokenNearExpiry = (resultEx.Result.ExpiresOn <=
@@ -529,9 +478,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     DisplayableId = displayableId
                 });
 
-                TokenCacheKey tokenCacheKey = new TokenCacheKey(authority, resource, clientId, subjectType,
+                AdalTokenCacheKey AdalTokenCacheKey = new AdalTokenCacheKey(authority, resource, clientId, subjectType,
                     result.Result.UserInfo);
-                this.tokenCacheDictionary[tokenCacheKey] = result;
+                this.tokenCacheDictionary[AdalTokenCacheKey] = result;
 
                 msg = "An item was stored in the cache";
                 requestContext.Logger.Verbose(msg);
@@ -551,13 +500,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 if (result.Result.UserInfo != null && result.IsMultipleResourceRefreshToken)
                 {
                     //pass null for authority to update the token for all the tenants
-                    List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> mrrtItems =
+                    List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> mrrtItems =
                         this.QueryCache(null, clientId, subjectType, result.Result.UserInfo.UniqueId,
                                 result.Result.UserInfo.DisplayableId, null)
                             .Where(p => p.Value.IsMultipleResourceRefreshToken)
                             .ToList();
 
-                    foreach (KeyValuePair<TokenCacheKey, AdalResultWrapper> mrrtItem in mrrtItems)
+                    foreach (KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> mrrtItem in mrrtItems)
                     {
                         mrrtItem.Value.RefreshToken = result.RefreshToken;
                     }
@@ -565,21 +514,21 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             }
         }
 
-        private KeyValuePair<TokenCacheKey, AdalResultWrapper>? LoadSingleItemFromCache(
+        private KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>? LoadSingleItemFromCache(
             CacheQueryData cacheQueryData, RequestContext requestContext)
         {
             lock (cacheLock)
             {
                 // First identify all potential tokens.
-                List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> items =
+                List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> items =
                     this.QueryCache(cacheQueryData.Authority, cacheQueryData.ClientId, cacheQueryData.SubjectType,
                         cacheQueryData.UniqueId, cacheQueryData.DisplayableId, cacheQueryData.AssertionHash);
 
-                List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> resourceSpecificItems =
+                List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> resourceSpecificItems =
                     items.Where(p => p.Key.ResourceEquals(cacheQueryData.Resource)).ToList();
                 int resourceValuesCount = resourceSpecificItems.Count;
 
-                KeyValuePair<TokenCacheKey, AdalResultWrapper>? returnValue = null;
+                KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>? returnValue = null;
                 switch (resourceValuesCount)
                 {
                     case 1:
@@ -592,7 +541,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     case 0:
                     {
                         // There are no resource specific tokens.  Choose any of the MRRT tokens if there are any.
-                        List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> mrrtItems =
+                        List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> mrrtItems =
                             items.Where(p => p.Value.IsMultipleResourceRefreshToken).ToList();
 
                         if (mrrtItems.Any())
@@ -613,11 +562,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 // this check only applies to user tokens. client tokens should be ignored.
                 if (returnValue == null && cacheQueryData.SubjectType != TokenSubjectType.Client)
                 {
-                    List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> itemsForAllTenants = this.QueryCache(
+                    List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> itemsForAllTenants = this.QueryCache(
                         null, cacheQueryData.ClientId, cacheQueryData.SubjectType, cacheQueryData.UniqueId,
                         cacheQueryData.DisplayableId, cacheQueryData.AssertionHash);
 
-                    List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> cloudSpecificItemsForAllTenants =
+                    List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> cloudSpecificItemsForAllTenants =
                         itemsForAllTenants.Where(item => IsSameCloud(item.Key.Authority, cacheQueryData.Authority)).ToList();
 
                     if (cloudSpecificItemsForAllTenants.Count != 0)
@@ -647,7 +596,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// authority value that this AuthorizationContext was created with.  In every case passing
         /// null results in a wildcard evaluation.
         /// </summary>
-        private List<KeyValuePair<TokenCacheKey, AdalResultWrapper>> QueryCache(string authority, string clientId,
+        private List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> QueryCache(string authority, string clientId,
             TokenSubjectType subjectType, string uniqueId, string displayableId, string assertionHash)
         {
             lock (cacheLock)

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
@@ -494,7 +494,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 this.HasStateChanged = true;
 
                 //store ADAL RT in MSAL cache for user tokens where authority is AAD
-                if (subjectType == TokenSubjectType.User && Authenticator.DetectAuthorityType(authority) != AuthorityType.AAD)
+                if (subjectType == TokenSubjectType.User && Authenticator.DetectAuthorityType(authority) == AuthorityType.AAD)
                 {
                     CacheFallbackOperations.WriteMsalRefreshToken(result, authority, clientId, displayableId, result.Result.UserInfo.IdentityProvider, result.Result.UserInfo.GivenName);
                 }

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCacheItem.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCacheItem.cs
@@ -36,13 +36,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// </summary>
     public sealed class TokenCacheItem
     {
-        private readonly TokenCacheKey _key;
+        private readonly AdalTokenCacheKey _key;
         private readonly AdalResult _result;
 
         /// <summary>
         /// Default constructor.
         /// </summary>
-        internal TokenCacheItem(TokenCacheKey key, AdalResult result)
+        internal TokenCacheItem(AdalTokenCacheKey key, AdalResult result)
         {
             _key = key;
             _result = result;
@@ -110,7 +110,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         internal TokenSubjectType TokenSubjectType => _key.TokenSubjectType;
 
-        internal bool Match(TokenCacheKey key)
+        internal bool Match(AdalTokenCacheKey key)
         {
             return (key.Authority == this.Authority && key.ResourceEquals(this.Resource) &&
                     key.ClientIdEquals(this.ClientId)

--- a/adal/tests/Test.ADAL.NET.Common/Mocks/MockHelpers.cs
+++ b/adal/tests/Test.ADAL.NET.Common/Mocks/MockHelpers.cs
@@ -245,7 +245,7 @@ namespace Test.ADAL.NET.Common.Mocks
             return responseMessage;
         }
 
-        private static string CreateIdToken(string uniqueId, string displayableId)
+        internal static string CreateIdToken(string uniqueId, string displayableId)
         {
             string header = "{alg: \"none\"," +
                              "typ:\"JWT\"" +

--- a/adal/tests/Test.ADAL.NET.Integration/AcquireTokenSilentTests.cs
+++ b/adal/tests/Test.ADAL.NET.Integration/AcquireTokenSilentTests.cs
@@ -58,7 +58,7 @@ namespace Test.ADAL.NET.Integration
         public void AcquireTokenSilentServiceErrorTestAsync()
         {
             TokenCache cache = new TokenCache();
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User, "unique_id",
                 "displayable@id.com");
             cache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -97,7 +97,7 @@ namespace Test.ADAL.NET.Integration
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -153,7 +153,7 @@ namespace Test.ADAL.NET.Integration
                 }
             });
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
 

--- a/adal/tests/Test.ADAL.NET.Integration/FederatedUserCredentialTests.cs
+++ b/adal/tests/Test.ADAL.NET.Integration/FederatedUserCredentialTests.cs
@@ -258,7 +258,7 @@ namespace Test.ADAL.NET.Integration
             AuthenticationContext context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             await context.Authenticator.UpdateFromTemplateAsync(null);
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper

--- a/adal/tests/Test.ADAL.NET.Integration/ManagedUsercredentialTests.cs
+++ b/adal/tests/Test.ADAL.NET.Integration/ManagedUsercredentialTests.cs
@@ -120,7 +120,7 @@ namespace Test.ADAL.NET.Integration
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -178,7 +178,7 @@ namespace Test.ADAL.NET.Integration
 
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
             TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
             TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             var setupResult = new AdalResultWrapper

--- a/adal/tests/Test.ADAL.NET.Integration/PromptBehaviorTests.cs
+++ b/adal/tests/Test.ADAL.NET.Integration/PromptBehaviorTests.cs
@@ -100,7 +100,7 @@ namespace Test.ADAL.NET.Integration
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, true, new TokenCache());
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -284,7 +284,7 @@ namespace Test.ADAL.NET.Integration
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
 
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper

--- a/adal/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
@@ -151,7 +151,7 @@ namespace Test.ADAL.NET.Unit
         public async Task ExtendedLifetimePositiveTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -186,7 +186,7 @@ namespace Test.ADAL.NET.Unit
         public async Task ExtendedLifetimeExpiredTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -226,7 +226,7 @@ namespace Test.ADAL.NET.Unit
         public async Task ExtendedLifetimeTokenTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -270,7 +270,7 @@ namespace Test.ADAL.NET.Unit
         public async Task ExtendedLifetimeRequestTimeoutTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -392,7 +392,7 @@ namespace Test.ADAL.NET.Unit
         public async Task ClientCredentialExtendedExpiryPositiveTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.Client,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -456,7 +456,7 @@ namespace Test.ADAL.NET.Unit
         public void ClientCredentialExtendedExpiryNegativeTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -518,7 +518,7 @@ namespace Test.ADAL.NET.Unit
         public void ClientCredentialNegativeRequestTimeoutTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -581,7 +581,7 @@ namespace Test.ADAL.NET.Unit
         public void ClientCredentialExtendedExpiryNoFlagSetTest()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityCommonTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -731,7 +731,7 @@ namespace Test.ADAL.NET.Unit
         public void AcquireTokenWithInvalidResourceTestAsync()
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -801,7 +801,7 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAdfsAuthorityTenant, false, new TokenCache());
             //add simple RT to cache
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAdfsAuthorityTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAdfsAuthorityTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User, null, null);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
@@ -1096,7 +1096,7 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             string accessToken = "some-access-token";
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -1154,7 +1154,7 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityCommonTenant, new TokenCache());
             string accessToken = "some-access-token";
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             context.TokenCache.tokenCacheDictionary[key] = new AdalResultWrapper
@@ -1268,7 +1268,7 @@ namespace Test.ADAL.NET.Unit
             AdalResultWrapper resultEx = TokenCacheTests.CreateCacheValue("id", "user1");
             resultEx.UserAssertionHash = "hash1";
             cache.tokenCacheDictionary.Add(
-            new TokenCacheKey("https://login.microsoftonline.com/common/", "resource1", "client1",
+            new AdalTokenCacheKey("https://login.microsoftonline.com/common/", "resource1", "client1",
                 TokenSubjectType.Client, "id", "user1"), resultEx);
             RequestData data = new RequestData
             {
@@ -1297,7 +1297,7 @@ namespace Test.ADAL.NET.Unit
         public void HttpErrorResponseAsInnerException()
         {
             TokenCache cache = new TokenCache();
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityCommonTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User, "unique_id", "displayable@id.com");
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityCommonTenant, TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User, "unique_id", "displayable@id.com");
             cache.tokenCacheDictionary[key] = new AdalResultWrapper
             {
                 RefreshToken = "something-invalid",

--- a/adal/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit/AdalDotNetTests.cs
@@ -1130,10 +1130,7 @@ namespace Test.ADAL.NET.Unit
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityCommonTenant))
             {
                 Method = HttpMethod.Post,
-                ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent("{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"access_token\":\"some-other-token\"}")
-                },
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
                 PostData = new Dictionary<string, string>()
                 {
                     {"client_id", TestConstants.DefaultClientId},
@@ -1188,10 +1185,7 @@ namespace Test.ADAL.NET.Unit
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.DefaultAuthorityCommonTenant))
             {
                 Method = HttpMethod.Post,
-                ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StringContent("{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"access_token\":\"some-other-token\"}")
-                },
+                ResponseMessage = MockHelpers.CreateSuccessTokenResponseMessage(),
                 PostData = new Dictionary<string, string>()
                 {
                     {"client_id", TestConstants.DefaultClientId},

--- a/adal/tests/Test.ADAL.NET.Unit/BrokerParametersTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit/BrokerParametersTests.cs
@@ -30,6 +30,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;

--- a/adal/tests/Test.ADAL.NET.Unit/InstanceDiscoveryTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit/InstanceDiscoveryTests.cs
@@ -32,6 +32,7 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Net;
 using Microsoft.Identity.Core;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Instance;

--- a/adal/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit/OboFlowTests.cs
@@ -204,7 +204,7 @@ namespace Test.ADAL.NET.Unit
 
             foreach (var cachenoise in _cacheNoise)
             {
-                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                     TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                     cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
                 //cache entry has no user assertion hash
@@ -275,7 +275,7 @@ namespace Test.ADAL.NET.Unit
 
             foreach (var cachenoise in _cacheNoise)
             {
-                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                     TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                     cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
 
@@ -386,7 +386,7 @@ namespace Test.ADAL.NET.Unit
             string tokenInCache = "obo-access-token";
             foreach (var cachenoise in _cacheNoise)
             {
-                TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+                AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                     TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                     cachenoise + TestConstants.DefaultUniqueId, cachenoise + TestConstants.DefaultDisplayableId);
 
@@ -611,7 +611,7 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
             //cache entry has no user assertion hash
@@ -677,7 +677,7 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
 
@@ -788,7 +788,7 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.User,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
 
@@ -898,7 +898,7 @@ namespace Test.ADAL.NET.Unit
         {
             var context = new AuthenticationContext(TestConstants.DefaultAuthorityHomeTenant, new TokenCache());
             string accessToken = "access-token";
-            TokenCacheKey key = new TokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
+            AdalTokenCacheKey key = new AdalTokenCacheKey(TestConstants.DefaultAuthorityHomeTenant,
                 TestConstants.DefaultResource, TestConstants.DefaultClientId, TokenSubjectType.UserPlusClient,
                 TestConstants.DefaultUniqueId, TestConstants.DefaultDisplayableId);
 

--- a/adal/tests/Test.ADAL.NET.Unit/TokenCacheKeyTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit/TokenCacheKeyTests.cs
@@ -53,8 +53,8 @@ namespace Test.ADAL.NET.Unit
         public void TokenCacheKey_Equals_SameValuesDifferenceInstancesAreEqual()
         {
             // Setup
-            var testSubject1 = new TokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, DisplayableId);
-            var testSubject2 = new TokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, DisplayableId);
+            var testSubject1 = new AdalTokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, DisplayableId);
+            var testSubject2 = new AdalTokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, DisplayableId);
 
             // Act
             var result1 = testSubject1.Equals(testSubject2);
@@ -71,7 +71,7 @@ namespace Test.ADAL.NET.Unit
         public void TokenCacheKey_Equals_SameInstancesAreEqual()
         {
             // Setup
-            var testSubject = new TokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, DisplayableId);
+            var testSubject = new AdalTokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, DisplayableId);
 
             // Act
             var result = testSubject.Equals(testSubject);
@@ -86,7 +86,7 @@ namespace Test.ADAL.NET.Unit
         public void TokenCacheKey_Equals_DifferentValuesAreNotEqual()
         {
             // Setup
-            var referenceSubject = new TokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, DisplayableId);
+            var referenceSubject = new AdalTokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, DisplayableId);
 
             foreach (var other in ChangeEachProperty(referenceSubject, "a different value", TokenSubjectType.Client))
             {
@@ -112,7 +112,7 @@ namespace Test.ADAL.NET.Unit
         public void TokenCacheKey_GetHashCode_DifferentValuesAreNotEqual()
         {
             // Setup
-            var referenceSubject = new TokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, DisplayableId);
+            var referenceSubject = new AdalTokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, DisplayableId);
 
             var baseCode = referenceSubject.GetHashCode();
 
@@ -136,7 +136,7 @@ namespace Test.ADAL.NET.Unit
             try
             {
                 // Setup
-                var testSubject = new TokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, "a displayable ID with four types of letter iIİı");
+                var testSubject = new AdalTokenCacheKey(Authority, Resource, ClientId, SubjectType, UniqueId, "a displayable ID with four types of letter iIİı");
 
                 // Act: en-US as current culture
                 Thread.CurrentThread.CurrentCulture = GetEnglishUsCulture();
@@ -193,34 +193,34 @@ namespace Test.ADAL.NET.Unit
             }
         }
 
-        private static string AsString(TokenCacheKey key)
+        private static string AsString(AdalTokenCacheKey key)
         {
             return $"({key.Authority}, {key.Resource}, {key.ClientId}, {key.TokenSubjectType}, {key.UniqueId}, {key.DisplayableId})";
         }
 
         /// <summary>
-        /// Generate a series of <see cref="TokenCacheKey"/> instances based on the given <paramref name="reference"/>
+        /// Generate a series of <see cref="AdalTokenCacheKey"/> instances based on the given <paramref name="reference"/>
         /// instance, but change one property in each instance.
         /// </summary>
-        private static IEnumerable<TokenCacheKey> ChangeEachProperty(TokenCacheKey reference, string differentString, TokenSubjectType differentSubjectType)
+        private static IEnumerable<AdalTokenCacheKey> ChangeEachProperty(AdalTokenCacheKey reference, string differentString, TokenSubjectType differentSubjectType)
         {
             // Different authority
-            yield return new TokenCacheKey(differentString, reference.Resource, reference.ClientId, reference.TokenSubjectType, reference.UniqueId, reference.DisplayableId);
+            yield return new AdalTokenCacheKey(differentString, reference.Resource, reference.ClientId, reference.TokenSubjectType, reference.UniqueId, reference.DisplayableId);
 
             // Different resource
-            yield return new TokenCacheKey(reference.Authority, differentString, reference.ClientId, reference.TokenSubjectType, reference.UniqueId, reference.DisplayableId);
+            yield return new AdalTokenCacheKey(reference.Authority, differentString, reference.ClientId, reference.TokenSubjectType, reference.UniqueId, reference.DisplayableId);
 
             // Different client ID
-            yield return new TokenCacheKey(reference.Authority, reference.Resource, differentString, reference.TokenSubjectType, reference.UniqueId, reference.DisplayableId);
+            yield return new AdalTokenCacheKey(reference.Authority, reference.Resource, differentString, reference.TokenSubjectType, reference.UniqueId, reference.DisplayableId);
 
             // Different token subject type
-            yield return new TokenCacheKey(reference.Authority, reference.Resource, reference.ClientId, differentSubjectType, reference.UniqueId, reference.DisplayableId);
+            yield return new AdalTokenCacheKey(reference.Authority, reference.Resource, reference.ClientId, differentSubjectType, reference.UniqueId, reference.DisplayableId);
 
             // Different unique ID
-            yield return new TokenCacheKey(reference.Authority, reference.Resource, reference.ClientId, reference.TokenSubjectType, differentString, reference.DisplayableId);
+            yield return new AdalTokenCacheKey(reference.Authority, reference.Resource, reference.ClientId, reference.TokenSubjectType, differentString, reference.DisplayableId);
 
             // Different displayable ID
-            yield return new TokenCacheKey(reference.Authority, reference.Resource, reference.ClientId, reference.TokenSubjectType, reference.UniqueId, differentString);
+            yield return new AdalTokenCacheKey(reference.Authority, reference.Resource, reference.ClientId, reference.TokenSubjectType, reference.UniqueId, differentString);
         }
 
         #endregion

--- a/adal/tests/Test.ADAL.NET.Unit/TokenCacheKeyTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit/TokenCacheKeyTests.cs
@@ -31,6 +31,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Threading;
+using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;
 
 namespace Test.ADAL.NET.Unit

--- a/adal/tests/Test.ADAL.NET.Unit/TokenCacheTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit/TokenCacheTests.cs
@@ -68,23 +68,23 @@ namespace Test.ADAL.Common.Unit
 
             const string DisplayableId = "testuser@microsoft.com";
             Log.Comment("====== Creating a set of keys and values for the test...");
-            TokenCacheKey key = new TokenCacheKey("https://localhost/MockSts", ValidResource, ValidClientId,
+            AdalTokenCacheKey key = new AdalTokenCacheKey("https://localhost/MockSts", ValidResource, ValidClientId,
                 TokenSubjectType.User, null, DisplayableId);
             var value = CreateCacheValue(key.UniqueId, key.DisplayableId);
             Log.Comment(string.Format(CultureInfo.CurrentCulture, " Cache Key (with User): {0}", key));
             Log.Comment(string.Format(CultureInfo.CurrentCulture, " Cache Value 1: {0}", value));
-            TokenCacheKey key2 = new TokenCacheKey("https://localhost/MockSts", InvalidResource, ValidClientId,
+            AdalTokenCacheKey key2 = new AdalTokenCacheKey("https://localhost/MockSts", InvalidResource, ValidClientId,
                 TokenSubjectType.User, null, DisplayableId);
             var value2 = CreateCacheValue(null, DisplayableId);
             Log.Comment(string.Format(CultureInfo.CurrentCulture, " Cache Key (with User): {0}", key));
             Log.Comment(string.Format(CultureInfo.CurrentCulture, " Cache Value 2: {0}", value2));
-            TokenCacheKey userlessKey = new TokenCacheKey("https://localhost/MockSts", ValidResource, ValidClientId,
+            AdalTokenCacheKey userlessKey = new AdalTokenCacheKey("https://localhost/MockSts", ValidResource, ValidClientId,
                 TokenSubjectType.User, null, null);
             var userlessValue = CreateCacheValue(null, null);
             Log.Comment(string.Format(CultureInfo.CurrentCulture, " Cache Key (withoutUser): {0}", userlessKey));
             Log.Comment(string.Format(CultureInfo.CurrentCulture, " Cache Value 3: {0}", userlessValue));
 
-            TokenCacheKey incorrectUserKey = new TokenCacheKey("https://localhost/MockSts", InvalidResource,
+            AdalTokenCacheKey incorrectUserKey = new AdalTokenCacheKey("https://localhost/MockSts", InvalidResource,
                 ValidClientId, TokenSubjectType.User, null, "testuser2@microsoft.com");
 
             Log.Comment("====== Verifying that cache stores the first key/value pair...");
@@ -201,7 +201,7 @@ namespace Test.ADAL.Common.Unit
             displayableId = Guid.NewGuid().ToString();
             var cacheValue = CreateCacheValue(uniqueId, displayableId);
             AddToDictionary(localCache,
-                new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
+                new AdalTokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
                 cacheValue);
 
             //Add second user into cache
@@ -209,7 +209,7 @@ namespace Test.ADAL.Common.Unit
             displayableId = Guid.NewGuid().ToString();
             cacheValue = CreateCacheValue(uniqueId, displayableId);
             AddToDictionary(localCache,
-                new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
+                new AdalTokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
                 cacheValue);
 
             var acWithLocalCache = new AuthenticationContext(authority, false, localCache);
@@ -251,7 +251,7 @@ namespace Test.ADAL.Common.Unit
             localCache.Clear();
 
             // @Resource, Credential
-            TokenCacheKey tokenCacheKey = new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User,
+            AdalTokenCacheKey tokenCacheKey = new AdalTokenCacheKey(authority, resource, clientId, TokenSubjectType.User,
                 uniqueId, displayableId);
             AddToDictionary(localCache, tokenCacheKey, authenticationResult);
             AuthenticationContext acWithLocalCache = new AuthenticationContext(authority, false, localCache);
@@ -262,7 +262,7 @@ namespace Test.ADAL.Common.Unit
             // Duplicate throws error
             authenticationResult.Result.UserInfo.UniqueId = null;
             AddToDictionary(localCache,
-                new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, null, displayableId),
+                new AdalTokenCacheKey(authority, resource, clientId, TokenSubjectType.User, null, displayableId),
                 authenticationResult);
 
 
@@ -288,7 +288,7 @@ namespace Test.ADAL.Common.Unit
             resource = Guid.NewGuid().ToString();
             clientId = Guid.NewGuid().ToString();
 
-            TokenCacheKey tempKey = new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, null, null);
+            AdalTokenCacheKey tempKey = new AdalTokenCacheKey(authority, resource, clientId, TokenSubjectType.User, null, null);
             AddToDictionary(localCache, tempKey, cacheValue);
             RemoveFromDictionary(localCache, tempKey);
             Assert.IsFalse(localCache.tokenCacheDictionary.ContainsKey(tempKey));
@@ -307,7 +307,7 @@ namespace Test.ADAL.Common.Unit
             displayableId = Guid.NewGuid().ToString();
             cacheValue = CreateCacheValue(uniqueId, displayableId);
             AddToDictionary(localCache,
-                new TokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
+                new AdalTokenCacheKey(authority, resource, clientId, TokenSubjectType.User, uniqueId, displayableId),
                 cacheValue);
 
             var userId = new UserIdentifier(uniqueId, UserIdentifierType.UniqueId);
@@ -331,7 +331,7 @@ namespace Test.ADAL.Common.Unit
             var cacheDictionary = tokenCache.tokenCacheDictionary;
             tokenCache.Clear();
 
-            TokenCacheKey key = new TokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
+            AdalTokenCacheKey key = new AdalTokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
                 TokenSubjectType.User, null, "user1");
             AdalResultWrapper value = CreateCacheValue(null, "user1");
         }
@@ -343,11 +343,11 @@ namespace Test.ADAL.Common.Unit
 
             tokenCache.Clear();
 
-            TokenCacheKey key = new TokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
+            AdalTokenCacheKey key = new AdalTokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
                 TokenSubjectType.User, null, "user1");
-            TokenCacheKey key2 = new TokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
+            AdalTokenCacheKey key2 = new AdalTokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
                 TokenSubjectType.User, null, "user2");
-            TokenCacheKey key3 = new TokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
+            AdalTokenCacheKey key3 = new AdalTokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
                 TokenSubjectType.UserPlusClient, null, "user1");
             Assert.AreNotEqual(key, key3);
 
@@ -436,10 +436,10 @@ namespace Test.ADAL.Common.Unit
             Assert.IsTrue(cacheDictionary.ContainsKey(key2));
             Assert.IsFalse(cacheDictionary.ContainsKey(key3));
 
-            Assert.IsTrue(cacheDictionary.Contains(new KeyValuePair<TokenCacheKey, AdalResultWrapper>(key, value)));
-            Assert.IsTrue(cacheDictionary.Contains(new KeyValuePair<TokenCacheKey, AdalResultWrapper>(key2, value2)));
-            Assert.IsFalse(cacheDictionary.Contains(new KeyValuePair<TokenCacheKey, AdalResultWrapper>(key, value2)));
-            Assert.IsFalse(cacheDictionary.Contains(new KeyValuePair<TokenCacheKey, AdalResultWrapper>(key2, value)));
+            Assert.IsTrue(cacheDictionary.Contains(new KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>(key, value)));
+            Assert.IsTrue(cacheDictionary.Contains(new KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>(key2, value2)));
+            Assert.IsFalse(cacheDictionary.Contains(new KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>(key, value2)));
+            Assert.IsFalse(cacheDictionary.Contains(new KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>(key2, value)));
 
 
             // Duplicate key -> error
@@ -451,7 +451,7 @@ namespace Test.ADAL.Common.Unit
             Assert.AreEqual(3, cacheDictionary.Keys.Count);
             Assert.IsTrue(cacheDictionary.ContainsKey(key3));
 
-            var cacheItemsCopy = new KeyValuePair<TokenCacheKey, AdalResultWrapper>[cacheDictionary.Count + 1];
+            var cacheItemsCopy = new KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>[cacheDictionary.Count + 1];
             cacheDictionary.CopyTo(cacheItemsCopy, 1);
             for (int i = 0; i < cacheDictionary.Count; i++)
             {
@@ -488,9 +488,9 @@ namespace Test.ADAL.Common.Unit
 
         internal static async Task MultipleUserAssertionHashTest()
         {
-            TokenCacheKey key = new TokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
+            AdalTokenCacheKey key = new AdalTokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
                 TokenSubjectType.Client, null, "user1");
-            TokenCacheKey key2 = new TokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
+            AdalTokenCacheKey key2 = new AdalTokenCacheKey("https://localhost/MockSts/", "resource1", "client1",
                 TokenSubjectType.Client, null, "user2");
             AdalResultWrapper value = CreateCacheValue(null, "user1");
             value.UserAssertionHash = "hash1";
@@ -532,7 +532,7 @@ namespace Test.ADAL.Common.Unit
             tokenCache.Clear();
 
             const int MaxItemCount = 100;
-            TokenCacheKey[] keys = new TokenCacheKey[MaxItemCount];
+            AdalTokenCacheKey[] keys = new AdalTokenCacheKey[MaxItemCount];
             AdalResultWrapper[] values = new AdalResultWrapper[MaxItemCount];
 
             for (int i = 0; i < MaxItemCount; i++)
@@ -561,7 +561,7 @@ namespace Test.ADAL.Common.Unit
         internal static void TokenCacheValueSplitTest()
         {
             var tokenCache = new TokenCache();
-            TokenCacheKey key = new TokenCacheKey("https://localhost/MockSts", "resourc1", "client1",
+            AdalTokenCacheKey key = new AdalTokenCacheKey("https://localhost/MockSts", "resourc1", "client1",
                 TokenSubjectType.User, null, "user1");
 
             tokenCache.Clear();
@@ -585,7 +585,7 @@ namespace Test.ADAL.Common.Unit
             tokenCache.Clear();
             for (int count = 0; count < Rand.Next(1, MaxItemCount); count++)
             {
-                TokenCacheKey key = GenerateRandomTokenCacheKey();
+                AdalTokenCacheKey key = GenerateRandomTokenCacheKey();
                 AdalResultWrapper result = GenerateRandomCacheValue(MaxFieldSize, key.UniqueId, key.DisplayableId);
                 AddToDictionary(tokenCache, key, result);
             }
@@ -626,7 +626,7 @@ namespace Test.ADAL.Common.Unit
 
         public static void CheckPublicGetSets()
         {
-            TokenCacheKey tokenCacheKey = new TokenCacheKey("Authority", "Resource", "ClientId", TokenSubjectType.User,
+            AdalTokenCacheKey tokenCacheKey = new AdalTokenCacheKey("Authority", "Resource", "ClientId", TokenSubjectType.User,
                 "UniqueId", "DisplayableId");
 
             Assert.IsTrue(tokenCacheKey.Authority == "Authority");
@@ -642,13 +642,13 @@ namespace Test.ADAL.Common.Unit
             Assert.AreEqual(cache.Count, expectedCount);
         }
 
-        private static void VerifyCacheItems(TokenCache cache, int expectedCount, TokenCacheKey firstKey)
+        private static void VerifyCacheItems(TokenCache cache, int expectedCount, AdalTokenCacheKey firstKey)
         {
             VerifyCacheItems(cache, expectedCount, firstKey, null);
         }
 
-        private static void VerifyCacheItems(TokenCache cache, int expectedCount, TokenCacheKey firstKey,
-            TokenCacheKey secondKey)
+        private static void VerifyCacheItems(TokenCache cache, int expectedCount, AdalTokenCacheKey firstKey,
+            AdalTokenCacheKey secondKey)
         {
             var items = cache.ReadItems().ToList();
             Assert.AreEqual(expectedCount, items.Count);
@@ -686,7 +686,7 @@ namespace Test.ADAL.Common.Unit
             return EncodingHelper.Base64Encode(GenerateRandomString(len)).Substring(0, len);
         }
 
-        private static bool AreEqual(TokenCacheItem item, TokenCacheKey key)
+        private static bool AreEqual(TokenCacheItem item, AdalTokenCacheKey key)
         {
             return item.Match(key);
         }
@@ -745,7 +745,7 @@ namespace Test.ADAL.Common.Unit
             return (str1 == str2 || string.IsNullOrEmpty(str1) && string.IsNullOrEmpty(str2));
         }
 
-        private static void AddToDictionary(TokenCache tokenCache, TokenCacheKey key, AdalResultWrapper value)
+        private static void AddToDictionary(TokenCache tokenCache, AdalTokenCacheKey key, AdalResultWrapper value)
         {
             tokenCache.OnBeforeAccess(new TokenCacheNotificationArgs {TokenCache = tokenCache});
             tokenCache.OnBeforeWrite(new TokenCacheNotificationArgs {TokenCache = tokenCache});
@@ -754,7 +754,7 @@ namespace Test.ADAL.Common.Unit
             tokenCache.OnAfterAccess(new TokenCacheNotificationArgs {TokenCache = tokenCache});
         }
 
-        private static bool RemoveFromDictionary(TokenCache tokenCache, TokenCacheKey key)
+        private static bool RemoveFromDictionary(TokenCache tokenCache, AdalTokenCacheKey key)
         {
             tokenCache.OnBeforeAccess(new TokenCacheNotificationArgs {TokenCache = tokenCache});
             tokenCache.OnBeforeWrite(new TokenCacheNotificationArgs {TokenCache = tokenCache});
@@ -765,9 +765,9 @@ namespace Test.ADAL.Common.Unit
             return result;
         }
 
-        private static TokenCacheKey GenerateRandomTokenCacheKey()
+        private static AdalTokenCacheKey GenerateRandomTokenCacheKey()
         {
-            return new TokenCacheKey(Guid.NewGuid().ToString(),
+            return new AdalTokenCacheKey(Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString(),
                 Guid.NewGuid().ToString(),
                 TokenSubjectType.User,

--- a/core/src/Cache/AdalCacheOperations.cs
+++ b/core/src/Cache/AdalCacheOperations.cs
@@ -1,0 +1,107 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Core.Cache
+{
+    internal class AdalCacheOperations
+    {
+        public static byte[] Serialize(IDictionary<AdalTokenCacheKey, AdalResultWrapper> tokenCacheDictionary, int schemaVersion, string delimiter)
+        {
+            using (Stream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                writer.Write(schemaVersion);
+                CoreLoggerBase.Default.Info(string.Format(CultureInfo.CurrentCulture, "Serializing token cache with {0} items.",
+                    tokenCacheDictionary.Count));
+                writer.Write(tokenCacheDictionary.Count);
+                foreach (KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> kvp in tokenCacheDictionary)
+                {
+                    writer.Write(string.Format(CultureInfo.InvariantCulture, "{1}{0}{2}{0}{3}{0}{4}", delimiter,
+                        kvp.Key.Authority, kvp.Key.Resource, kvp.Key.ClientId, (int)kvp.Key.TokenSubjectType));
+                    writer.Write(kvp.Value.Serialize());
+                }
+
+                int length = (int)stream.Position;
+                stream.Position = 0;
+                BinaryReader reader = new BinaryReader(stream);
+                return reader.ReadBytes(length);
+            }
+        }
+
+        public static IDictionary<AdalTokenCacheKey, AdalResultWrapper> Deserialize(byte[] state, int schemaVersion, string delimiter)
+        {
+            IDictionary<AdalTokenCacheKey, AdalResultWrapper> dictionary =
+                new Dictionary<AdalTokenCacheKey, AdalResultWrapper>();
+            if (state == null)
+            {
+                return dictionary;
+            }
+
+            using (Stream stream = new MemoryStream())
+            {
+                BinaryWriter writer = new BinaryWriter(stream);
+                writer.Write(state);
+                writer.Flush();
+                stream.Position = 0;
+
+                BinaryReader reader = new BinaryReader(stream);
+                int blobSchemaVersion = reader.ReadInt32();
+                if (blobSchemaVersion != schemaVersion)
+                {
+                    CoreLoggerBase.Default.Warning("The version of the persistent state of the cache does not match the current schema, so skipping deserialization.");
+                    return dictionary;
+                }
+                
+                int count = reader.ReadInt32();
+                for (int n = 0; n < count; n++)
+                {
+                    string keyString = reader.ReadString();
+
+                    string[] kvpElements = keyString.Split(new[] { delimiter }, StringSplitOptions.None);
+                    AdalResultWrapper resultEx = AdalResultWrapper.Deserialize(reader.ReadString());
+                    AdalTokenCacheKey key = new AdalTokenCacheKey(kvpElements[0], kvpElements[1], kvpElements[2],
+                        (TokenSubjectType)int.Parse(kvpElements[3], CultureInfo.CurrentCulture),
+                        resultEx.Result.UserInfo);
+
+                    dictionary.Add(key, resultEx);
+                }
+
+                CoreLoggerBase.Default.Info(string.Format(CultureInfo.CurrentCulture, "Deserialized {0} items to token cache.", count));
+            }
+
+            return dictionary;
+        }
+    }
+}

--- a/core/src/Cache/AdalResultWrapper.cs
+++ b/core/src/Cache/AdalResultWrapper.cs
@@ -43,6 +43,9 @@ namespace Microsoft.Identity.Core.Cache
         [DataMember]
         public AdalResult Result { get; set; }
 
+        [DataMember]
+        public string RawClientInfo { get; set; }
+
         /// <summary>
         /// Gets the Refresh Token associated with the requested Access Token. Note: not all operations will return a Refresh Token.
         /// </summary>

--- a/core/src/Cache/AdalTokenCacheKey.cs
+++ b/core/src/Cache/AdalTokenCacheKey.cs
@@ -26,9 +26,8 @@
 //------------------------------------------------------------------------------
 
 using System;
-using Microsoft.Identity.Core.Cache;
 
-namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache
+namespace Microsoft.Identity.Core.Cache
 {
     /// <summary>
     /// Determines what type of subject the token was issued for.
@@ -50,16 +49,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache
     };
 
     /// <summary>
-    /// <see cref="TokenCacheKey"/> can be used with Linq to access items from the TokenCache dictionary.
+    /// <see cref="AdalTokenCacheKey"/> can be used with Linq to access items from the TokenCache dictionary.
     /// </summary>
-    internal sealed class TokenCacheKey
+    internal sealed class AdalTokenCacheKey
     {
-        internal TokenCacheKey(string authority, string resource, string clientId, TokenSubjectType tokenSubjectType, AdalUserInfo adalUserInfo)
+        internal AdalTokenCacheKey(string authority, string resource, string clientId, TokenSubjectType tokenSubjectType, AdalUserInfo adalUserInfo)
             : this(authority, resource, clientId, tokenSubjectType, (adalUserInfo != null) ? adalUserInfo.UniqueId : null, (adalUserInfo != null) ? adalUserInfo.DisplayableId : null)
         {
         }
 
-        internal TokenCacheKey(string authority, string resource, string clientId, TokenSubjectType tokenSubjectType, string uniqueId, string displayableId)
+        internal AdalTokenCacheKey(string authority, string resource, string clientId, TokenSubjectType tokenSubjectType, string uniqueId, string displayableId)
         {
             this.Authority = authority;
             this.Resource = resource;
@@ -90,7 +89,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache
         /// <param name="obj">The object to compare with the current object. </param><filterpriority>2</filterpriority>
         public override bool Equals(object obj)
         {
-            TokenCacheKey other = obj as TokenCacheKey;
+            AdalTokenCacheKey other = obj as AdalTokenCacheKey;
             return (other != null) && this.Equals(other);
         }
 
@@ -101,7 +100,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache
         /// true if the specified TokenCacheKey is equal to the current object; otherwise, false.
         /// </returns>
         /// <param name="other">The TokenCacheKey to compare with the current object. </param><filterpriority>2</filterpriority>
-        public bool Equals(TokenCacheKey other)
+        public bool Equals(AdalTokenCacheKey other)
         {
             if (ReferenceEquals(this, other))
             {

--- a/core/src/Cache/CacheFallbackOperations.cs
+++ b/core/src/Cache/CacheFallbackOperations.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Core.Cache
 {
     internal class CacheFallbackOperations
     {
-        public void WriteMsalRefreshToken(AdalResultWrapper resultWrapper)
+        public static void WriteMsalRefreshToken(AdalResultWrapper resultWrapper, string authority, string clientId, string displayableId, string identityProvider, string givenName)
         {
             if (string.IsNullOrEmpty(resultWrapper.RawClientInfo))
             {
@@ -52,14 +52,21 @@ namespace Microsoft.Identity.Core.Cache
 
             MsalRefreshTokenCacheItem rtItem = new MsalRefreshTokenCacheItem()
             {
-
+                RefreshToken = resultWrapper.RefreshToken,
+                ClientId = clientId,
+                RawClientInfo = resultWrapper.RawClientInfo,
+                Version = MsalTokenCacheItemBase.CacheVersion,
+                DisplayableId = displayableId,
+                IdentityProvider = identityProvider,
+                Name = givenName,
+                ClientInfo = ClientInfo.CreateFromEncodedString(resultWrapper.RawClientInfo)
             };
 
             ITokenCacheAccessor accessor = new TokenCacheAccessor();
             accessor.SaveRefreshToken(rtItem.GetRefreshTokenItemKey().ToString(), JsonHelper.SerializeToJson(rtItem));
         }
 
-        public void WriteAdalRefreshToken(MsalRefreshTokenCacheItem rtItem)
+        public static void WriteAdalRefreshToken(MsalRefreshTokenCacheItem rtItem, string authority, string uniqueId, string scope)
         {
             if (rtItem == null)
             {
@@ -67,11 +74,108 @@ namespace Microsoft.Identity.Core.Cache
                 return;
             }
 
+            AdalTokenCacheKey key = new AdalTokenCacheKey(authority, null, rtItem.ClientId, TokenSubjectType.User, uniqueId, rtItem.DisplayableId);
             AdalResultWrapper wrapper = new AdalResultWrapper()
             {
-                RefreshToken = rtItem.RefreshToken
+                Result = new AdalResult(null,null, DateTimeOffset.MinValue),
+                RefreshToken = rtItem.RefreshToken,
+                RawClientInfo = rtItem.RawClientInfo,
+                //ResourceInResponse is needed to treat RT as an MRRT. See IsMultipleResourceRefreshToken 
+                //property in AdalResultWrapper and its usage. Stronger design would be for the STS to return resource
+                //for which the token was issued as well on v2 endpoint.
+                ResourceInResponse = scope
             };
-            
+
+#if !FACADE || !NETSTANDARD1_3
+            IDictionary<AdalTokenCacheKey, AdalResultWrapper> dictionary = AdalCacheOperations.Deserialize(LegacyCachePersistance.LoadCache());
+            dictionary[key] = wrapper;
+            AdalCacheOperations.Serialize(dictionary);
+#endif
+        }
+
+
+        public static List<MsalRefreshTokenCacheItem> GetAllAdalUsersForMsal(string environment, string clientId)
+        {
+            //returns all the adal entries where client info is present
+            List<MsalRefreshTokenCacheItem> list = GetAllAdalEntriesForMsal(environment, clientId, null, null);
+            //TODO return distinct clientinfo only
+            return list.Where(p => !string.IsNullOrEmpty(p.RawClientInfo)).ToList();
+        }
+
+        public static List<MsalRefreshTokenCacheItem> GetAllAdalEntriesForMsal(string environment, string clientId, string upn, string rawClientInfo)
+        {
+            IDictionary<AdalTokenCacheKey, AdalResultWrapper> dictionary = AdalCacheOperations.Deserialize(LegacyCachePersistance.LoadCache());
+            //filter by client id and environment first
+            List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> listToProcess =
+                    dictionary.Where(p => p.Key.ClientId.Equals(clientId) && environment.Equals(new Uri(p.Key.Authority).Host)).ToList();
+
+            //if client info is provided then use it to filter
+            if (!string.IsNullOrEmpty(rawClientInfo))
+            {
+                List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> clientInfoEntries = listToProcess.Where(p => rawClientInfo.Equals(p.Value.RawClientInfo)).ToList();
+                if (clientInfoEntries.Any())
+                {
+                    listToProcess = clientInfoEntries;
+                }
+            }
+
+            //if upn is provided then use it to filter
+            if (!string.IsNullOrEmpty(upn))
+            {
+                //TODO - authority check needs to be updated for alias check
+                List<KeyValuePair<AdalTokenCacheKey, AdalResultWrapper>> upnEntries = listToProcess.Where(p => upn.Equals(p.Key.DisplayableId)).ToList();
+                if (upnEntries.Any())
+                {
+                    listToProcess = upnEntries;
+                }
+            }
+
+            List<MsalRefreshTokenCacheItem> list = new List<MsalRefreshTokenCacheItem>();
+            foreach(KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> pair in listToProcess)
+            {
+                list.Add(
+            new MsalRefreshTokenCacheItem()
+            {
+                RawClientInfo = pair.Value.RawClientInfo,
+                RefreshToken = pair.Value.RefreshToken,
+                DisplayableId = pair.Key.DisplayableId,
+                ClientId = pair.Key.ClientId,
+                Version = MsalTokenCacheItemBase.CacheVersion,
+                Environment = environment,
+                IdentityProvider = pair.Value.Result?.UserInfo.IdentityProvider,
+                Name = pair.Value.Result?.UserInfo.GivenName,
+                ClientInfo = ClientInfo.CreateFromEncodedString(pair.Value.RawClientInfo)
+            });
+            }
+
+            return list;
+        }
+
+        public static MsalRefreshTokenCacheItem GetAdalEntryForMsal(string environment, string clientId, string upn, string rawClientInfo)
+        {
+            return GetAllAdalEntriesForMsal(environment, clientId, upn, rawClientInfo).FirstOrDefault();
+        }
+
+        public static AdalResultWrapper FindMsalEntryForAdal(string authority, string clientId, string upn)
+        {
+            ITokenCacheAccessor accessor = new TokenCacheAccessor();
+            foreach(string rtString in accessor.GetAllRefreshTokensAsString())
+            {
+                MsalRefreshTokenCacheItem rtItem =
+                    JsonHelper.DeserializeFromJson<MsalRefreshTokenCacheItem>(rtString);
+
+                //TODO - authority check needs to be updated for alias check
+                if (new Uri(authority).Host.Equals(rtItem.Environment) && rtItem.ClientId.Equals(clientId) && rtItem.DisplayableId.Equals(upn)) {
+                    return new AdalResultWrapper()
+                    {
+                        Result = new AdalResult(null, null, DateTimeOffset.MinValue),
+                        RefreshToken = rtItem.RefreshToken,
+                        RawClientInfo = rtItem.RawClientInfo
+                    };
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/core/src/Cache/CacheFallbackOperations.cs
+++ b/core/src/Cache/CacheFallbackOperations.cs
@@ -25,31 +25,53 @@
 //
 //------------------------------------------------------------------------------
 
-using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Cache;
-using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.ClientCreds;
-using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Instance;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Identity.Core.Cache;
+using Microsoft.Identity.Core.Helpers;
 
-namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
+namespace Microsoft.Identity.Core.Cache
 {
-    class RequestData
+    internal class CacheFallbackOperations
     {
-        public Authenticator Authenticator { get; set; }
+        public void WriteMsalRefreshToken(AdalResultWrapper resultWrapper)
+        {
+            if (string.IsNullOrEmpty(resultWrapper.RawClientInfo))
+            {
+                CoreLoggerBase.Default.Info("Client Info is missing. Skipping MSAL RT cache write");
+                return;
+            }
 
-        public TokenCache TokenCache { get; set; }
+            if (string.IsNullOrEmpty(resultWrapper.RefreshToken))
+            {
+                CoreLoggerBase.Default.Info("Refresh Token is missing. Skipping MSAL RT cache write");
+                return;
+            }
 
-        public string Resource { get; set; }
+            MsalRefreshTokenCacheItem rtItem = new MsalRefreshTokenCacheItem()
+            {
 
-        public ClientKey ClientKey { get; set; }
+            };
 
-        public TokenSubjectType SubjectType { get; set; }
+            ITokenCacheAccessor accessor = new TokenCacheAccessor();
+            accessor.SaveRefreshToken(rtItem.GetRefreshTokenItemKey().ToString(), JsonHelper.SerializeToJson(rtItem));
+        }
 
-        public bool ExtendedLifeTimeEnabled { get; set; }
+        public void WriteAdalRefreshToken(MsalRefreshTokenCacheItem rtItem)
+        {
+            if (rtItem == null)
+            {
+                CoreLoggerBase.Default.Info("rtItem is null. Skipping MSAL RT cache write");
+                return;
+            }
 
+            AdalResultWrapper wrapper = new AdalResultWrapper()
+            {
+                RefreshToken = rtItem.RefreshToken
+            };
+            
+        }
     }
 }

--- a/core/src/Cache/CacheFallbackOperations.cs
+++ b/core/src/Cache/CacheFallbackOperations.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Core.Cache
                 ResourceInResponse = scope
             };
 
-#if !FACADE || !NETSTANDARD1_3
+#if !FACADE && !NETSTANDARD1_3
             IDictionary<AdalTokenCacheKey, AdalResultWrapper> dictionary = AdalCacheOperations.Deserialize(LegacyCachePersistance.LoadCache());
             dictionary[key] = wrapper;
             AdalCacheOperations.Serialize(dictionary);

--- a/core/src/Microsoft.Identity.Core.csproj
+++ b/core/src/Microsoft.Identity.Core.csproj
@@ -127,4 +127,8 @@
   </ItemGroup>
   
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
+  
+  <ItemGroup>
+    <Compile Remove="Platforms\net45\LegacyCachePersistance.cs" />
+  </ItemGroup>
 </Project>

--- a/core/src/Microsoft.Identity.Core.csproj
+++ b/core/src/Microsoft.Identity.Core.csproj
@@ -128,7 +128,4 @@
   
   <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
   
-  <ItemGroup>
-    <Compile Remove="Platforms\net45\LegacyCachePersistance.cs" />
-  </ItemGroup>
 </Project>

--- a/core/src/Platforms/net45/LegacyCachePersistance.cs
+++ b/core/src/Platforms/net45/LegacyCachePersistance.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------------------------
+﻿//----------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -25,47 +25,20 @@
 //
 //------------------------------------------------------------------------------
 
-using System.Globalization;
-using System.Runtime.Serialization;
-using Microsoft.Identity.Core.Helpers;
+using System;
 
 namespace Microsoft.Identity.Core.Cache
 {
-    /// <summary>
-    /// Token cache item
-    /// </summary>
-    [DataContract]
-    internal abstract class MsalTokenCacheItemBase
+    internal class LegacyCachePersistance
     {
-        internal const int CacheVersion = 1;
-
-        /// <summary>
-        /// Default constructor.
-        /// </summary>
-        public MsalTokenCacheItemBase(string clientId)
+        //this class is an empty implementation to facilitate testing of forward/backward cache compat testing.
+        public static byte[] LoadCache()
         {
-            ClientId = clientId;
+            return null;
         }
 
-        public MsalTokenCacheItemBase()
+        public static void WriteCache(byte[] serializedCache)
         {
-        }
-
-        [DataMember(Name = "ver", IsRequired = false)]
-        public int Version { get; set; } = CacheVersion;
-
-        [DataMember(Name = "client_info")]
-        public string RawClientInfo { get; set; }
-
-        [DataMember(Name = "client_id")]
-        public string ClientId { get; set; }
-
-        public ClientInfo ClientInfo { get; set; }
-
-        internal string GetUserIdentifier()
-        {
-            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", Base64UrlHelpers.Encode(ClientInfo?.UniqueIdentifier),
-                Base64UrlHelpers.Encode(ClientInfo?.UniqueTenantIdentifier));
         }
     }
 }

--- a/core/src/Platforms/netstandard1.1/LegacyCachePersistance.cs
+++ b/core/src/Platforms/netstandard1.1/LegacyCachePersistance.cs
@@ -1,0 +1,44 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Identity.Core.Cache
+{
+    internal class LegacyCachePersistance
+    {
+        //this class is an empty implementation to facilitate testing of forward/backward cache compat testing.
+        public static byte[] LoadCache()
+        {
+            return null;
+        }
+
+        public static void WriteCache(byte[] serializedCache)
+        {
+        }
+    }
+}

--- a/core/src/Platforms/netstandard1.3/LegacyCachePersistance.cs
+++ b/core/src/Platforms/netstandard1.3/LegacyCachePersistance.cs
@@ -1,0 +1,44 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+
+namespace Microsoft.Identity.Core.Cache
+{
+    internal class LegacyCachePersistance
+    {
+        //this class is an empty implementation to facilitate testing of forward/backward cache compat testing.
+        public static byte[] LoadCache()
+        {
+            return null;
+        }
+
+        public static void WriteCache(byte[] serializedCache)
+        {
+        }
+    }
+}

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -41,6 +41,11 @@ namespace Microsoft.Identity.Client.Internal.Requests
 {
     internal abstract class RequestBase
     {
+        static RequestBase()
+        {
+            PlatformPlugin.PlatformInformation = new PlatformInformation();
+        }
+
         protected static readonly Task CompletedTask = Task.FromResult(false);
         internal readonly AuthenticationRequestParameters AuthenticationRequestParameters;
         internal readonly TokenCache TokenCache;
@@ -64,7 +69,6 @@ namespace Microsoft.Identity.Client.Internal.Requests
         protected RequestBase(AuthenticationRequestParameters authenticationRequestParameters)
         {
             TokenCache = authenticationRequestParameters.TokenCache;
-            
             // Log contains Pii 
             authenticationRequestParameters.RequestContext.Logger.InfoPii(string.Format(CultureInfo.InvariantCulture,
                 "=== Token Acquisition ({4}) started:\n\tAuthority: {0}\n\tScope: {1}\n\tClientId: {2}\n\tCache Provided: {3}",

--- a/msal/tests/dev apps/XForms/XForms.Android/Resources/Resource.Designer.cs
+++ b/msal/tests/dev apps/XForms/XForms.Android/Resources/Resource.Designer.cs
@@ -565,7 +565,6 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Id.actions = global::XForms.Droid.Resource.Id.actions;
 			global::Microsoft.Identity.Client.Resource.Id.activity_chooser_view_content = global::XForms.Droid.Resource.Id.activity_chooser_view_content;
 			global::Microsoft.Identity.Client.Resource.Id.add = global::XForms.Droid.Resource.Id.add;
-			global::Microsoft.Identity.Client.Resource.Id.agentWebView = global::XForms.Droid.Resource.Id.agentWebView;
 			global::Microsoft.Identity.Client.Resource.Id.alertTitle = global::XForms.Droid.Resource.Id.alertTitle;
 			global::Microsoft.Identity.Client.Resource.Id.always = global::XForms.Droid.Resource.Id.always;
 			global::Microsoft.Identity.Client.Resource.Id.beginning = global::XForms.Droid.Resource.Id.beginning;
@@ -704,8 +703,6 @@ namespace XForms.Droid
 			global::Microsoft.Identity.Client.Resource.Layout.select_dialog_multichoice_material = global::XForms.Droid.Resource.Layout.select_dialog_multichoice_material;
 			global::Microsoft.Identity.Client.Resource.Layout.select_dialog_singlechoice_material = global::XForms.Droid.Resource.Layout.select_dialog_singlechoice_material;
 			global::Microsoft.Identity.Client.Resource.Layout.support_simple_spinner_dropdown_item = global::XForms.Droid.Resource.Layout.support_simple_spinner_dropdown_item;
-			global::Microsoft.Identity.Client.Resource.Layout.WebAuthenticationBroker = global::XForms.Droid.Resource.Layout.WebAuthenticationBroker;
-			global::Microsoft.Identity.Client.Resource.String.ApplicationName = global::XForms.Droid.Resource.String.ApplicationName;
 			global::Microsoft.Identity.Client.Resource.String.abc_action_bar_home_description = global::XForms.Droid.Resource.String.abc_action_bar_home_description;
 			global::Microsoft.Identity.Client.Resource.String.abc_action_bar_home_description_format = global::XForms.Droid.Resource.String.abc_action_bar_home_description_format;
 			global::Microsoft.Identity.Client.Resource.String.abc_action_bar_home_subtitle_description_format = global::XForms.Droid.Resource.String.abc_action_bar_home_subtitle_description_format;
@@ -4269,9 +4266,6 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f08001e
 			public const int add = 2131230750;
 			
-			// aapt resource value: 0x7f0800b4
-			public const int agentWebView = 2131230900;
-			
 			// aapt resource value: 0x7f080058
 			public const int alertTitle = 2131230808;
 			
@@ -4437,8 +4431,8 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f080048
 			public const int list_item = 2131230792;
 			
-			// aapt resource value: 0x7f0800b6
-			public const int masked = 2131230902;
+			// aapt resource value: 0x7f0800b5
+			public const int masked = 2131230901;
 			
 			// aapt resource value: 0x7f0800a1
 			public const int media_actions = 2131230881;
@@ -4743,8 +4737,8 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f08000e
 			public const int view_offset_helper = 2131230734;
 			
-			// aapt resource value: 0x7f0800b5
-			public const int visible = 2131230901;
+			// aapt resource value: 0x7f0800b4
+			public const int visible = 2131230900;
 			
 			// aapt resource value: 0x7f080093
 			public const int volume_item_container = 2131230867;
@@ -5040,9 +5034,6 @@ namespace XForms.Droid
 			// aapt resource value: 0x7f030043
 			public const int Toolbar = 2130903107;
 			
-			// aapt resource value: 0x7f030044
-			public const int WebAuthenticationBroker = 2130903108;
-			
 			static Layout()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
@@ -5055,9 +5046,6 @@ namespace XForms.Droid
 		
 		public partial class String
 		{
-			
-			// aapt resource value: 0x7f09003e
-			public const int ApplicationName = 2131296318;
 			
 			// aapt resource value: 0x7f090015
 			public const int abc_action_bar_home_description = 2131296277;


### PR DESCRIPTION
Dual Write RTs when persisting cache in iOS/Android/WinRT. RTs should be written in existing format and MSAL format. This will allow apps using MSAL and same client id and same publisher to get SSO. #932 