### PR TITLE
Jmprieur/fix989

### DIFF
--- a/build/Microsoft.IdentityModel.Clients.ActiveDirectory.nuspec
+++ b/build/Microsoft.IdentityModel.Clients.ActiveDirectory.nuspec
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+﻿<?xml version="1.0"?>
 <package >
   <metadata minClientVersion="2.8.6">
     <title>Active Directory Authentication Library</title>
@@ -8,11 +8,9 @@
     <licenseUrl>https://go.microsoft.com/fwlink/?linkid=841311</licenseUrl>
     <projectUrl>https://aka.ms/adalnet</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
-    <description>
-      ADAL.NET enables you to acquire a security token to access protected Web APIs, for instance Microsoft Graph or your own Web API.
-      It's a .NET Standard class library which you can consume on various .NET client platforms (including Windows desktop, UWP, Windows 8.1, Xamarin iOS and Xamarin Android)
-      but also you Web applications and Web APIs (ASP.NET, .NET Core, ASP.NET Core) that call other Web APIs in the name of a user, or without a user.
-      ADAL.NET takes advantage of Windows Server Active Directory and Azure Active Directory (Azure AD).
+    <description>ADAL.NET enables you to acquire a security token to access protected Web APIs, for instance Microsoft Graph or your own Web API.
+ADAL.NET is a .NET Standard class library which you can consume on various .NET client platforms (including Windows desktop, UWP, Windows 8.1, Xamarin iOS and Xamarin Android) but also you Web applications and Web APIs (ASP.NET, .NET Core, ASP.NET Core) that call other Web APIs in the name of a user, or without a user.
+ADAL.NET takes advantage of Windows Server Active Directory and Azure Active Directory (Azure AD).
     </description>
     <summary>This package contains the binaries of the Active Directory Authentication Library (ADAL). ADAL provides easy to use authentication functionality for your .NET based client by taking advantage of Windows Server Active Directory and Azure Active Directory.</summary>
     <language>en-US</language>

--- a/build/Microsoft.IdentityModel.Clients.ActiveDirectory.nuspec
+++ b/build/Microsoft.IdentityModel.Clients.ActiveDirectory.nuspec
@@ -1,31 +1,36 @@
 <?xml version="1.0"?>
 <package >
-    <metadata minClientVersion="2.8.6">
-        <title>Active Directory Authentication Library</title>
-        <id>Microsoft.IdentityModel.Clients.ActiveDirectory</id>
-        <version>0.0.1-LOCALBUILD</version>
-        <authors>Microsoft</authors>
-        <licenseUrl>https://go.microsoft.com/fwlink/?linkid=841311</licenseUrl>
-        <projectUrl>https://aka.ms/adalnet</projectUrl>
-        <requireLicenseAcceptance>true</requireLicenseAcceptance>
-        <description>This package contains the binaries of the Active Directory Authentication Library (ADAL). ADAL provides a .NET Standard class library with easy to use authentication functionality for your .NET client on various platforms including Windows desktop, Windows Store, Xamarin iOS and Xamarin Android by taking advantage of Windows Server Active Directory and Azure Active Directory.</description>
-        <summary>This package contains the binaries of the Active Directory Authentication Library (ADAL). ADAL provides easy to use authentication functionality for your .NET based client by taking advantage of Windows Server Active Directory and Azure Active Directory.</summary>
-        <language>en-US</language>
-        <owners>Microsoft Open Technologies</owners>
-        <tags>Active Directory Authentication Library, ADAL, Active Directory, Azure Active Directory, AD, AAD, Identity, Authentication, .NET, Windows Store, Xamarin iOS, Xamarin Android</tags>
-        <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+  <metadata minClientVersion="2.8.6">
+    <title>Active Directory Authentication Library</title>
+    <id>Microsoft.IdentityModel.Clients.ActiveDirectory</id>
+    <version>0.0.1-LOCALBUILD</version>
+    <authors>Microsoft</authors>
+    <licenseUrl>https://go.microsoft.com/fwlink/?linkid=841311</licenseUrl>
+    <projectUrl>https://aka.ms/adalnet</projectUrl>
+    <requireLicenseAcceptance>true</requireLicenseAcceptance>
+    <description>
+      <a href="https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki">ADAL.NET</a> enables you to acquire a security token to access protected Web APIs, for instance Microsoft Graph or your own Web API.
+      It's a .NET Standard class library which you can consume on various .NET client platforms (including Windows desktop, UWP, Windows 8.1, Xamarin iOS and Xamarin Android)
+      but also you Web applications and Web APIs (ASP.NET, .NET Core, ASP.NET Core) that call other Web APIs in the name of a user, or without a user.
+      ADAL.NET takes advantage of Windows Server Active Directory and Azure Active Directory (Azure AD).
+    </description>
+    <summary>This package contains the binaries of the Active Directory Authentication Library (ADAL). ADAL provides easy to use authentication functionality for your .NET based client by taking advantage of Windows Server Active Directory and Azure Active Directory.</summary>
+    <language>en-US</language>
+    <owners>Microsoft Open Technologies</owners>
+    <tags>Active Directory Authentication Library, ADAL, Active Directory, Azure Active Directory, AD, AAD, Identity, Authentication, .NET, Windows Store, Xamarin iOS, Xamarin Android</tags>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
 
     <dependencies>
-		<group targetFramework="netstandard1.4">
-			<dependency id="NETStandard.Library" version="1.6" />
-			<dependency id="System.Runtime.Serialization.Json" version="4.3.0" />
-			<dependency id="System.Runtime.Serialization.Primitives" version="4.3.0" />
-		</group>
-		<group targetFramework="netcore45"/>
-		<group targetFramework="net45"/>
-		<group targetFramework="portable-net45+win8"/>
-		<group targetFramework="MonoAndroid10"/>
-		<group targetFramework=" Xamarin.iOS10"/>
+      <group targetFramework="netstandard1.4">
+        <dependency id="NETStandard.Library" version="1.6" />
+        <dependency id="System.Runtime.Serialization.Json" version="4.3.0" />
+        <dependency id="System.Runtime.Serialization.Primitives" version="4.3.0" />
+      </group>
+      <group targetFramework="netcore45"/>
+      <group targetFramework="net45"/>
+      <group targetFramework="portable-net45+win8"/>
+      <group targetFramework="MonoAndroid10"/>
+      <group targetFramework=" Xamarin.iOS10"/>
     </dependencies>
-    </metadata>
+  </metadata>
 </package>

--- a/build/Microsoft.IdentityModel.Clients.ActiveDirectory.nuspec
+++ b/build/Microsoft.IdentityModel.Clients.ActiveDirectory.nuspec
@@ -9,7 +9,7 @@
     <projectUrl>https://aka.ms/adalnet</projectUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <description>
-      <a href="https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki">ADAL.NET</a> enables you to acquire a security token to access protected Web APIs, for instance Microsoft Graph or your own Web API.
+      ADAL.NET enables you to acquire a security token to access protected Web APIs, for instance Microsoft Graph or your own Web API.
       It's a .NET Standard class library which you can consume on various .NET client platforms (including Windows desktop, UWP, Windows 8.1, Xamarin iOS and Xamarin Android)
       but also you Web applications and Web APIs (ASP.NET, .NET Core, ASP.NET Core) that call other Web APIs in the name of a user, or without a user.
       ADAL.NET takes advantage of Windows Server Active Directory and Azure Active Directory (Azure AD).


### PR DESCRIPTION
This rewords the description of the ADAL.NET NuGet package so that searching for "secure API", or "token for protected API", or "access token" finds ADAL.Net
See #989 