### PR TITLE
removing console.writeLine from WinCommon

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/Logger.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/Logger.cs
@@ -25,9 +25,6 @@
 //
 //------------------------------------------------------------------------------
 
-using System;
-using System.Globalization;
-
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 {
     internal class Logger : LoggerBase
@@ -41,12 +38,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
         internal override void DefaultLog(LogLevel logLevel, string message)
         {
-#if NETSTANDARD1_3
-
-            Console.WriteLine(message);
-#else
             AdalEventSource.Error(message);
-#endif
         }
     }
 }


### PR DESCRIPTION
Addressing issue #1028 - removing Console.WriteLine. Now default logging on NetStandard1.2 will not log to the Console, but logging can still be pushed to the console by setting the callback