### PR TITLE
Trwalke/ios background thread fix

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 3.19.5
+==============
+This hotfix release includes:
+- Resolved issue with iOS 11.3 where network resources are reclaimed by the system when sending the app to the background.
+
 Version 3.19.4
 ==============
 This hotfix release includes:

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,7 @@
 Version 3.19.5
 ==============
 This hotfix release includes:
-- Resolved issue with iOS 11.3 where network resources are reclaimed by the system when sending the app to the background.
+- Resolved issue with iOS 11.3 where network resources are reclaimed by the system when sending the app to the background (#1053)
 
 Version 3.19.4
 ==============

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
@@ -118,6 +118,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         private void CallbackMethod(AuthorizationResult result)
         {
             SetAuthorizationResult(result);
+            inBackground = false;
             DidEnterBackgroundNotification.Dispose();
             WillEnterForegroundNotification.Dispose();
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
@@ -59,14 +59,20 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
             //This will prevent authentication from failing while the application is moved to the background while waiting for MFA to finish.
             this.taskId = UIApplication.SharedApplication.BeginBackgroundTask(() => {
                 if (this.taskId != UIApplication.BackgroundTaskInvalid)
+                {
                     UIApplication.SharedApplication.EndBackgroundTask(this.taskId);
+                    this.taskId = UIApplication.BackgroundTaskInvalid;
+                }
             });
         }
 
         void OnMoveToForeground(NSNotification notification)
         {
             if (this.taskId != UIApplication.BackgroundTaskInvalid)
+            {
                 UIApplication.SharedApplication.EndBackgroundTask(this.taskId);
+                this.taskId = UIApplication.BackgroundTaskInvalid;
+            }
         }
 
         public async Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri, CallState callState)
@@ -116,9 +122,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
         public void Dispose()
         {
-            if (this.taskId != UIApplication.BackgroundTaskInvalid)
-                UIApplication.SharedApplication.EndBackgroundTask(this.taskId);
-
             this.didEnterBackgroundNotification.Dispose();
             this.willEnterForegroundNotification.Dispose();
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
@@ -38,7 +38,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         private static SemaphoreSlim returnedUriReady;
         private static AuthorizationResult authorizationResult;
         private PlatformParameters parameters;
-        private static Mutex mutex = new Mutex();
         private nint taskId = 0;
         private static bool inBackground;
         NSObject DidEnterBackgroundNotification, WillEnterForegroundNotification;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
@@ -39,8 +39,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         private static AuthorizationResult authorizationResult;
         private PlatformParameters parameters;
         private nint taskId = 0;
-        private static bool inBackground;
-        NSObject DidEnterBackgroundNotification, WillEnterForegroundNotification;
+        private bool inBackground;
+        private NSObject DidEnterBackgroundNotification, WillEnterForegroundNotification;
 
         public WebUI(IPlatformParameters parameters)
         {
@@ -57,7 +57,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         void OnMoveToBackground(NSNotification notification)
         {
             taskId = UIApplication.SharedApplication.BeginBackgroundTask(() => {
-                mutex.ReleaseMutex();
+                inBackground = false;
                 UIApplication.SharedApplication.EndBackgroundTask(taskId);
             });
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/AssemblyInfo.cs
@@ -39,7 +39,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyFileVersion("3.19.4.0")]
+[assembly: AssemblyFileVersion("3.19.5.0")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
Resolved issue with iOS 11.3 where network resources are reclaimed by the system when sending an app to the background.

437419

https://identitydivision.visualstudio.com/DevEx/_workitems/edit/437419

**Repro steps**
1. Launch any ios app that uses adal.
2. Try to authenticate with an account that requires MFA.
3. Switch to the broker app for MFA when prompted.(if the broker app is on another device, simply send the app      to the background with the home button)
4. Switch back to the ios app
5. Authenticate with MFA 
6. Notice that the app hangs waiting for MFA to be completed