### PR TITLE
Fix VSTS build warning - cannot find "TestMexMalformed.xml" in federa…

### DIFF
--- a/tests/Test.ADAL.NET.Integration/AcquireTokenSilentTests.cs
+++ b/tests/Test.ADAL.NET.Integration/AcquireTokenSilentTests.cs
@@ -80,7 +80,7 @@ namespace Test.ADAL.NET.Integration
                 });
             
             Assert.AreEqual(AdalError.FailedToAcquireTokenSilently, ex.ErrorCode);
-            Assert.AreEqual(AdalErrorMessage.FailedToRefreshToken, ex.Message);
+            Assert.AreEqual(AdalErrorMessage.FailedToAcquireTokenSilently, ex.Message);
             Assert.IsNotNull(ex.InnerException);
             Assert.IsTrue(ex.InnerException is AdalException);
             Assert.AreEqual(((AdalException)ex.InnerException).ErrorCode, "invalid_grant");

--- a/tests/Test.ADAL.NET.Integration/FederatedUserCredentialTests.cs
+++ b/tests/Test.ADAL.NET.Integration/FederatedUserCredentialTests.cs
@@ -47,7 +47,6 @@ namespace Test.ADAL.NET.Integration
     [DeploymentItem("TestMex.xml")]
     [DeploymentItem("WsTrustResponse.xml")]
     [DeploymentItem("WsTrustResponse13.xml")]
-    [DeploymentItem("TestMexMalformed.xml")]
     public class FederatedUserCredentialTests
     {
         [TestInitialize]

--- a/tests/Test.ADAL.NET.Unit/BrokerParametersTests.cs
+++ b/tests/Test.ADAL.NET.Unit/BrokerParametersTests.cs
@@ -83,7 +83,7 @@ namespace Test.ADAL.NET.Unit
             Assert.AreEqual(ClientId, brokerParams[BrokerParameter.ClientId]);
 
             Assert.AreEqual(acquireTokenInteractiveHandler.CallState.CorrelationId.ToString(), brokerParams[BrokerParameter.CorrelationId]);
-            Assert.AreEqual(AdalIdHelper.GetAdalVersion(), brokerParams[BrokerParameter.ClientVersion]);
+            Assert.AreEqual(AdalIdHelper.GetAssemblyFileVersion(), brokerParams[BrokerParameter.ClientVersion]);
             Assert.AreEqual("NO", brokerParams[BrokerParameter.Force]);
             Assert.AreEqual(string.Empty, brokerParams[BrokerParameter.Username]);
             Assert.AreEqual(UserIdentifierType.OptionalDisplayableId.ToString(), brokerParams[BrokerParameter.UsernameType]);
@@ -108,7 +108,7 @@ namespace Test.ADAL.NET.Unit
             Assert.AreEqual(Resource, brokerParams[BrokerParameter.Resource]);
             Assert.AreEqual(ClientId, brokerParams[BrokerParameter.ClientId]);
             Assert.AreEqual(acquireTokenSilentHandler.CallState.CorrelationId.ToString(), brokerParams[BrokerParameter.CorrelationId]);
-            Assert.AreEqual(AdalIdHelper.GetAdalVersion(), brokerParams[BrokerParameter.ClientVersion]);
+            Assert.AreEqual(AdalIdHelper.GetAssemblyFileVersion(), brokerParams[BrokerParameter.ClientVersion]);
             Assert.AreEqual(UniqueUserId, brokerParams[BrokerParameter.Username]);
             Assert.AreEqual(UserIdentifierType.UniqueId.ToString(), brokerParams[BrokerParameter.UsernameType]);
 


### PR DESCRIPTION
…ted tests..this is not needed. have removed

Fix VSTS build error AdalIdHelper.GetAdalVersion always returns 0.0.0.0, we need to use GetAssemblyFileVerison(), which should return the match.