### PR TITLE
Trwalke/add x5c claim to auth code client credential flow

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -682,6 +682,29 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                 new ClientKey(clientCertificate, Authenticator), resource).ConfigureAwait(false);
         }
 
+#if !(ANDROID || iOS || WINDOWS_APP)
+        /// <summary>
+        /// Acquires security token from the authority using an authorization code previously received.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="AuthenticationContext.AcquireTokenSilentAsync(string, string, UserIdentifier)"/>.
+        /// </summary>
+        /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
+        /// <param name="redirectUri">The redirect address used for obtaining authorization code.</param>
+        /// <param name="clientCertificate">The client certificate to use for token acquisition.</param>
+        /// <param name="resource">Identifier of the target resource that is the recipient of the requested token. It can be null if provided earlier to acquire authorizationCode.</param>
+        /// <param name="sendX5c">This parameter enables application developers to achieve easy certificates roll-over
+        /// in Azure AD: setting this parameter to true will send the public certificate to Azure AD
+        /// along with the token request, so that Azure AD can use it to validate the subject name based on a trusted issuer policy.
+        /// This saves the application admin from the need to explicitly manage the certificate rollover
+        /// (either via portal or powershell/CLI operation)</param>
+        /// <returns>It contains Access Token, its expiration time, user information.</returns>
+        public async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeAsync(string authorizationCode,
+            Uri redirectUri, IClientAssertionCertificate clientCertificate, string resource, bool sendX5c)
+        {
+            return await AcquireTokenByAuthorizationCodeCommonAsync(authorizationCode, redirectUri,
+                new ClientKey(clientCertificate, Authenticator) { SendX5c = sendX5c }, resource).ConfigureAwait(false);
+        }
+#endif
+
         /// <summary>
         /// Acquires an access token from the authority on behalf of a user. It requires using a user token previously received.
         /// </summary>

--- a/tests/Test.ADAL.NET.Common/TestConstants.cs
+++ b/tests/Test.ADAL.NET.Common/TestConstants.cs
@@ -57,6 +57,7 @@ namespace Test.ADAL.NET.Common
         public static readonly string TokenEndPoint = "oauth2/token";
         public static readonly string UserRealmEndPoint = "userrealm";
         public static readonly string DiscoveryEndPoint = "discovery/instance";
+        public static readonly string DefaultAuthorizationCode = "AwABAAAAvPM1KaPlrEqdFSBzjqfTGBCmLdgfSTLEMPGYuNHSUYBrqqf_ZT_p5uEAEJJ_nZ3UmphWygRNy2C3jJ239gV_DBnZ2syeg95Ki-374WHUP-i3yIhv5i-7KU2CEoPXwURQp6IVYMw-DjAOzn7C3JCu5wpngXmbZKtJdWmiBzHpcO2aICJPu1KvJrDLDP20chJBXzVYJtkfjviLNNW7l7Y3ydcHDsBRKZc3GuMQanmcghXPyoDg41g8XbwPudVh7uCmUponBQpIhbuffFP_tbV8SNzsPoFz9CLpBCZagJVXeqWoYMPe2dSsPiLO9Alf_YIe5zpi-zY4C3aLw5g9at35eZTfNd0gBRpR5ojkMIcZZ6IgAA";
         public static readonly Guid CorrelationId = new Guid("8efe4c4f-ec26-4044-b9e3-ab8cea76c418");
 
         public static string GetTokenEndpoint(string Authority)

--- a/tests/Test.ADAL.NET.Unit/JsonWebTokenTests.cs
+++ b/tests/Test.ADAL.NET.Unit/JsonWebTokenTests.cs
@@ -123,8 +123,7 @@ namespace Test.ADAL.NET.Unit
             Assert.IsNotNull(result.AccessToken);
 
             HttpMessageHandlerFactory.AddMockHandler(X5CMockHandler);
-            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource,
-                true).ConfigureAwait(false);
+            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource, true).ConfigureAwait(false);
             Assert.IsNotNull(result.AccessToken);
 
             //Check for empty x5c claim
@@ -134,8 +133,7 @@ namespace Test.ADAL.NET.Unit
             Assert.IsNotNull(result.AccessToken);
 
             HttpMessageHandlerFactory.AddMockHandler(EmptyX5CMockHandler);
