### PR TITLE
fixing issues related to incorrect parameters send in broker requests

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -110,7 +110,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
             brokerParameters[BrokerParameter.Resource] = requestData.Resource;
             brokerParameters[BrokerParameter.ClientId] = requestData.ClientKey.ClientId;
             brokerParameters[BrokerParameter.CorrelationId] = this.CallState.CorrelationId.ToString();
-            brokerParameters[BrokerParameter.ClientVersion] = AdalIdHelper.GetAdalVersion();
+            brokerParameters[BrokerParameter.ClientVersion] = AdalIdHelper.GetAssemblyFileVersion();
+
             this.ResultEx = null;
 
             CacheQueryData.ExtendedLifeTimeEnabled = requestData.ExtendedLifeTimeEnabled;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenInteractiveHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenInteractiveHandler.cs
@@ -97,6 +97,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
                 CallState.Logger.VerbosePii(CallState, msg);
 
                 this.claims = claims;
+                this.brokerParameters[BrokerParameter.Claims] = claims;
             }
             else
             {
@@ -116,7 +117,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
 
             this.brokerParameters[BrokerParameter.RedirectUri] = this.redirectUri.AbsoluteUri;
             this.brokerParameters[BrokerParameter.ExtraQp] = extraQueryParameters;
-            this.brokerParameters[BrokerParameter.Claims] = claims;
             brokerHelper.PlatformParameters = authorizationParameters;
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AuthenticationRequest.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AuthenticationRequest.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows;
 using System;
 using System.Collections.Generic;
 
@@ -68,10 +69,17 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
                 RedirectUri = brokerPayload["redirect_uri"];
             }
 
-            if (brokerPayload.ContainsKey("username"))
+            if (brokerPayload.ContainsKey(BrokerParameter.Username))
             {
-                LoginHint = brokerPayload["username"];
-                BrokerAccountName = LoginHint;
+                if (brokerPayload[BrokerParameter.UsernameType].Equals(UserIdentifierType.UniqueId.ToString()))
+                {
+                    UserId = brokerPayload["username"];
+                }
+                else
+                {
+                    LoginHint = brokerPayload["username"];
+                    BrokerAccountName = LoginHint;
+                }
             }
 
             if (brokerPayload.ContainsKey("extra_qp"))

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AuthenticationRequest.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AuthenticationRequest.cs
@@ -61,37 +61,37 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
         public AuthenticationRequest(IDictionary<string, string> brokerPayload)
         {
-            Authority = brokerPayload["authority"];
-            Resource = brokerPayload["resource"];
-            ClientId = brokerPayload["client_id"];
-            if (brokerPayload.ContainsKey("redirect_uri"))
+            Authority = brokerPayload[BrokerParameter.Authority];
+            Resource = brokerPayload[BrokerParameter.Resource];
+            ClientId = brokerPayload[BrokerParameter.ClientId];
+            if (brokerPayload.ContainsKey(BrokerParameter.RedirectUri))
             {
-                RedirectUri = brokerPayload["redirect_uri"];
+                RedirectUri = brokerPayload[BrokerParameter.RedirectUri];
             }
 
             if (brokerPayload.ContainsKey(BrokerParameter.Username))
             {
                 if (brokerPayload[BrokerParameter.UsernameType].Equals(UserIdentifierType.UniqueId.ToString()))
                 {
-                    UserId = brokerPayload["username"];
+                    UserId = brokerPayload[BrokerParameter.Username];
                 }
                 else
                 {
-                    LoginHint = brokerPayload["username"];
+                    LoginHint = brokerPayload[BrokerParameter.Username];
                     BrokerAccountName = LoginHint;
                 }
             }
 
-            if (brokerPayload.ContainsKey("extra_qp"))
+            if (brokerPayload.ContainsKey(BrokerParameter.ExtraQp))
             {
-                ExtraQueryParamsAuthentication = brokerPayload["extra_qp"];
+                ExtraQueryParamsAuthentication = brokerPayload[BrokerParameter.ExtraQp];
             }
 
-            CorrelationId = Guid.Parse(brokerPayload["correlation_id"]);
-            Version = brokerPayload["client_version"];
+            CorrelationId = Guid.Parse(brokerPayload[BrokerParameter.CorrelationId]);
+            Version = brokerPayload[BrokerParameter.ClientVersion];
 
-            if (brokerPayload.ContainsKey("claims")) {
-                Claims = brokerPayload["claims"];
+            if (brokerPayload.ContainsKey(BrokerParameter.Claims)) {
+                Claims = brokerPayload[BrokerParameter.Claims];
             }
         }
     }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerConstants.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerConstants.cs
@@ -150,7 +150,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
          * component.
          */
         public const string Signature = "1L4Z9FJCgn5c0VLhyAxC5O9LdlE=";
-        
+
         /**
          * Signature info for Azure authenticator app that installs authenticator
          * component.
@@ -174,6 +174,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         public const string BrowserExtInstallPrefix = "msauth://";
 
         public const string CallerInfoPackage = "caller.info.package";
+
+        public const string CallerInfoUid = "caller.info.uid";
 
         // Claims step-up. Skip cache look up
         public const string SkipCache = "skip.cache";

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerProxy.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/BrokerProxy.cs
@@ -477,6 +477,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
             brokerOptions.PutString(BrokerConstants.AccountLoginHint, username);
             brokerOptions.PutString(BrokerConstants.AccountName, username);
 
+            brokerOptions.PutString(BrokerConstants.CallerInfoPackage, mContext.PackageName);
+            brokerOptions.PutInt(BrokerConstants.CallerInfoUid, Process.MyUid());
+
             return brokerOptions;
         }
 


### PR DESCRIPTION
- Sending correct user id to android broker for the case of silent flow + user id of Unique Type
- Fixing issue with always sending skip cache parameter to IOS Broker
- sending caller.info.package and caller.info.uid  to android Broker as hot fix to "recent" breaking change from they side
- use AssemblyFileVersion instead of AssemblyVersion as value for ClientVersion broker parameter 