### PR TITLE
High CPU under load fix

### DIFF
--- a/core/src/Http/HttpClientFactory.cs
+++ b/core/src/Http/HttpClientFactory.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace Microsoft.Identity.Core.Http
 {
@@ -43,6 +44,9 @@ namespace Microsoft.Identity.Core.Http
             {
                 MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
             };
+
+            httpClient.DefaultRequestHeaders.Accept.Clear();
+            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             return httpClient;
         }

--- a/core/src/Http/HttpRequest.cs
+++ b/core/src/Http/HttpRequest.cs
@@ -31,7 +31,6 @@ using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Core.Http
@@ -144,8 +143,6 @@ namespace Microsoft.Identity.Core.Http
             Dictionary<string, string> bodyParameters, HttpMethod method)
         {
             HttpClient client = HttpClientFactory.GetHttpClient();
-            client.DefaultRequestHeaders.Accept.Clear();
-            client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             using (HttpRequestMessage requestMessage = CreateRequestMessage(endpoint, headers))
             {

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/HttpTests/HttpClientFactoryTests.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/HttpTests/HttpClientFactoryTests.cs
@@ -26,10 +26,12 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Linq;
 using System.Text;
 using System.Collections.Generic;
 using System.Dynamic;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Threading.Tasks;
 using Microsoft.Identity.Core.Http;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -45,6 +47,15 @@ namespace Test.Microsoft.Identity.Unit.HttpTests
         {
             HttpClientFactory.ReturnHttpClientForMocks = false;
             Assert.AreEqual(1024 * 1024, HttpClientFactory.GetHttpClient().MaxResponseContentBufferSize);
+        }
+
+        [TestMethod]
+        [TestCategory("HttpClientFactoryTests")]
+        public void GetHttpClient_DefaultHeadersSetToJson()
+        {
+            var client = HttpClientFactory.GetHttpClient();
+            Assert.IsNotNull(client.DefaultRequestHeaders.Accept);
+            Assert.IsTrue(client.DefaultRequestHeaders.Accept.Any<MediaTypeWithQualityHeaderValue>(x => x.MediaType == "application/json"));
         }
     }
 }


### PR DESCRIPTION
The default headers should only be changed once so I moved the change to the factory. Otherwise, the following problem occurs under load: https://blogs.msdn.microsoft.com/tess/2009/12/21/high-cpu-in-net-app-using-a-static-generic-dictionary/