### PR TITLE
Trwalke/x5c claim hotfix proposal

### DIFF
--- a/devApps/AdalCoreCLRTestApp/Program.cs
+++ b/devApps/AdalCoreCLRTestApp/Program.cs
@@ -55,7 +55,7 @@ namespace AdalCoreCLRTestApp
         {
             AuthenticationContext context = new AuthenticationContext("https://login.microsoftonline.com/common", true);
             var certificate = GetCertificateByThumbprint("<CERT_THUMBPRINT>");
-            var result = await context.AcquireTokenAsync("https://graph.windows.net", new ClientAssertionCertificate("<CLIENT_ID>", certificate));
+            var result = await context.AcquireTokenAsync("https://graph.windows.net", new ClientAssertionCertificate("<CLIENT_ID>", certificate), true);
 
             string token = result.AccessToken;
             Console.WriteLine(token + "\n");

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -765,13 +765,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
-        /// <param name="sendX5c">Sends the x509 public certificate to the STS as a x5c claim.
-        /// This parameter enables application developers to opt-in to easy certificates roll-up
-        /// in Azure AD: in the case the certificate was renewed on the machine executing ADAL.NET,
-        /// setting this parameter to true will send the certificate public key to Azure AD in
-        /// addition to the certificate thumbprint, so that Azure AD rolls-over it's internal
-        /// knowledge of the certificate. This avoid the azure AD application admin to have to
-        /// change the application manifest in the Azure portal (or to run a powershell / CLI script)</param>
+        /// <param name="sendX5c">This parameter enables application developers to achieve easy certificates roll-up
+        /// in Azure AD: setting this parameter to true will send the certificate bits to Azure AD 
+        /// along with the token request, so that Azure AD can use it to update the application’s certificate registration.
+        /// This saves the application admin from the need to explicitly manage the certificate rollover
+        /// (either via portal or powershell/CLI operation)</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
 #if ANDROID || iOS || WINDOWS_APP
         [Obsolete("As a security hygiene, this confidential flow API should not be used on this platform which only supports public client applications. For details please see https://aka.ms/AdalNetConfFlows")] 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -761,11 +761,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         }
 
         /// <summary>
-        /// Acquires security token from the authority.
+        /// Acquires security token from the authority and sends the x509 public certificate
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
-        /// <param name="sendX5c">Sends the x509 public certificate as x5c</param>
+        /// <param name="sendX5c">Sends the x509 public certificate as a x5c claim</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
 #if ANDROID || iOS || WINDOWS_APP
         [Obsolete("As a security hygiene, this confidential flow API should not be used on this platform which only supports public client applications. For details please see https://aka.ms/AdalNetConfFlows")] 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -765,7 +765,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
-        /// <param name="sendX5c">Sends the x509 public certificate as a x5c claim</param>
+        /// <param name="sendX5c">Sends the x509 public certificate to the STS as a x5c claim.
+        /// This parameter enables application developers to opt-in to easy certificates roll-up
+        /// in Azure AD: in the case the certificate was renewed on the machine executing ADAL.NET,
+        /// setting this parameter to true will send the certificate public key to Azure AD in
+        /// addition to the certificate thumbprint, so that Azure AD rolls-over it's internal
+        /// knowledge of the certificate. This avoid the azure AD application admin to have to
+        /// change the application manifest in the Azure portal (or to run a powershell / CLI script)</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
 #if ANDROID || iOS || WINDOWS_APP
         [Obsolete("As a security hygiene, this confidential flow API should not be used on this platform which only supports public client applications. For details please see https://aka.ms/AdalNetConfFlows")] 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -764,6 +764,23 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// Acquires security token from the authority.
         /// </summary>
         /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
+        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
+        /// <param name="sendX5c">Sends the x509 public certificate as x5c</param>
+        /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
+#if ANDROID || iOS || WINDOWS_APP
+        [Obsolete("As a security hygiene, this confidential flow API should not be used on this platform which only supports public client applications. For details please see https://aka.ms/AdalNetConfFlows")] 
+#endif
+        public async Task<AuthenticationResult> AcquireTokenAsync(string resource,
+            IClientAssertionCertificate clientCertificate, bool sendX5c)
+        {
+            return await AcquireTokenForClientCommonAsync(resource, new ClientKey(clientCertificate, Authenticator, sendX5c))
+                .ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Acquires security token from the authority.
+        /// </summary>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token.</param>
         /// <param name="clientAssertion">The client assertion to use for token acquisition.</param>
         /// <returns>It contains Access Token and the Access Token's expiration time. Refresh Token property will be null for this overload.</returns>
 #if ANDROID || iOS || WINDOWS_APP

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/ClientCreds/ClientKey.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/ClientCreds/ClientKey.cs
@@ -41,6 +41,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
             this.ClientId = clientId;
             this.HasCredential = false;
+            this.SendX5c = false;
         }
 
         public ClientKey(ClientCredential clientCredential)
