### PR TITLE
WebBrowserNavigateErrorEventHandler namespace change breaks public API

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/CustomWebBrowser.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/CustomWebBrowser.cs
@@ -182,8 +182,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
                 if (msg.message != WM_CHAR && (ModifierKeys == Keys.Shift || ModifierKeys == Keys.Alt ||
                                                ModifierKeys == Keys.Control))
                 {
-                    int num = (int) msg.wParam | (int) ModifierKeys;
-                    Shortcut s = (Shortcut) num;
+                    int num = (int)msg.wParam | (int)ModifierKeys;
+                    Shortcut s = (Shortcut)num;
                     if (shortcutBlacklist.Contains(s))
                     {
                         return S_OK;
@@ -262,6 +262,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         public event WebBrowserNavigateErrorEventHandler NavigateError;
     }
 
+}
+
+namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
+{ 
     /// <summary>
     /// Delegate to handle navifation errors in the browser control
     /// </summary>


### PR DESCRIPTION
WebBrowserNavigateErrorEventHandler  was in Microsoft.IdentityModel.Clients.ActiveDirectory.Internal in ADAL.Net 3.17.3, and therefore changing the namespace of all this file to Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform constituted a public API breaking change (even if the delegate was not used by customers)

Restoring the namespace for this type only (WebBrowserNavigateErrorEventHandler) to fix #954 