### PR TITLE
Sagonzal/correlation

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -199,7 +199,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 TokenCache = this.TokenCache,
                 ExtendedLifeTimeEnabled = this.ExtendedLifeTimeEnabled,
                 Resource = deviceCodeResult.Resource,
-                ClientKey = new ClientKey(deviceCodeResult.ClientId)
+                ClientKey = new ClientKey(deviceCodeResult.ClientId),
+                CorrelationId = deviceCodeResult.CorrelationId
             };
 
             var handler = new AcquireTokenByDeviceCodeHandler(requestData, deviceCodeResult);

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/DeviceCodeResult.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/DeviceCodeResult.cs
@@ -77,5 +77,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// Identifier of the target resource that would be the recipient of the token.
         /// </summary>
         public string Resource { get; internal set; }
+
+        /// <summary>
+        /// Identifier of the correlation id. Used in diagnostic purposes.
+        /// </summary>
+        public Guid CorrelationId { get; internal set; }
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -54,7 +54,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
         protected AcquireTokenHandlerBase(RequestData requestData)
         {
             this.Authenticator = requestData.Authenticator;
-            this.CallState = CreateCallState(this.Authenticator.CorrelationId);
+            this.CallState = CreateCallState(requestData.CorrelationId != Guid.Empty
+                ? requestData.CorrelationId 
+                : this.Authenticator.CorrelationId);
             brokerHelper.CallState = this.CallState;
 
             var msg = string.Format(CultureInfo.CurrentCulture,

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/OAuth2/DeviceCodeResponse.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/OAuth2/DeviceCodeResponse.cs
@@ -59,6 +59,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2
         [DataMember(Name = "error_description", IsRequired = false)]
         public string ErrorDescription { get; internal set; }
 
+        [DataMember(Name = "client-request-id", IsRequired =false)]
+        public Guid CorrelationId { get; internal set; }
+
         public DeviceCodeResult GetResult(string clientId, string resource)
         {
             return new DeviceCodeResult()
@@ -70,7 +73,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2
                 Interval = this.Interval,
                 VerificationUrl = this.VerificationUrl,
                 ClientId = clientId,
-                Resource = resource
+                Resource = resource,
+                CorrelationId = this.CorrelationId
             };
         }
     }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/RequestData.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/RequestData.cs
@@ -50,5 +50,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
 
         public bool ExtendedLifeTimeEnabled { get; set; }
 
+        public Guid CorrelationId { get; set; }
     }
 }

--- a/tests/Test.ADAL.NET.Common/TestConstants.cs
+++ b/tests/Test.ADAL.NET.Common/TestConstants.cs
@@ -57,6 +57,7 @@ namespace Test.ADAL.NET.Common
         public static readonly string TokenEndPoint = "oauth2/token";
         public static readonly string UserRealmEndPoint = "userrealm";
         public static readonly string DiscoveryEndPoint = "discovery/instance";
+        public static readonly Guid CorrelationId = new Guid("8efe4c4f-ec26-4044-b9e3-ab8cea76c418");
 
         public static string GetTokenEndpoint(string Authority)
         {

--- a/tests/Test.ADAL.NET.Unit/DeviceCodeFlowTests.cs
+++ b/tests/Test.ADAL.NET.Unit/DeviceCodeFlowTests.cs
@@ -98,7 +98,7 @@ namespace Test.ADAL.NET.Unit
         }
 
         [TestMethod]
-        [Description("Test CorrelationId is being correctly set")]
+        [Description("Test CorrelationId is being correctly set correctly")]
         public void CorrelationIdTest()
         {
             DeviceCodeResult dcr = new DeviceCodeResult()


### PR DESCRIPTION
Device code flow makes two API calls, which were previously using different `CorrelationIds`. They are "one business transaction" and should therefore use the same Id. 