@@ -53,6 +54,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.Credential = clientCredential;
             this.ClientId = clientCredential.ClientId;
             this.HasCredential = true;
+            this.SendX5c = false;
         }
 
         public ClientKey(IClientAssertionCertificate clientCertificate, Authenticator authenticator)
@@ -67,6 +69,22 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.Certificate = clientCertificate;
             this.ClientId = clientCertificate.ClientId;
             this.HasCredential = true;
+            this.SendX5c = false;
+        }
+
+        public ClientKey(IClientAssertionCertificate clientCertificate, Authenticator authenticator, bool sendX5c)
+        {
+            this.Authenticator = authenticator;
+
+            if (clientCertificate == null)
+            {
+                throw new ArgumentNullException("clientCertificate");
+            }
+
+            this.Certificate = clientCertificate;
+            this.ClientId = clientCertificate.ClientId;
+            this.HasCredential = true;
+            this.SendX5c = sendX5c;
         }
 
         public ClientKey(ClientAssertion clientAssertion)
@@ -79,6 +97,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.Assertion = clientAssertion;
             this.ClientId = clientAssertion.ClientId;
             this.HasCredential = true;
+            this.SendX5c = false;
         }
 
         public ClientCredential Credential { get; private set; }
@@ -92,6 +111,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public string ClientId { get; private set; }
 
         public bool HasCredential { get; private set; }
+        public bool SendX5c { get; private set; }
 
 
         public void AddToParameters(IDictionary<string, string> parameters)
@@ -120,7 +140,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             else if (this.Certificate != null)
             {
                 JsonWebToken jwtToken = new JsonWebToken(this.Certificate, this.Authenticator.SelfSignedJwtAudience);
-                ClientAssertion clientAssertion = jwtToken.Sign(this.Certificate);
+                ClientAssertion clientAssertion = jwtToken.Sign(this.Certificate, this.SendX5c);
                 parameters[OAuthParameter.ClientAssertionType] = clientAssertion.AssertionType;
                 parameters[OAuthParameter.ClientAssertion] = clientAssertion.Assertion;
             }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/ClientCreds/JsonWebToken.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/ClientCreds/JsonWebToken.cs
@@ -71,7 +71,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         private readonly JWTPayload payload;
 
