### PR TITLE
Use RelativeLayout instead of LinearLayout for creating webview

### DIFF
--- a/core/src/Platforms/Android/EmbeddedWebview/AuthenticationAgentActivity.cs
+++ b/core/src/Platforms/Android/EmbeddedWebview/AuthenticationAgentActivity.cs
@@ -53,13 +53,12 @@ namespace Microsoft.Identity.Core.UI.EmbeddedWebview
             // Create your application here
 
             WebView webView = new WebView(ApplicationContext);
-            var linearLayout = new LinearLayout(ApplicationContext)
-            {
-                Orientation = Orientation.Vertical
-            };
-            linearLayout.AddView(webView);
-            SetContentView(linearLayout);
+            var relativeLayout = new RelativeLayout(ApplicationContext);
+            webView.LayoutParameters = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MatchParent, RelativeLayout.LayoutParams.MatchParent);
 
+            relativeLayout.AddView(webView);
+            SetContentView(relativeLayout);
+            
             string url = Intent.GetStringExtra("Url");
             WebSettings webSettings = webView.Settings;
             string userAgent = webSettings.UserAgentString;


### PR DESCRIPTION
Suggestion from a customer to use [RelativeLayout](https://developer.android.com/guide/topics/ui/layout/relative) instead of LinearLayout for the webview. Here is documentation on the [differences](https://developer.android.com/training/improving-layouts/optimizing-layout).

[MatchParent](https://developer.android.com/reference/android/view/ViewGroup.LayoutParams.html#MATCH_PARENT)

Open to discussion on this, but apparently the webview dimensions were coming in at zero and using RelativeLayout fixed the look of the login screen. It also seems to load faster 

**Tested embedded webview w/Android device (Plus One) with MSAL & ADAL Xamarin test apps**