### PR TITLE
Hotfix 3.19.7

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/WsTrust/WsTrustResponse.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/WsTrust/WsTrustResponse.cs
@@ -95,7 +95,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.WsTrust
         {
             try
             {
-                return XDocument.Load(responseStream, LoadOptions.None);
+                return XDocument.Load(responseStream, LoadOptions.PreserveWhitespace);
             }
             catch (XmlException ex)
             {
@@ -148,9 +148,17 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.WsTrust
                     {
                         continue;
                     }
-                    
-                    tokenResponseDictionary.Add(tokenTypeElement.Value,
-                        requestedSecurityToken.FirstNode.ToString(SaveOptions.DisableFormatting));
+
+                    var token = new System.Text.StringBuilder();
+                    foreach (var node in requestedSecurityToken.Nodes())
+                    {
+                        // Since we moved from XDocument.Load(..., LoadOptions.None) to Load(..., LoadOptions.PreserveWhitespace),
+                        // requestedSecurityToken can contain multiple nodes, and the first node is possibly just whitespaces e.g. "\n   ",
+                        // so we concatenate all the sub-nodes to include everything
+                        token.Append(node.ToString(SaveOptions.DisableFormatting));
+                    }
+
+                    tokenResponseDictionary.Add(tokenTypeElement.Value, token.ToString());
                 }
             }
             catch (XmlException ex)

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/UserPasswordCredential.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/UserPasswordCredential.cs
@@ -85,13 +85,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             requestParameters[OAuthParameter.GrantType] = OAuthGrantType.Password;
             requestParameters[OAuthParameter.Username] = this.UserName;
             requestParameters[OAuthParameter.Password] = new string(PasswordToCharArray());
-            
-            if (SecurePassword != null && !SecurePassword.IsReadOnly())
-            {
-                SecurePassword.Clear();
-            }
-
-            SecurePassword = null;
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/AssemblyInfo.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Properties/AssemblyInfo.cs
@@ -39,7 +39,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyMetadata("Serviceable", "True")]
 
-[assembly: AssemblyFileVersion("3.19.6.0")]
+[assembly: AssemblyFileVersion("3.19.7.0")]
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 

--- a/tests/Test.ADAL.NET.Unit/WsTrustTests.cs
+++ b/tests/Test.ADAL.NET.Unit/WsTrustTests.cs
@@ -29,6 +29,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.WsTrust;
 using System.IO;
 using System.Xml.Linq;
+using System.Text;
 
 namespace Test.ADAL.NET.Unit
 {
@@ -45,6 +46,18 @@ namespace Test.ADAL.NET.Unit
             StringAssert.Contains(sample, characteristic);
             WsTrustResponse resp = WsTrustResponse.CreateFromResponseDocument(
                 XDocument.Parse(sample, LoadOptions.PreserveWhitespace), WsTrustVersion.WsTrust2005);
+            StringAssert.Contains(resp.Token, characteristic);
+        }
+
+        [TestMethod]
+        [TestCategory("WsTrustTests")]
+        public void TestCreateFromResponse_WhenInputContainsWhitespace_ShouldPreserveWhitespace()
+        {
+            string sample = File.ReadAllText("WsTrustResponse.xml");
+            string characteristic = "\n        <saml:Assertion";
+            StringAssert.Contains(sample, characteristic);
+            WsTrustResponse resp = WsTrustResponse.CreateFromResponse(
+                new MemoryStream(Encoding.UTF8.GetBytes(sample)), WsTrustVersion.WsTrust2005);
             StringAssert.Contains(resp.Token, characteristic);
         }
     }

--- a/tests/Test.ADAL.NET.Unit/WsTrustTests.cs
+++ b/tests/Test.ADAL.NET.Unit/WsTrustTests.cs
@@ -1,0 +1,51 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.WsTrust;
+using System.IO;
+using System.Xml.Linq;
+
+namespace Test.ADAL.NET.Unit
+{
+    [TestClass]
+    [DeploymentItem("WsTrustResponse.xml")]
+    public class WsTrustTests
+    {
+        [TestMethod]
+        [TestCategory("WsTrustTests")]
+        public void TestCreateFromResponseDocument_WhenInputContainsWhitespace_ShouldPreserveWhitespace()
+        {
+            string sample = File.ReadAllText("WsTrustResponse.xml");
+            string characteristic = "\n        <saml:Assertion";
+            StringAssert.Contains(sample, characteristic);
+            WsTrustResponse resp = WsTrustResponse.CreateFromResponseDocument(
+                XDocument.Parse(sample, LoadOptions.PreserveWhitespace), WsTrustVersion.WsTrust2005);
+            StringAssert.Contains(resp.Token, characteristic);
+        }
+    }
+}


### PR DESCRIPTION
This hotfix will:

* No longer clear SecurePassword after the username password grant flow
* Keep whitespaces inside a SAML token. This will bring better interoperability with other federated IDPs.