### PR TITLE
Merging Master into Adalv3/dev (update to 3.19.6)

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,19 @@
+Version 3.19.6
+==============
+This hotfix release includes:
+- Updated ADAL to follow the Public Key Authentication spec when running on a non workplace joined device (#1058)
+
+Version 3.19.5
+==============
+This hotfix release includes:
+- Resolved issue with iOS 11.3 where network resources are reclaimed by the system when sending the app to the background (#1053)
+
+Version 3.19.4
+==============
+This hotfix release includes:
+- X5c claim added to AcquireTokenByAuthorizationCodeAsync for easy certificate rollover (#1043)
+- Filter logs for AdalEventSource based on log level in default log (#1039)
+
 Version 3.19.3
 ==============
 This hotfix release includes:

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/WebUI.cs
@@ -25,17 +25,21 @@
 //
 //------------------------------------------------------------------------------
 
+using Foundation;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using UIKit;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 {
-    internal class WebUI : IWebUI
+    internal class WebUI : IWebUI, IDisposable
     {
         private static SemaphoreSlim returnedUriReady;
         private static AuthorizationResult authorizationResult;
         private PlatformParameters parameters;
+        private nint taskId = UIApplication.BackgroundTaskInvalid;
+        private NSObject didEnterBackgroundNotification, willEnterForegroundNotification;
 
         public WebUI(IPlatformParameters parameters)
         {
@@ -43,6 +47,31 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
             if (this.parameters == null)
             {
                 throw new ArgumentException("parameters should be of type PlatformParameters", "parameters");
+            }
+
+            this.didEnterBackgroundNotification = NSNotificationCenter.DefaultCenter.AddObserver(UIApplication.DidEnterBackgroundNotification, OnMoveToBackground);
+            this.willEnterForegroundNotification = NSNotificationCenter.DefaultCenter.AddObserver(UIApplication.WillEnterForegroundNotification, OnMoveToForeground);
+        }
+
+        void OnMoveToBackground(NSNotification notification)
+        {
+            //After iOS 11.3, it is neccesary to keep a background task running while moving an app to the background in order to prevent the system from reclaiming network resources from the app. 
+            //This will prevent authentication from failing while the application is moved to the background while waiting for MFA to finish.
+            this.taskId = UIApplication.SharedApplication.BeginBackgroundTask(() => {
+                if (this.taskId != UIApplication.BackgroundTaskInvalid)
+                {
+                    UIApplication.SharedApplication.EndBackgroundTask(this.taskId);
+                    this.taskId = UIApplication.BackgroundTaskInvalid;
+                }
+            });
+        }
+
+        void OnMoveToForeground(NSNotification notification)
+        {
+            if (this.taskId != UIApplication.BackgroundTaskInvalid)
+            {
+                UIApplication.SharedApplication.EndBackgroundTask(this.taskId);
+                this.taskId = UIApplication.BackgroundTaskInvalid;
             }
         }
 
@@ -89,6 +118,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         private void CallbackMethod(AuthorizationResult result)
         {
             SetAuthorizationResult(result);
+        }
+
+        public void Dispose()
+        {
+            this.didEnterBackgroundNotification.Dispose();
+            this.willEnterForegroundNotification.Dispose();
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/winrt/DeviceAuthHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/winrt/DeviceAuthHelper.cs
@@ -52,8 +52,18 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         public static async Task<string> CreateDeviceAuthChallengeResponseAsync(IDictionary<string, string> challengeData)
         {
             string authHeaderTemplate = "PKeyAuth {0}, Context=\"{1}\", Version=\"{2}\"";
-            
-            Certificate certificate = await FindCertificate(challengeData).ConfigureAwait(false);
+            Certificate certificate = null;
+            try
+            {
+                certificate = await FindCertificate(challengeData).ConfigureAwait(false);
+            }
+            catch (AdalException ex)
+            {
+                if (ex.ErrorCode == AdalError.DeviceCertificateNotFound)
+                {
+                    return await Task.FromResult(string.Format(CultureInfo.InvariantCulture, @"PKeyAuth Context=""{0}"",Version=""{1}""", challengeData["Context"], challengeData["Version"])).ConfigureAwait(false);
+                }
+            }
             DeviceAuthJWTResponse response = new DeviceAuthJWTResponse(challengeData["SubmitUrl"],
                 challengeData["nonce"], Convert.ToBase64String(certificate.GetCertificateBlob().ToArray()));
             IBuffer input = CryptographicBuffer.ConvertStringToBinary(response.GetResponseToSign(),

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/AssemblyInfo.cs
@@ -39,7 +39,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyFileVersion("3.19.3.0")]
+[assembly: AssemblyFileVersion("3.19.6.0")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
Merging Master into Adalv3/dev (update to 3.19.6)

Release of 3.19.2
Hotfix for CoreCLR writing to console by default and update to changelog for release 3.19.3 (#1034)
Hotfix (#1035)

* Hotfix for CoreCLR writing to console by default and update to changelog for release 3.19.3

* Change assembly file version to 3.19.3.0
Hotfix #1043 (#1045)

* Adding X5c claim to AcquireTokenByAuthorizationCodeAsync
for easy certificate rollover and parity with AcquireTokenAsync

* Filter logs for AdalEventSource based on log level in default log #1039

* Updating version to 3.19.4.0
Update changelog.txt
Trwalke/ios background thread fix (#1053)

* Resolved issue with iOS 11.3 where network resources are reclaimed by the system when sending an app to the background.

437419

* Clean Up

* Making field private.
Clean up

* Ensuring that the background thread is ended when interactive authentication is completed or canceled.

* Removed unnecessary background tasks.
Implemented IDisposable interface to clean up registered notifications when authentication finishes.

* Setting taskId to BackgroundTaskInvalid after background task is finished

* Updating version to 3.19.5

* Updating changelog.txt
Trwalke/fixpkey auth implementation (#1058)

* Non work place joined devices that do not have the cert required to satisfy the PKeyAuth Device challenge will no longer fail when the challenge is presented.

* Update changelog.txt

* Updating ADAL version to 3.19.6.0