-        private bool _sendX5c = false;
+        private bool sendX5c = false;
 
         public JsonWebToken(IClientAssertionCertificate certificate, string audience)
         {
@@ -92,7 +92,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public ClientAssertion Sign(IClientAssertionCertificate credential, bool sendX5c)
         {
             string token;
-            this._sendX5c = sendX5c;
+            this.sendX5c = sendX5c;
 
             // Base64Url encoded header and claims
             token = this.Encode(credential);
@@ -132,7 +132,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         private string Encode(IClientAssertionCertificate credential)
         {
             // Header segment
-            string jsonHeader = EncodeHeaderToJson(credential, _sendX5c);
+            string jsonHeader = EncodeHeaderToJson(credential, sendX5c);
             string encodedHeader = EncodeSegment(jsonHeader);
 
             // Payload segment
@@ -217,7 +217,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 _thumbPrint = this.Credential.Thumbprint;
                 X509CertificatePublicCertValue = null;
 
-                if (sendX5C)
+                if (!sendX5C)
                     return;
 
                 //Check to see if credential is our implementation or developer provided.

--- a/tests/Test.ADAL.NET.Unit/ClientAssertionTestImplementation.cs
+++ b/tests/Test.ADAL.NET.Unit/ClientAssertionTestImplementation.cs
@@ -1,0 +1,63 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Test.ADAL.NET.Unit
+{
+    /// <summary>
+    /// Test implementation of IClientAssertionCertificate.
+    /// </summary>
+    [DeploymentItem("valid_cert.pfx")]
+    public class ClientAssertionTestImplementation : IClientAssertionCertificate
+    {
+
+        public string ClientId { get { return TestConstants.DefaultClientId; } }
+
+        public string Thumbprint { get { return TestConstants.DefaultThumbprint; } }
+
+        public byte[] Sign(string message)
+        {
+            CryptographyHelper helper = new CryptographyHelper();
+            return helper.SignWithCertificate(message, this.Certificate);
+        }
+
+        public X509Certificate2 Certificate { get; }
+
+        public ClientAssertionTestImplementation()
+        {
+            this.Certificate = new X509Certificate2("valid_cert.pfx", TestConstants.DefaultPassword);
+        }
+    }
+}

--- a/tests/Test.ADAL.NET.Unit/JsonWebTokenTests.cs
+++ b/tests/Test.ADAL.NET.Unit/JsonWebTokenTests.cs
@@ -1,0 +1,159 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Helpers;
+using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http;
+using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using System.Threading.Tasks;
+using Test.ADAL.Common;
+using Test.ADAL.NET.Common;
+using Test.ADAL.NET.Common.Mocks;
+using AuthenticationContext = Microsoft.IdentityModel.Clients.ActiveDirectory.AuthenticationContext;
+
+namespace Test.ADAL.NET.Unit
+{
+    [TestClass]
+    [DeploymentItem("valid_cert.pfx")]
+    public class JsonWebTokenTests
+    {
+        private PlatformParameters platformParameters;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            HttpMessageHandlerFactory.ClearMockHandlers();
+            InstanceDiscovery.InstanceCache.Clear();
+            HttpMessageHandlerFactory.AddMockHandler(MockHelpers.CreateInstanceDiscoveryMockHandler(TestConstants.GetDiscoveryEndpoint(TestConstants.DefaultAuthorityCommonTenant)));
+            platformParameters = new PlatformParameters(PromptBehavior.Auto);
+        }
+
+        [TestMethod]
+        [Description("Test for Json Web Token with client assertion and a X509 public certificate claim")]
+        public async Task JsonWebTokenWithX509PublicCertClaimTest()
+        {
+            var certificate = new X509Certificate2("valid_cert.pfx", TestConstants.DefaultPassword);
+            var clientAssertion = new ClientAssertionCertificate(TestConstants.DefaultClientId, certificate);
+            var context = new AuthenticationContext(TestConstants.TenantSpecificAuthority, new TokenCache());
+
+            var validCertClaim = "\"x5c\":\"" + Convert.ToBase64String(certificate.GetRawCertData());
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.TenantSpecificAuthority))
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"access_token\":\"some-access-token\"}")
+                },
+                AdditionalRequestValidation = request =>
+                {
+                    var requestContent = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                    var formsData = EncodingHelper.ParseKeyValueList(requestContent, '&', true, null);
+
+                    // Check presence of client_assertion in request
+                    string encodedJwt;
+                    Assert.IsTrue(formsData.TryGetValue("client_assertion", out encodedJwt), "Missing client_assertion from request");
+
+                    // Check presence of x5c cert claim. It should not exist.
+                    var jwtHeader = EncodingHelper.UrlDecode(encodedJwt.Split('.')[0]);
+                    Assert.IsTrue(!jwtHeader.Contains("\"x5c\":"));
+                }
+            });
+
+            AuthenticationResult result = await context.AcquireTokenAsync(TestConstants.DefaultResource, clientAssertion);
+            Assert.IsNotNull(result.AccessToken);
+        }
+
+        [TestMethod]
+        [Description("Test for Json Web Token with developer implemented client assertion")]
+        public async Task JsonWebTokenWithDeveloperImplementedClientAssertionTest()
+        {
+            var certificate = new X509Certificate2("valid_cert.pfx", TestConstants.DefaultPassword);
+            var clientAssertion = new ClientAssertionTestImplementation();
+            var context = new AuthenticationContext(TestConstants.TenantSpecificAuthority, new TokenCache());
+
+            var validCertClaim = "\"x5c\":\"" + Convert.ToBase64String(certificate.GetRawCertData());
+
+            HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler(TestConstants.GetTokenEndpoint(TestConstants.TenantSpecificAuthority))
+            {
+                Method = HttpMethod.Post,
+                ResponseMessage = new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent("{\"token_type\":\"Bearer\",\"expires_in\":\"3599\",\"access_token\":\"some-access-token\"}")
+                },
+                AdditionalRequestValidation = request =>
+                {
+                    var requestContent = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                    var formsData = EncodingHelper.ParseKeyValueList(requestContent, '&', true, null);
+
+                    // Check presence of client_assertion in request
+                    string encodedJwt;
+                    Assert.IsTrue(formsData.TryGetValue("client_assertion", out encodedJwt), "Missing client_assertion from request");
+
+                    // Check presence of x5c cert claim. It should not exist.
+                    var jwtHeader = EncodingHelper.UrlDecode(encodedJwt.Split('.')[0]);
+                    Assert.IsTrue(!jwtHeader.Contains("\"x5c\":"));
+                }
+            });
+
+            AuthenticationResult result = await context.AcquireTokenAsync(TestConstants.DefaultResource, clientAssertion);
+            Assert.IsNotNull(result.AccessToken);
+        }
+    }
+
+
+    [DeploymentItem("valid_cert.pfx")]
+    class ClientAssertionTestImplementation : IClientAssertionCertificate
+    {
+
+        public string ClientId { get { return TestConstants.DefaultClientId; } }
+
+        public string Thumbprint { get { return TestConstants.DefaultThumbprint; } }
+
+        public byte[] Sign(string message)
+        {
+            CryptographyHelper helper = new CryptographyHelper();
+            return helper.SignWithCertificate(message, this.Certificate);
+        }
+
+        public X509Certificate2 Certificate { get; }
+
+        public ClientAssertionTestImplementation()
+        {
+            this.Certificate = new X509Certificate2("valid_cert.pfx", TestConstants.DefaultPassword);
+        }
+    }
+}
+

