### PR TITLE
Add the missing X in the name exception

### DIFF
--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Exceptions/AdalExceptionService.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Exceptions/AdalExceptionService.cs
@@ -37,7 +37,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// </summary>
     /// <remarks>Does not currently throw <see cref="AdalSilentTokenAcquisitionException"/> and 
     /// <see cref="AdalUserMismatchException"/></remarks>
-    internal class AdalEceptionFactory : CoreExceptionFactory
+    internal class AdalExceptionFactory : CoreExceptionFactory
     {
         public override Exception GetClientException(
             string errorCode, 

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Platform/AdalLoggerBase.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Platform/AdalLoggerBase.cs
@@ -120,7 +120,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
         public override void Error(Exception ex)
         {
-            Log(LogLevel.Error, AdalEceptionFactory.GetPiiScrubbedExceptionDetails(ex), false);
+            Log(LogLevel.Error, AdalExceptionFactory.GetPiiScrubbedExceptionDetails(ex), false);
         }
 
         public override void ErrorPii(Exception ex)

--- a/adal/tests/Test.ADAL.NET.Unit/AdalExceptionServiceTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit/AdalExceptionServiceTests.cs
@@ -39,12 +39,12 @@ namespace Test.ADAL.NET.Unit
         private const string exCode = "exCode";
         private const string exMessage = "exMessage";
 
-        AdalEceptionFactory adalExceptionFactory;
+        AdalExceptionFactory adalExceptionFactory;
 
         [TestInitialize]
         public void Init()
         {
-            adalExceptionFactory = new AdalEceptionFactory();
+            adalExceptionFactory = new AdalExceptionFactory();
         }
 
         [TestMethod]


### PR DESCRIPTION
Currently there are [4 occurrences of the typo](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/search?q=adaleceptionfactory&unscoped_q=adaleceptionfactory).