### PR TITLE
Changing order of callback and dismissing the view controller

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/AuthenticationAgentUIViewController.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/AuthenticationAgentUIViewController.cs
@@ -93,8 +93,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
                 if (requestUrlString.StartsWith(callback, StringComparison.OrdinalIgnoreCase) || 
                     requestUrlString.StartsWith(BrokerConstants.BrowserExtInstallPrefix, StringComparison.OrdinalIgnoreCase))
                 {
-                    callbackMethod(new AuthorizationResult(AuthorizationStatus.Success, request.Url.ToString()));
-                    this.DismissViewController(true, null);
+                    this.DismissViewController(true, () =>
+                        callbackMethod(new AuthorizationResult(AuthorizationStatus.Success, request.Url.ToString())));
                     return false;
                 }
 
@@ -123,8 +123,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
                     AuthorizationResult result = new AuthorizationResult(AuthorizationStatus.ErrorHttp);
                     result.Error = AdalError.NonHttpsRedirectNotSupported;
                     result.ErrorDescription = AdalErrorMessage.NonHttpsRedirectNotSupported;
-                    callbackMethod(result);
-                    this.DismissViewController(true, null);
+                    this.DismissViewController(true, () => callbackMethod(result));
                     return false;
                 }
 
@@ -150,8 +149,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
         private void CancelAuthentication(object sender, EventArgs e)
         {
-            this.DismissViewController(true, null);
-            callbackMethod(new AuthorizationResult(AuthorizationStatus.UserCancel, null));
+            this.DismissViewController(true, () =>
+                callbackMethod(new AuthorizationResult(AuthorizationStatus.UserCancel, null)));
         }
 
         public override void DismissViewController(bool animated, Action completionHandler)

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/AuthenticationAgentUIViewController.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/AuthenticationAgentUIViewController.cs
@@ -27,9 +27,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using CoreFoundation;
-using CoreGraphics;
 using Foundation;
 using UIKit;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Helpers;
@@ -152,8 +150,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
         private void CancelAuthentication(object sender, EventArgs e)
         {
-            callbackMethod(new AuthorizationResult(AuthorizationStatus.UserCancel, null));
             this.DismissViewController(true, null);
+            callbackMethod(new AuthorizationResult(AuthorizationStatus.UserCancel, null));
         }
 
         public override void DismissViewController(bool animated, Action completionHandler)


### PR DESCRIPTION
Addressing issue #1016 
Customer reports issues with navigation stack when authentication is cancelled and we perform the callback first and then `DismissViewController`. It makes sense to shut down the UI first, especially for customers using more complex view controllers

Manually tested:
> Xamarin iOS test app
