### PR TITLE
Some binary compatibility fix between ADAL 2.x and ADAL 3.x 

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -412,6 +412,12 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             return WebUIFactoryProvider.WebUIFactory.CreateAuthenticationDialog(parameters);
         }
 
+        // Added for fixing backwards binary compat with ADAL 2.x!
+        public async Task<AuthenticationResult> AcquireTokenAsync(string resource, string clientId, UserCredential userCredential)
+        {
+            return await AcquireTokenCommonAsync(resource, clientId, userCredential).ConfigureAwait(false);
+        }
+
         internal async Task<AuthenticationResult> AcquireTokenCommonAsync(string resource, string clientId,
             UserCredential userCredential)
         {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextIntegratedAuthExtensions.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Features/WinCommon/AuthenticationContextIntegratedAuthExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="clientId">Identifier of the client requesting the token.</param>
         /// <param name="userCredential">The user credential to use for token acquisition.</param>
         /// <returns>It contains Access Token, its expiration time, user information.</returns>
-        public static async Task<AuthenticationResult> AcquireTokenAsync(this AuthenticationContext ctx, string resource, string clientId, UserCredential userCredential)
+        public static async Task<AuthenticationResult> AcquireTokenAsync(AuthenticationContext ctx, string resource, string clientId, UserCredential userCredential)
         {
             return await ctx.AcquireTokenCommonAsync(resource, clientId, userCredential).ConfigureAwait(false);
         }


### PR DESCRIPTION
for calls to AuthenticationContext.AcquireTokenAsync(string, string, UserCredential).