### PR TITLE
Fix binary compat with ADAL 2.x for calls to AuthenticationContext.AcquireTokenAsync

### DIFF
--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -410,6 +410,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return WebUIFactoryProvider.WebUIFactory.CreateAuthenticationDialog(parameters.GetCoreUIParent(), null);
         }
 
+        // Added for fixing backwards binary compat with ADAL 2.x!
+        public async Task<AuthenticationResult> AcquireTokenAsync(string resource, string clientId, UserCredential userCredential)
+        {
+            return await AcquireTokenCommonAsync(resource, clientId, userCredential).ConfigureAwait(false);
+        }
+
         internal async Task<AuthenticationResult> AcquireTokenCommonAsync(string resource, string clientId,
             UserCredential userCredential)
         {

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextIntegratedAuthExtensions.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextIntegratedAuthExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="userCredential">The user credential to use for token acquisition.</param>
         /// <returns>It contains Access Token, its expiration time, user information.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, string clientId, UserCredential userCredential)
+        public static async Task<AuthenticationResult> AcquireTokenAsync(AuthenticationContext ctx, string resource, string clientId, UserCredential userCredential)
         {
             return await ctx.AcquireTokenCommonAsync(resource, clientId, userCredential).ConfigureAwait(false);
         }


### PR DESCRIPTION
Because I believe if it is not necessary to break binary compat, it is just better not to! For discussion see #1085.