-            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource,
-                false).ConfigureAwait(false);
+            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource, false).ConfigureAwait(false);
             Assert.IsNotNull(result.AccessToken);
         }
 
@@ -152,8 +150,7 @@ namespace Test.ADAL.NET.Unit
             Assert.IsNotNull(result.AccessToken);
 
             HttpMessageHandlerFactory.AddMockHandler(EmptyX5CMockHandler);
-            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource)
-                .ConfigureAwait(false);
+            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource).ConfigureAwait(false);
             Assert.IsNotNull(result.AccessToken);
         }
 
@@ -170,8 +167,7 @@ namespace Test.ADAL.NET.Unit
             Assert.IsNotNull(result.AccessToken);
 
             HttpMessageHandlerFactory.AddMockHandler(EmptyX5CMockHandler);
-            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource,
-                true).ConfigureAwait(false);
+            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource, true).ConfigureAwait(false);
             Assert.IsNotNull(result.AccessToken);
         }
     }

--- a/tests/Test.ADAL.NET.Unit/JsonWebTokenTests.cs
+++ b/tests/Test.ADAL.NET.Unit/JsonWebTokenTests.cs
@@ -122,10 +122,20 @@ namespace Test.ADAL.NET.Unit
             AuthenticationResult result = await context.AcquireTokenAsync(TestConstants.DefaultResource, clientAssertion, true).ConfigureAwait(false);
             Assert.IsNotNull(result.AccessToken);
 
+            HttpMessageHandlerFactory.AddMockHandler(X5CMockHandler);
+            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource,
+                true).ConfigureAwait(false);
+            Assert.IsNotNull(result.AccessToken);
+
             //Check for empty x5c claim
             HttpMessageHandlerFactory.AddMockHandler(EmptyX5CMockHandler);
             context.TokenCache.Clear();
             result = await context.AcquireTokenAsync(TestConstants.DefaultResource, clientAssertion, false).ConfigureAwait(false);
+            Assert.IsNotNull(result.AccessToken);
+
+            HttpMessageHandlerFactory.AddMockHandler(EmptyX5CMockHandler);
+            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource,
+                false).ConfigureAwait(false);
             Assert.IsNotNull(result.AccessToken);
         }
 
@@ -138,8 +148,12 @@ namespace Test.ADAL.NET.Unit
             var context = new AuthenticationContext(TestConstants.TenantSpecificAuthority, new TokenCache());
 
             HttpMessageHandlerFactory.AddMockHandler(EmptyX5CMockHandler);
-
             AuthenticationResult result = await context.AcquireTokenAsync(TestConstants.DefaultResource, clientAssertion).ConfigureAwait(false);
+            Assert.IsNotNull(result.AccessToken);
+
+            HttpMessageHandlerFactory.AddMockHandler(EmptyX5CMockHandler);
+            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource)
+                .ConfigureAwait(false);
             Assert.IsNotNull(result.AccessToken);
         }
 
@@ -152,8 +166,12 @@ namespace Test.ADAL.NET.Unit
             var context = new AuthenticationContext(TestConstants.TenantSpecificAuthority, new TokenCache());
 
             HttpMessageHandlerFactory.AddMockHandler(EmptyX5CMockHandler);
-
             AuthenticationResult result = await context.AcquireTokenAsync(TestConstants.DefaultResource, clientAssertion, true).ConfigureAwait(false);
+            Assert.IsNotNull(result.AccessToken);
+
+            HttpMessageHandlerFactory.AddMockHandler(EmptyX5CMockHandler);
+            result = await context.AcquireTokenByAuthorizationCodeAsync(TestConstants.DefaultAuthorizationCode, TestConstants.DefaultRedirectUri, clientAssertion, TestConstants.DefaultResource,
+                true).ConfigureAwait(false);
             Assert.IsNotNull(result.AccessToken);
         }
     }


### PR DESCRIPTION
Adding x5c claim to the AcquireTokenByAuthorizationCodeAsync for easy certificate rollover.

Added feature to unit tests and verified with fiddler

https://identitydivision.visualstudio.com/DevEx/_workitems/edit/412551
