### PR TITLE
Jennyf/hotfix2

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/ClientCreds/ClientKey.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/ClientCreds/ClientKey.cs
@@ -47,7 +47,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.ClientCreds
 
         public ClientKey(ClientCredential clientCredential)
         {
-            this.Credential = clientCredential ?? throw new ArgumentNullException(nameof(clientCredential));
+            if (clientCredential == null)
+            {
+                throw new ArgumentNullException(nameof(clientCredential));
+            }
+            this.Credential = clientCredential;
+
             this.ClientId = clientCredential.ClientId;
             this.HasCredential = true;
         }
@@ -55,14 +60,24 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.ClientCreds
         public ClientKey(IClientAssertionCertificate clientCertificate, Authenticator authenticator)
         {
             this.Authenticator = authenticator;
-            this.Certificate = clientCertificate ?? throw new ArgumentNullException(nameof(clientCertificate));
+            if (clientCertificate == null)
+            {
+                throw new ArgumentNullException(nameof(clientCertificate));
+            }
+            this.Certificate = clientCertificate;
+
             this.ClientId = clientCertificate.ClientId;
             this.HasCredential = true;
         }
 
         public ClientKey(ClientAssertion clientAssertion)
         {
-            this.Assertion = clientAssertion ?? throw new ArgumentNullException(nameof(clientAssertion));
+            if (clientAssertion == null)
+            {
+                throw new ArgumentNullException(nameof(clientAssertion));
+            }
+            this.Assertion = clientAssertion;
+
             this.ClientId = clientAssertion.ClientId;
             this.HasCredential = true;
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -110,7 +110,13 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
             brokerParameters[BrokerParameter.Resource] = requestData.Resource;
             brokerParameters[BrokerParameter.ClientId] = requestData.ClientKey.ClientId;
             brokerParameters[BrokerParameter.CorrelationId] = this.CallState.CorrelationId.ToString();
-            brokerParameters[BrokerParameter.ClientVersion] = AdalIdHelper.GetAssemblyFileVersion();
+
+            var adalVersion = AdalIdHelper.GetAdalVersion();
+            if (AdalIdHelper.VersionNotDetermined.Equals(adalVersion))
+            {
+                adalVersion = AdalIdHelper.GetAssemblyFileVersion();
+            }
+            brokerParameters[BrokerParameter.ClientVersion] = adalVersion;
 
             this.ResultEx = null;
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Helpers/AdalIdHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Helpers/AdalIdHelper.cs
@@ -68,6 +68,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Helpers
     internal static class AdalIdHelper
     {
         private static readonly Regex AdalVersionRegex = new Regex(@"Version=[\d]+.[\d+]+.[\d]+.[\d]+", RegexOptions.CultureInvariant);
+        internal static readonly string VersionNotDetermined = "0.0.0.0";
 
         public static IDictionary<string, string> GetAdalIdParameters()
         {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Instance/Authenticator.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Instance/Authenticator.cs
@@ -109,7 +109,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Instance
 
                 if (this.AuthorityType == AuthorityType.AAD)
                 {
-                    var metadata = await InstanceDiscovery.GetMetadataEntry(authorityUri, this.ValidateAuthority, callState);
+                    var metadata = await InstanceDiscovery.GetMetadataEntry(authorityUri, this.ValidateAuthority, callState).ConfigureAwait(false);
                     host = metadata.PreferredNetwork;
                     // All the endpoints will use this updated host, and it affects future network calls, as desired.
                     // The Authority remains its original host, and will be used in TokenCache later.


### PR DESCRIPTION
Due to missing ConfigureAwait(false) in one method, deadlock was created when calling UI context without specifying ConfigureAwait(false) - basically passing the context