### PR TITLE
Removing Console.WriteLine from WinCommon

### DIFF
--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AdalLogger.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AdalLogger.cs
@@ -46,12 +46,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
         internal override void DefaultLog(LogLevel logLevel, string message)
         {
-#if NETSTANDARD1_3
-
-            Console.WriteLine(message);
-#else
             AdalEventSource.Error(message);
-#endif
         }
     }
 }


### PR DESCRIPTION
Addressing issue #1028 - removing Console.WriteLine. Now default logging on NetStandard1.2 will not log to the Console, but logging can still be pushed to the console by setting the callback