--- a/tests/Test.ADAL.NET.Unit/JsonWebTokenTests.cs
+++ b/tests/Test.ADAL.NET.Unit/JsonWebTokenTests.cs
@@ -114,6 +114,7 @@ namespace Test.ADAL.NET.Unit
 
             //Check for empty x5c claim
             HttpMessageHandlerFactory.AddMockHandler(EmptyX5CMockHandler);
+            context.TokenCache.Clear();
             result = await context.AcquireTokenAsync(TestConstants.DefaultResource, clientAssertion, false);
             Assert.IsNotNull(result.AccessToken);
         }

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -85,6 +85,7 @@
     <Compile Include="AuthenticationParametersTests.cs" />
     <Compile Include="ClaimsChallengeExceptionTests.cs" />
     <Compile Include="Common\AssertException.cs" />
+    <Compile Include="JsonWebTokenTests.cs" />
     <Compile Include="LoggerCallbackTests.cs" />
     <Compile Include="Mocks\MockHelpers.cs" />
     <Compile Include="Mocks\MockHttpMessageHandler.cs" />

--- a/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
+++ b/tests/Test.ADAL.NET.Unit/Test.ADAL.NET.Unit.csproj
@@ -84,6 +84,7 @@
     <Compile Include="AdalDotNetTests.cs" />
     <Compile Include="AuthenticationParametersTests.cs" />
     <Compile Include="ClaimsChallengeExceptionTests.cs" />
+    <Compile Include="ClientAssertionTestImplementation.cs" />
     <Compile Include="Common\AssertException.cs" />
     <Compile Include="JsonWebTokenTests.cs" />
     <Compile Include="LoggerCallbackTests.cs" />

--- a/tests/Test.ADAL.NET.Unit/TestConstants.cs
+++ b/tests/Test.ADAL.NET.Unit/TestConstants.cs
@@ -12,6 +12,7 @@ namespace Test.ADAL.NET.Unit
         public static readonly string TenantSpecificAuthority = $"https://login.microsoftonline.com/{SomeTenantId}/";
         public static readonly string DefaultAuthorityGuestTenant = "https://login.microsoftonline.com/guest/";
         public static readonly string DefaultAuthorityCommonTenant = "https://login.microsoftonline.com/common/";
+        public static readonly string DefaultThumbprint = "some_thumbprint";
         public static readonly string DefaultClientId = "client_id";
         public static readonly string DefaultUniqueId = "unique_id";
         public static readonly string DefaultDisplayableId = "displayable@id.com";


### PR DESCRIPTION
Proposed implementation of X5C public certificate claim.
This claim is not sent by default so the user needs to opt in to send it.
Changing public API with changes to AuthenticationContext.cs Ln:763