### PR TITLE
Trwalke/fixpkey auth implementation

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 3.19.6
+==============
+This hotfix release includes:
+- Updated ADAL to follow the Public Key Authentication spec when running on a non workplace joined device (#1058)
+
 Version 3.19.5
 ==============
 This hotfix release includes:

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/winrt/DeviceAuthHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/winrt/DeviceAuthHelper.cs
@@ -52,8 +52,18 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         public static async Task<string> CreateDeviceAuthChallengeResponseAsync(IDictionary<string, string> challengeData)
         {
             string authHeaderTemplate = "PKeyAuth {0}, Context=\"{1}\", Version=\"{2}\"";
-            
-            Certificate certificate = await FindCertificate(challengeData).ConfigureAwait(false);
+            Certificate certificate = null;
+            try
+            {
+                certificate = await FindCertificate(challengeData).ConfigureAwait(false);
+            }
+            catch (AdalException ex)
+            {
+                if (ex.ErrorCode == AdalError.DeviceCertificateNotFound)
+                {
+                    return await Task.FromResult(string.Format(CultureInfo.InvariantCulture, @"PKeyAuth Context=""{0}"",Version=""{1}""", challengeData["Context"], challengeData["Version"])).ConfigureAwait(false);
+                }
+            }
             DeviceAuthJWTResponse response = new DeviceAuthJWTResponse(challengeData["SubmitUrl"],
                 challengeData["nonce"], Convert.ToBase64String(certificate.GetCertificateBlob().ToArray()));
             IBuffer input = CryptographicBuffer.ConvertStringToBinary(response.GetResponseToSign(),

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/AssemblyInfo.cs
@@ -39,7 +39,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyFileVersion("3.19.5.0")]
+[assembly: AssemblyFileVersion("3.19.6.0")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
Updated adal to follow the PKeyAuth spec when running on a non workplace joined device

https://identitydivision.visualstudio.com/DevEx/_workitems/edit/441317

This was manually tested by following the reproduction steps above and acquiring a token instead of failing with the error message.