### PR TITLE
Fix some of the build warnings

### DIFF
--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/netstandard1.1/PlatformParameters.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/netstandard1.1/PlatformParameters.cs
@@ -30,9 +30,15 @@ using System;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
+    /// <summary>
+    ///  Additional parameters used in acquiring user's authorization, specific to netstadard 1.1
+    /// </summary>
     public class PlatformParameters : IPlatformParameters
     {
-        // NetStandard1.1 does not have UI
+        /// <summary>
+        /// Get the UI parent for the app
+        /// </summary>
+        /// <remarks> NetStandard1.1 does not have UI</remarks>
         internal CoreUIParent GetCoreUIParent()
         {
             throw new NotImplementedException();

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/netstandard1.3/PlatformParameters.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/netstandard1.3/PlatformParameters.cs
@@ -30,6 +30,9 @@ using System;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 {
+    /// <summary>
+    ///  Additional parameters used in acquiring user's authorization, specific to netstadard 1.1
+    /// </summary>
     public class PlatformParameters : IPlatformParameters
     {
         // NetStandard1.3 does not have UI

--- a/msal/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/msal/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -139,8 +139,6 @@
     </PackageReference>
     <Compile Include="Platforms\Android\**\*.cs" />
   </ItemGroup>
-
-  <Import Project="$(MSBuildSDKExtrasTargets)" Condition="Exists('$(MSBuildSDKExtrasTargets)')" />
   
   <!-- This is here to workaround designer issues so VS sees them appropriately -->
   <ItemGroup>

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -953,7 +953,6 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Only used by dev test apps
         /// </summary>
-        /// <param name="msalAccessTokenCacheItem"></param>
         internal void SaveAccesTokenCacheItem(MsalAccessTokenCacheItem msalAccessTokenCacheItem, MsalIdTokenCacheItem msalIdTokenCacheItem)
         {
             lock (LockObject)


### PR DESCRIPTION
This should fix all but 2 warnings: 

- Xamarin wanting to connect to a MAC 
- warning NU1603: runtime.native.System.IO.Compression 4.3.0

These are both external and I am tracking them