### PR TITLE
Add xml documentation to UseCorporateNetwork

### DIFF
--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Identity.Client
 
 #if WINRT
 /// <summary>
-/// flag to enable logged in user authentication
+/// Flag to enable logged in user authentication.
+/// When set to true, the application will try to connect to the corporate network using windows integrated authentication.
 /// </summary>
         public bool UseCorporateNetwork { get; set; }
 #endif

--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Client
 
 #if WINRT
 /// <summary>
-/// 
+/// flag to enable logged in user authentication
 /// </summary>
         public bool UseCorporateNetwork { get; set; }
 #endif


### PR DESCRIPTION
This addresses the [comments in another PR](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/pull/1118#pullrequestreview-140598220). And, now the new document wording comes from [here](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blame/3430f2f41cac9f5525dd8c6870178bd9fbfb225d/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/uap/PlatformParameters.cs#L41).