### PR TITLE
Jennyf/console log

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 3.19.2
+==============
+This hotfix release includes:
+- Fix for an issue with web UI failure on UWP platform
+
 Version 3.19.1
 ==============
 This hotfix release includes:

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/Logger.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/Logger.cs
@@ -41,12 +41,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
         internal override void DefaultLog(LogLevel logLevel, string message)
         {
-#if NETSTANDARD1_3
-
-            Console.WriteLine(message);
-#else
             AdalEventSource.Error(message);
-#endif
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -110,13 +110,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
             brokerParameters[BrokerParameter.Resource] = requestData.Resource;
             brokerParameters[BrokerParameter.ClientId] = requestData.ClientKey.ClientId;
             brokerParameters[BrokerParameter.CorrelationId] = this.CallState.CorrelationId.ToString();
-
-            var adalVersion = AdalIdHelper.GetAdalVersion();
-            if (AdalIdHelper.VersionNotDetermined.Equals(adalVersion))
-            {
-                adalVersion = AdalIdHelper.GetAssemblyFileVersion();
-            }
-            brokerParameters[BrokerParameter.ClientVersion] = adalVersion;
+            brokerParameters[BrokerParameter.ClientVersion] = AdalIdHelper.GetClientVersion();
 
             this.ResultEx = null;
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Helpers/AdalIdHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Helpers/AdalIdHelper.cs
@@ -116,6 +116,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Helpers
             return new PlatformInformation().GetAssemblyFileVersionAttribute();
         }
 
+        public static string GetClientVersion()
+        {
+            var clientVersion = AdalIdHelper.GetAdalVersion();
+            if (AdalIdHelper.VersionNotDetermined.Equals(clientVersion))
+            {
+                clientVersion = AdalIdHelper.GetAssemblyFileVersion();
+            }
+            return clientVersion;
+        }
+
         public static string GetAssemblyInformationalVersion()
         {
             AssemblyInformationalVersionAttribute attribute = typeof(AdalIdHelper).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/AssemblyInfo.cs
@@ -39,7 +39,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyFileVersion("3.19.1.0")]
+[assembly: AssemblyFileVersion("3.19.2.0")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/tests/Test.ADAL.NET.Unit/BrokerParametersTests.cs
+++ b/tests/Test.ADAL.NET.Unit/BrokerParametersTests.cs
@@ -83,7 +83,7 @@ namespace Test.ADAL.NET.Unit
             Assert.AreEqual(ClientId, brokerParams[BrokerParameter.ClientId]);
 
             Assert.AreEqual(acquireTokenInteractiveHandler.CallState.CorrelationId.ToString(), brokerParams[BrokerParameter.CorrelationId]);
-            Assert.AreEqual(AdalIdHelper.GetAssemblyFileVersion(), brokerParams[BrokerParameter.ClientVersion]);
+            Assert.AreEqual(AdalIdHelper.GetClientVersion(), brokerParams[BrokerParameter.ClientVersion]);
             Assert.AreEqual("NO", brokerParams[BrokerParameter.Force]);
             Assert.AreEqual(string.Empty, brokerParams[BrokerParameter.Username]);
             Assert.AreEqual(UserIdentifierType.OptionalDisplayableId.ToString(), brokerParams[BrokerParameter.UsernameType]);
@@ -108,7 +108,7 @@ namespace Test.ADAL.NET.Unit
             Assert.AreEqual(Resource, brokerParams[BrokerParameter.Resource]);
             Assert.AreEqual(ClientId, brokerParams[BrokerParameter.ClientId]);
             Assert.AreEqual(acquireTokenSilentHandler.CallState.CorrelationId.ToString(), brokerParams[BrokerParameter.CorrelationId]);
-            Assert.AreEqual(AdalIdHelper.GetAssemblyFileVersion(), brokerParams[BrokerParameter.ClientVersion]);
+            Assert.AreEqual(AdalIdHelper.GetClientVersion(), brokerParams[BrokerParameter.ClientVersion]);
             Assert.AreEqual(UniqueUserId, brokerParams[BrokerParameter.Username]);
             Assert.AreEqual(UserIdentifierType.UniqueId.ToString(), brokerParams[BrokerParameter.UsernameType]);
 


### PR DESCRIPTION
Addressing issue #1028 - removing Console.WriteLine. Now default logging on NetStandard1.2 will not log to the Console, but logging can still be pushed to the console by setting the [callback](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/wiki/Logging-in-ADAL.Net)