### PR TITLE
Refactor user to account

### DIFF
--- a/adal/tests/Test.ADAL.NET.Common/Mocks/MockHelpers.cs
+++ b/adal/tests/Test.ADAL.NET.Common/Mocks/MockHelpers.cs
@@ -139,7 +139,7 @@ namespace Test.ADAL.NET.Common.Mocks
 
             var clientInfo = new ClientInfo
             {
-                UniqueIdentifier = TestConstants.DefaultUniqueIdentifier,
+                UniqueObjectIdentifier = TestConstants.DefaultUniqueIdentifier,
                 UniqueTenantIdentifier = TestConstants.DefaultUniqueTenantIdentifier
             };
             var base64EncodedSerializedClientInfo = Base64UrlEncoder.Encode(Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Helpers.JsonHelper.EncodeToJson<ClientInfo>(clientInfo));

--- a/core/src/Cache/CacheFallbackOperations.cs
+++ b/core/src/Cache/CacheFallbackOperations.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Identity.Core.Cache
                 {
                     if (authorityHostAliases.Contains(new Uri(pair.Key.Authority).Host) &&
                          displayableId.Equals(pair.Key.DisplayableId) &&
-                         identifier.Equals(ClientInfo.CreateFromJson(pair.Value.RawClientInfo).ToUserIdentifier()))
+                         identifier.Equals(ClientInfo.CreateFromJson(pair.Value.RawClientInfo).ToAccountIdentifier()))
                     {
                         keysToRemove.Add(pair.Key);
                     }

--- a/core/src/Cache/MsalCacheItemBase.cs
+++ b/core/src/Cache/MsalCacheItemBase.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Core.Cache
         {
             if (ClientInfo != null)
             {
-                HomeAccountId = ClientInfo.ToUserIdentifier();
+                HomeAccountId = ClientInfo.ToAccountIdentifier();
             }
         }
     }

--- a/core/src/ClientInfo.cs
+++ b/core/src/ClientInfo.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Core
     internal class ClientInfo
     {
         [DataMember(Name = ClientInfoClaim.UniqueIdentifier, IsRequired = false)]
-        public string UniqueIdentifier { get; set; }
+        public string UniqueObjectIdentifier { get; set; }
 
         [DataMember(Name = ClientInfoClaim.UnqiueTenantIdentifier, IsRequired = false)]
         public string UniqueTenantIdentifier { get; set; }
@@ -74,31 +74,11 @@ namespace Microsoft.Identity.Core
             return Base64UrlHelpers.Encode(JsonHelper.SerializeToJson<ClientInfo>(this));
         }
 
-        public string ToUserIdentifier()
+        public string ToAccountIdentifier()
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", UniqueIdentifier, UniqueTenantIdentifier);
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", UniqueObjectIdentifier, UniqueTenantIdentifier);
         }
 
-        public static ClientInfo CreateFromUserIdentifier(string userIdentifier)
-        {
-            if (string.IsNullOrEmpty(userIdentifier))
-            {
-                return null;
-            }
-
-            string[] artifacts = userIdentifier.Split('.');
-
-            if (artifacts.Length == 0)
-            {
-                return null;
-            }
-
-            return new ClientInfo()
-            {
-                UniqueIdentifier = artifacts[0],
-                UniqueTenantIdentifier = artifacts[1]
-            };
-        }
         public static ClientInfo CreateFromEncodedString(string encodedUserIdentiier)
         {
             if (string.IsNullOrEmpty(encodedUserIdentiier))
@@ -115,7 +95,7 @@ namespace Microsoft.Identity.Core
 
             return new ClientInfo()
             {
-                UniqueIdentifier = Base64UrlHelpers.DecodeToString(artifacts[0]),
+                UniqueObjectIdentifier = Base64UrlHelpers.DecodeToString(artifacts[0]),
                 UniqueTenantIdentifier = Base64UrlHelpers.DecodeToString(artifacts[1]),
             };
         }

--- a/core/src/Microsoft.Identity.Core.csproj
+++ b/core/src/Microsoft.Identity.Core.csproj
@@ -55,9 +55,6 @@
     <Compile Remove="Platforms\**\*.*" />
     <Compile Remove="Features\**\*.*" />
     <None Remove="ConfigureAwait.ruleset" />
-    <None Remove="Instance\AadInstanceDiscovery.cs" />
-    <None Remove="Instance\AuthorityType.cs" />
-    <None Remove="Instance\InstanceDiscoveryMetadataEntry.cs" />
     <EmbeddedResource Include="Properties\Microsoft.Identity.Core.rd.xml" />
   </ItemGroup>
 

--- a/core/src/Telemetry/ApiEvent.cs
+++ b/core/src/Telemetry/ApiEvent.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Identity.Core.Telemetry
             }
         }
 
-        public string UserId
+        public string AccountId
         {
             set
             {

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/ClientInfoTests.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/ClientInfoTests.cs
@@ -39,7 +39,7 @@ namespace Test.Microsoft.Identity.Core.Unit
         {
             ClientInfo clientInfo = ClientInfo.CreateFromJson("eyJ1aWQiOiJteS11aWQiLCJ1dGlkIjoibXktdXRpZCJ9");
             Assert.IsNotNull(clientInfo);
-            Assert.AreEqual(TestConstants.Uid, clientInfo.UniqueIdentifier);
+            Assert.AreEqual(TestConstants.Uid, clientInfo.UniqueObjectIdentifier);
             Assert.AreEqual(TestConstants.Utid, clientInfo.UniqueTenantIdentifier);
         }
     }

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/TelemetryTests.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/TelemetryTests.cs
@@ -303,7 +303,7 @@ namespace Test.Microsoft.Identity.Core.Unit
             var reqId = telemetry.GenerateNewRequestId();
             try
             {
-                var e1 = new ApiEvent() { Authority = new Uri("https://login.microsoftonline.com"), AuthorityType = "Aad", TenantId = TenantId, UserId = UserId };
+                var e1 = new ApiEvent() { Authority = new Uri("https://login.microsoftonline.com"), AuthorityType = "Aad", TenantId = TenantId, AccountId = UserId };
                 telemetry.StartEvent(reqId, e1);
                 // do some stuff...
                 e1.WasSuccessful = true;
@@ -343,7 +343,7 @@ namespace Test.Microsoft.Identity.Core.Unit
             var reqId = telemetry.GenerateNewRequestId();
             try
             {
-                var e1 = new ApiEvent() { Authority = new Uri("https://login.microsoftonline.com"), AuthorityType = "Aad", TenantId = TenantId, UserId = UserId };
+                var e1 = new ApiEvent() { Authority = new Uri("https://login.microsoftonline.com"), AuthorityType = "Aad", TenantId = TenantId, AccountId = UserId };
                 telemetry.StartEvent(reqId, e1);
                 // do some stuff...
                 e1.WasSuccessful = true;

--- a/msal/samples/desktop/SampleApp/MainForm.cs
+++ b/msal/samples/desktop/SampleApp/MainForm.cs
@@ -36,14 +36,14 @@ namespace SampleApp
     public partial class MainForm : Form
     {
         private readonly MsalAuthHelper _msalHelper = new MsalAuthHelper("11744750-bfe5-4818-a1c0-655455f68fa7");
-        private IUser user = null;
+        private IAccount user = null;
         public MainForm()
         {
             InitializeComponent();
             tabControl1.Appearance = TabAppearance.FlatButtons;
             tabControl1.ItemSize = new Size(0, 1);
             tabControl1.SizeMode = TabSizeMode.Fixed;
-            user = _msalHelper.Application.GetUsersAsync().Result.FirstOrDefault();
+            user = _msalHelper.Application.GetAccountsAsync().Result.FirstOrDefault();
             tabControl1.SelectedIndexChanged += TabControl1_SelectedIndexChanged;
 
             signInPage.BackColor = Color.FromArgb(255, 67, 143, 255);

--- a/msal/samples/desktop/SampleApp/MsalAuthHelper.cs
+++ b/msal/samples/desktop/SampleApp/MsalAuthHelper.cs
@@ -48,12 +48,12 @@ namespace SampleApp
                 CachePersistence.GetUserCache());
         }
 
-        public async Task<IUser> SignInAsync()
+        public async Task<IAccount> SignInAsync()
         {
             try
             {
                 AuthenticationResult result = await Application.AcquireTokenAsync(new[] {"user.read", "calendars.read"}).ConfigureAwait(false);
-                return result.User;
+                return result.Account;
             }
             catch (Exception exc)
             {
@@ -63,7 +63,7 @@ namespace SampleApp
             return null;
         }
 
-        public async Task<string> GetTokenForCurrentUserAsync(IEnumerable<string> scopes, IUser user)
+        public async Task<string> GetTokenForCurrentUserAsync(IEnumerable<string> scopes, IAccount user)
         {
             AuthenticationResult result = null;
             Exception exception = null;

--- a/msal/samples/uap/MainPage.xaml.cs
+++ b/msal/samples/uap/MainPage.xaml.cs
@@ -45,7 +45,7 @@ namespace MsalUAPTestApp
             AuthenticationResult authResult = null;
             try
             {
-                var users = await PublicClientApp.GetUsersAsync();
+                var users = await PublicClientApp.GetAccountsAsync();
                 authResult = await PublicClientApp.AcquireTokenSilentAsync(scopes, users.FirstOrDefault());
             }
             catch (MsalUiRequiredException ex)
@@ -106,7 +106,7 @@ namespace MsalUAPTestApp
         /// </summary>
         private async void SignOutButton_Click(object sender, RoutedEventArgs e)
         {
-            var users = await PublicClientApp.GetUsersAsync();
+            var users = await PublicClientApp.GetAccountsAsync();
             if (users.Any())
             {
                 try
@@ -131,9 +131,9 @@ namespace MsalUAPTestApp
             TokenInfoText.Text = "";
             if (authResult != null)
             {
-                TokenInfoText.Text += $"Identifier: {authResult.User.Identifier}" + Environment.NewLine;
-                TokenInfoText.Text += $"Env: {authResult.User.Environment}" + Environment.NewLine;
-                TokenInfoText.Text += $"Username: {authResult.User.DisplayableId}" + Environment.NewLine;
+                TokenInfoText.Text += $"Identifier: {authResult.Account.HomeAccountId}" + Environment.NewLine;
+                TokenInfoText.Text += $"Env: {authResult.Account.Environment}" + Environment.NewLine;
+                TokenInfoText.Text += $"Username: {authResult.Account.Username}" + Environment.NewLine;
                 TokenInfoText.Text += $"Token Expires: {authResult.ExpiresOn.ToLocalTime()}" + Environment.NewLine;
                 TokenInfoText.Text += $"Access Token: {authResult.AccessToken}" + Environment.NewLine;
             }

--- a/msal/src/Microsoft.Identity.Client/Account.cs
+++ b/msal/src/Microsoft.Identity.Client/Account.cs
@@ -25,48 +25,37 @@
 //
 //------------------------------------------------------------------------------
 
+using Microsoft.Identity.Core;
 using System;
 
 namespace Microsoft.Identity.Client
 {
     /// <summary>
-    /// Contains information of a single user. This information is used for token cache lookup and enforcing the user session on STS authorize endpont.
+    /// Contains information of a single account. A user can be present in multiple directorie and thus have multiple accounts.
+    /// This information is used for token cache lookup and enforcing the user session on STS authorize endpont.
     /// </summary>
-    internal sealed class User: IUser
+    internal sealed class Account: IAccount
     {
-        public User()
+        public Account()
         {
         }
 
-        internal User(User other)
+        public Account(MsalAccountId homeAccountId, string username, string environment)
         {
-            DisplayableId = other.DisplayableId;
-            Identifier = other.Identifier;
-            Environment = other.Environment;
-        }
-
-        public User(string identifier, string displayableId, string environment)
-        {
-            if (string.IsNullOrWhiteSpace(identifier))
+            if (homeAccountId == null)
             {
-                throw new ArgumentNullException(nameof(identifier));
+                throw new ArgumentNullException(nameof(homeAccountId));
             }
 
-            DisplayableId = displayableId;
+            Username = username;
             Environment = environment;
-            Identifier = identifier;
+            HomeAccountId = homeAccountId;
         }
 
-        /// <summary>
-        /// Gets a displayable value in UserPrincipalName (UPN) format. The value can be null.
-        /// </summary>
-        public string DisplayableId { get; internal set; }
+        public string Username { get; internal set; }
 
-        /// <summary>
-        /// Gets given name of the user if provided by the service. If not, the value is null.
-        /// </summary>
         public string Environment { get; internal set; }
 
-        public string Identifier { get; internal set; }
+        public MsalAccountId HomeAccountId { get; internal set; }
     }
 }

--- a/msal/src/Microsoft.Identity.Client/Account.cs
+++ b/msal/src/Microsoft.Identity.Client/Account.cs
@@ -27,6 +27,7 @@
 
 using Microsoft.Identity.Core;
 using System;
+using System.Globalization;
 
 namespace Microsoft.Identity.Client
 {
@@ -40,7 +41,7 @@ namespace Microsoft.Identity.Client
         {
         }
 
-        public Account(MsalAccountId homeAccountId, string username, string environment)
+        public Account(AccountId homeAccountId, string username, string environment)
         {
             if (homeAccountId == null)
             {
@@ -56,6 +57,15 @@ namespace Microsoft.Identity.Client
 
         public string Environment { get; internal set; }
 
-        public MsalAccountId HomeAccountId { get; internal set; }
+        public AccountId HomeAccountId { get; internal set; }
+
+        public override string ToString()
+        {
+            return String.Format(
+                CultureInfo.CurrentCulture,
+                "Account username: {0} environment {1} home account id: {2}",
+                Username, Environment, HomeAccountId.ToString());
+
+        }
     }
 }

--- a/msal/src/Microsoft.Identity.Client/AccountId.cs
+++ b/msal/src/Microsoft.Identity.Client/AccountId.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Identity.Client
     /// <summary>
     /// An identifier for an account in a specific tenant
     /// </summary>
-    public class MsalAccountId
+    public class AccountId
     {
         /// <summary>
         /// An identifier for an account in a specific tenant
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Constructor
         /// </summary>
-        public MsalAccountId(string identifier, string objectId, string tenantId)
+        public AccountId(string identifier, string objectId, string tenantId)
         {
             if (identifier == null)
             {
@@ -70,20 +70,20 @@ namespace Microsoft.Identity.Client
             this.TenantId = tenantId;
         }
 
-        internal static MsalAccountId FromClientInfo(ClientInfo clientInfo)
+        internal static AccountId FromClientInfo(ClientInfo clientInfo)
         {
             if (clientInfo == null)
             {
                 throw new ArgumentNullException(nameof(clientInfo));
             }
 
-            return new MsalAccountId(
+            return new AccountId(
                 clientInfo.ToAccountIdentifier(),
                 clientInfo.UniqueObjectIdentifier,
                 clientInfo.UniqueTenantIdentifier);
         }
 
-        internal static ClientInfo ToClientInfo(MsalAccountId msalAccountId)
+        internal static ClientInfo ToClientInfo(AccountId msalAccountId)
         {
             if (msalAccountId == null)
             {
@@ -104,7 +104,7 @@ namespace Microsoft.Identity.Client
         {
             if (obj == null) { return false; }
 
-            var otherMsalAccountId = obj as MsalAccountId;
+            var otherMsalAccountId = obj as AccountId;
             if (otherMsalAccountId == null) { return false; }
 
             return this.Identifier == otherMsalAccountId.Identifier;
@@ -116,6 +116,14 @@ namespace Microsoft.Identity.Client
         public override int GetHashCode()
         {
             return this.Identifier.GetHashCode();
+        }
+
+        /// <summary>
+        /// Textual description of an <see cref="AccountId"/>
+        /// </summary>
+        public override string ToString()
+        {
+            return "AccountId: " + this.Identifier;
         }
     }
 }

--- a/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Client
             _msalIdTokenCacheItem = msalIdTokenCacheItem;
             if (_msalAccessTokenCacheItem.HomeAccountId != null)
             {
-                Account = new Account(MsalAccountId.FromClientInfo(_msalAccessTokenCacheItem.ClientInfo),
+                Account = new Account(AccountId.FromClientInfo(_msalAccessTokenCacheItem.ClientInfo),
                     _msalIdTokenCacheItem?.IdToken?.PreferredUsername, _msalAccessTokenCacheItem.Environment);
             }
         }

--- a/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Identity.Client
             _msalIdTokenCacheItem = msalIdTokenCacheItem;
             if (_msalAccessTokenCacheItem.HomeAccountId != null)
             {
-                User = new User(_msalAccessTokenCacheItem.HomeAccountId,
+                Account = new Account(MsalAccountId.FromClientInfo(_msalAccessTokenCacheItem.ClientInfo),
                     _msalIdTokenCacheItem?.IdToken?.PreferredUsername, _msalAccessTokenCacheItem.Environment);
             }
         }
@@ -81,10 +81,10 @@ namespace Microsoft.Identity.Client
         public virtual string TenantId => _msalIdTokenCacheItem?.IdToken?.TenantId;
 
         /// <summary>
-        /// Gets the user object. Some elements in User might be null if not returned by the
-        /// service. It can be passed back in some API overloads to identify which user should be used.
+        /// Gets the account object. Some elements in Account might be null if not returned by the
+        /// service. It can be passed back in some API overloads to identify which account should be used.
         /// </summary>
-        public virtual IUser User { get; internal set; }
+        public virtual IAccount Account { get; internal set; }
 
         /// <summary>
         /// Gets the entire Id Token if returned by the service or null if no Id Token is returned.

--- a/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -66,9 +66,9 @@ namespace Microsoft.Identity.Client
             Authority = authorityInstance.CanonicalAuthority;
             RedirectUri = redirectUri;
             ValidateAuthority = validateAuthority;
-            if (AccountTokenCache != null)
+            if (UserTokenCache != null)
             {
-                AccountTokenCache.ClientId = clientId;
+                UserTokenCache.ClientId = clientId;
             }
 
             RequestContext requestContext = new RequestContext(new MsalLogger(Guid.Empty, null));
@@ -112,7 +112,7 @@ namespace Microsoft.Identity.Client
         /// <Summary>
         /// Token Cache instance for storing User tokens.
         /// </Summary>
-        internal TokenCache AccountTokenCache
+        internal TokenCache UserTokenCache
         {
             get { return userTokenCache; }
             set
@@ -137,14 +137,14 @@ namespace Microsoft.Identity.Client
         public async Task<IEnumerable<IAccount>> GetAccountsAsync()
         {
             RequestContext requestContext = new RequestContext(new MsalLogger(Guid.Empty, null));
-            if (AccountTokenCache == null)
+            if (UserTokenCache == null)
             {
                 const string msg = "Token cache is null or empty. Returning empty list of accounts.";
                 requestContext.Logger.Info(msg);
                 requestContext.Logger.InfoPii(msg);
                 return Enumerable.Empty<Account>();
             }
-            return await AccountTokenCache.GetAccountsAsync(Authority, ValidateAuthority, requestContext).ConfigureAwait(false);
+            return await UserTokenCache.GetAccountsAsync(Authority, ValidateAuthority, requestContext).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -205,19 +205,19 @@ namespace Microsoft.Identity.Client
         public async Task RemoveAsync(IAccount account)
         {
             RequestContext requestContext = CreateRequestContext(Guid.Empty);
-            if (account == null || AccountTokenCache == null)
+            if (account == null || UserTokenCache == null)
             {
                 return;
             }
 
-            await AccountTokenCache.RemoveAsync(Authority, ValidateAuthority, account, requestContext).ConfigureAwait(false);
+            await UserTokenCache.RemoveAsync(Authority, ValidateAuthority, account, requestContext).ConfigureAwait(false);
         }
 
         internal async Task<AuthenticationResult> AcquireTokenSilentCommonAsync(Authority authority,
             IEnumerable<string> scopes, IAccount account, bool forceRefresh, ApiEvent.ApiIds apiId)
         {
             var handler = new SilentRequest(
-                CreateRequestParameters(authority, scopes, account, AccountTokenCache),
+                CreateRequestParameters(authority, scopes, account, UserTokenCache),
                 forceRefresh)
             { ApiId = apiId };
             return await handler.RunAsync().ConfigureAwait(false);

--- a/msal/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Acquires security token from the authority using authorization code previously received.
-        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="IClientApplicationBase.AcquireTokenSilentAsync(IEnumerable{string}, IUser)"/>.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="IClientApplicationBase.AcquireTokenSilentAsync(IEnumerable{string}, IAccount)"/>.
         /// </summary>
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="scopes">Array of scopes requested for resource</param>
@@ -240,7 +240,7 @@ namespace Microsoft.Identity.Client
             return await handler.RunAsync().ConfigureAwait(false);
         }
 
-        internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority, IEnumerable<string> scopes, IUser user, TokenCache cache)
+        internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority, IEnumerable<string> scopes, IAccount user, TokenCache cache)
         {
             AuthenticationRequestParameters parameters = base.CreateRequestParameters(authority, scopes, user, cache);
             parameters.ClientId = ClientId;

--- a/msal/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
@@ -73,10 +73,10 @@ namespace Microsoft.Identity.Client
             : base(clientId, authority, redirectUri, true)
         {
             ClientCredential = clientCredential;
-            AccountTokenCache = userTokenCache;
-            if (AccountTokenCache != null)
+            UserTokenCache = userTokenCache;
+            if (UserTokenCache != null)
             {
-                AccountTokenCache.ClientId = clientId;
+                UserTokenCache.ClientId = clientId;
             }
 
             AppTokenCache = appTokenCache;
@@ -171,7 +171,7 @@ namespace Microsoft.Identity.Client
         {
             Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             var requestParameters =
-                CreateRequestParameters(authority, scopes, null, AccountTokenCache);
+                CreateRequestParameters(authority, scopes, null, UserTokenCache);
             requestParameters.ClientId = ClientId;
             requestParameters.ExtraQueryParameters = extraQueryParameters;
 
@@ -195,7 +195,7 @@ namespace Microsoft.Identity.Client
         {
             Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
             var requestParameters = CreateRequestParameters(authorityInstance, scopes, null,
-                AccountTokenCache);
+                UserTokenCache);
             requestParameters.RedirectUri = new Uri(redirectUri);
             requestParameters.ClientId = ClientId;
             requestParameters.ExtraQueryParameters = extraQueryParameters;
@@ -222,7 +222,7 @@ namespace Microsoft.Identity.Client
         private async Task<AuthenticationResult> AcquireTokenOnBehalfCommonAsync(Authority authority,
             IEnumerable<string> scopes, UserAssertion userAssertion, ApiEvent.ApiIds apiId)
         {
-            var requestParams = CreateRequestParameters(authority, scopes, null, AccountTokenCache);
+            var requestParams = CreateRequestParameters(authority, scopes, null, UserTokenCache);
             requestParams.UserAssertion = userAssertion;
             var handler = new OnBehalfOfRequest(requestParams){ApiId = apiId, IsConfidentialClient = true};
             return await handler.RunAsync().ConfigureAwait(false);
@@ -232,7 +232,7 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes, Uri redirectUri, ApiEvent.ApiIds apiId)
         {
             Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
-            var requestParams = CreateRequestParameters(authority, scopes, null, AccountTokenCache);
+            var requestParams = CreateRequestParameters(authority, scopes, null, UserTokenCache);
             requestParams.AuthorizationCode = authorizationCode;
             requestParams.RedirectUri = redirectUri;
             var handler =

--- a/msal/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
@@ -73,10 +73,10 @@ namespace Microsoft.Identity.Client
             : base(clientId, authority, redirectUri, true)
         {
             ClientCredential = clientCredential;
-            UserTokenCache = userTokenCache;
-            if (UserTokenCache != null)
+            AccountTokenCache = userTokenCache;
+            if (AccountTokenCache != null)
             {
-                UserTokenCache.ClientId = clientId;
+                AccountTokenCache.ClientId = clientId;
             }
 
             AppTokenCache = appTokenCache;
@@ -171,7 +171,7 @@ namespace Microsoft.Identity.Client
         {
             Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             var requestParameters =
-                CreateRequestParameters(authority, scopes, null, UserTokenCache);
+                CreateRequestParameters(authority, scopes, null, AccountTokenCache);
             requestParameters.ClientId = ClientId;
             requestParameters.ExtraQueryParameters = extraQueryParameters;
 
@@ -195,7 +195,7 @@ namespace Microsoft.Identity.Client
         {
             Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
             var requestParameters = CreateRequestParameters(authorityInstance, scopes, null,
-                UserTokenCache);
+                AccountTokenCache);
             requestParameters.RedirectUri = new Uri(redirectUri);
             requestParameters.ClientId = ClientId;
             requestParameters.ExtraQueryParameters = extraQueryParameters;
@@ -222,7 +222,7 @@ namespace Microsoft.Identity.Client
         private async Task<AuthenticationResult> AcquireTokenOnBehalfCommonAsync(Authority authority,
             IEnumerable<string> scopes, UserAssertion userAssertion, ApiEvent.ApiIds apiId)
         {
-            var requestParams = CreateRequestParameters(authority, scopes, null, UserTokenCache);
+            var requestParams = CreateRequestParameters(authority, scopes, null, AccountTokenCache);
             requestParams.UserAssertion = userAssertion;
             var handler = new OnBehalfOfRequest(requestParams){ApiId = apiId, IsConfidentialClient = true};
             return await handler.RunAsync().ConfigureAwait(false);
@@ -232,7 +232,7 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes, Uri redirectUri, ApiEvent.ApiIds apiId)
         {
             Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
-            var requestParams = CreateRequestParameters(authority, scopes, null, UserTokenCache);
+            var requestParams = CreateRequestParameters(authority, scopes, null, AccountTokenCache);
             requestParams.AuthorizationCode = authorizationCode;
             requestParams.RedirectUri = redirectUri;
             var handler =

--- a/msal/src/Microsoft.Identity.Client/Features/ConfidentialClient/IConfidentialClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/ConfidentialClient/IConfidentialClientApplication.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Client
 
         /// <summary>
         /// Acquires security token from the authority using authorization code previously received.
-        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="IClientApplicationBase.AcquireTokenSilentAsync(System.Collections.Generic.IEnumerable{string}, IUser)"/>.
+        /// This method does not lookup token cache, but stores the result in it, so it can be looked up using other methods such as <see cref="IClientApplicationBase.AcquireTokenSilentAsync(System.Collections.Generic.IEnumerable{string}, IAccount)"/>.
         /// </summary>
         /// <param name="authorizationCode">The authorization code received from service authorization endpoint.</param>
         /// <param name="scopes">Array of scopes requested for resource</param>

--- a/msal/src/Microsoft.Identity.Client/Features/PublicClient/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/PublicClient/PublicClientApplication.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Client
         public PublicClientApplication(string clientId, string authority, TokenCache userTokenCache) : base(clientId,
             authority, PlatformPlugin.PlatformInformation.GetDefaultRedirectUri(clientId), true)
         {
-            UserTokenCache = userTokenCache;
+            AccountTokenCache = userTokenCache;
         }
     }
 }

--- a/msal/src/Microsoft.Identity.Client/IAccount.cs
+++ b/msal/src/Microsoft.Identity.Client/IAccount.cs
@@ -25,28 +25,31 @@
 //
 //------------------------------------------------------------------------------
 
-using System;
 
 namespace Microsoft.Identity.Client
 {
     /// <summary>
-    /// Contains information of a single user. This information is used for token cache lookup and enforcing the user session on STS authorize endpont.
+    /// Contains information of a single account and can be used to perform an AcquireTokenSilentAsync operation. The same user
+    /// can be present in different tenants, i.e. a user can have multiple accounts.
     /// </summary>
-    public interface IUser
+    public interface IAccount
     {
         /// <summary>
-        /// Gets a displayable value in UserPrincipalName (UPN) format. The value can be null.
+        /// Gets a displayable value in UserPrincipalName (UPN) format, e.g. "john.doe@contoso.com"
         /// </summary>
-        string DisplayableId { get; }
+        /// <remarks>Can be null</remarks>
+        string Username { get; }
 
         /// <summary>
-        /// Gets user`s environment.
+        /// Gets the identity provider for this account, e.g. "login.microsoftonline.com"
         /// </summary>
+        /// <remarks>Can be null</remarks>
         string Environment { get; }
 
         /// <summary>
-        /// Gets an identifier for the user that is used by the library and the service as a strong handle to user identity. Cannot be null.
+        /// Gets an identifier for the user that is used by the library and the service as a strong handle to user identity. 
         /// </summary>
-        string Identifier { get; }
+        /// <remarks>Can be null</remarks>
+        MsalAccountId HomeAccountId { get; }
    }
 }

--- a/msal/src/Microsoft.Identity.Client/IAccount.cs
+++ b/msal/src/Microsoft.Identity.Client/IAccount.cs
@@ -50,6 +50,6 @@ namespace Microsoft.Identity.Client
         /// Gets an identifier for the user that is used by the library and the service as a strong handle to user identity. 
         /// </summary>
         /// <remarks>Can be null</remarks>
-        MsalAccountId HomeAccountId { get; }
+        AccountId HomeAccountId { get; }
    }
 }

--- a/msal/src/Microsoft.Identity.Client/IClientApplicationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/IClientApplicationBase.cs
@@ -86,10 +86,10 @@ namespace Microsoft.Identity.Client
         /// close to expiration (within 5 minute window), then refresh token (if available) is used to acquire a new access token by making a network call.
         /// </summary>
         /// <param name="scopes">Array of scopes requested for resource</param>
-        /// <param name="user">User for which the token is requested. <see cref="IAccount"/></param>
+        /// <param name="account">Account for which the token is requested. <see cref="IAccount"/></param>
         Task<AuthenticationResult> AcquireTokenSilentAsync(
             IEnumerable<string> scopes,
-            IAccount user);
+            IAccount account);
 
         /// <summary>
         /// Attempts to acquire the access token from cache. Access token is considered a match if it AT LEAST contains all the requested scopes.
@@ -97,19 +97,19 @@ namespace Microsoft.Identity.Client
         /// close to expiration (within 5 minute window), then refresh token (if available) is used to acquire a new access token by making a network call.
         /// </summary>
         /// <param name="scopes">Array of scopes requested for resource</param>
-        /// <param name="user">User for which the token is requested <see cref="IAccount"/></param>
+        /// <param name="account">Account for which the token is requested <see cref="IAccount"/></param>
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <param name="forceRefresh">If TRUE, API will ignore the access token in the cache and attempt to acquire new access token using the refresh token if available</param>
         Task<AuthenticationResult> AcquireTokenSilentAsync(
             IEnumerable<string> scopes,
-            IAccount user,
+            IAccount account,
             string authority,
             bool forceRefresh);
 
         /// <summary>
         /// Removes all cached tokens for the specified user.
         /// </summary>
-        /// <param name="user">instance of the user that needs to be removed</param>
-        Task RemoveAsync(IAccount user);
+        /// <param name="account">instance of the user that needs to be removed</param>
+        Task RemoveAsync(IAccount account);
    }
 }

--- a/msal/src/Microsoft.Identity.Client/IClientApplicationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/IClientApplicationBase.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Returns a user-centric view over the cache that provides a list of all the available users in the cache.
         /// </summary>
-        Task<IEnumerable<IUser>> GetUsersAsync();
+        Task<IEnumerable<IAccount>> GetAccountsAsync();
 
         /// <summary>
         /// Sets or Gets the custom query parameters that may be sent to the STS for dogfood testing. This parameter should not be set by the 
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Client
         /// Get user by identifier from users available in the cache.
         /// </summary>
         /// <param name="identifier">user identifier</param>
-        Task<IUser> GetUserAsync(string identifier);
+        Task<IAccount> GetAccountAsync(string identifier);
 
         /// <summary>
         /// Attempts to acquire the access token from cache. Access token is considered a match if it AT LEAST contains all the requested scopes.
@@ -86,10 +86,10 @@ namespace Microsoft.Identity.Client
         /// close to expiration (within 5 minute window), then refresh token (if available) is used to acquire a new access token by making a network call.
         /// </summary>
         /// <param name="scopes">Array of scopes requested for resource</param>
-        /// <param name="user">User for which the token is requested. <see cref="IUser"/></param>
+        /// <param name="user">User for which the token is requested. <see cref="IAccount"/></param>
         Task<AuthenticationResult> AcquireTokenSilentAsync(
             IEnumerable<string> scopes,
-            IUser user);
+            IAccount user);
 
         /// <summary>
         /// Attempts to acquire the access token from cache. Access token is considered a match if it AT LEAST contains all the requested scopes.
@@ -97,12 +97,12 @@ namespace Microsoft.Identity.Client
         /// close to expiration (within 5 minute window), then refresh token (if available) is used to acquire a new access token by making a network call.
         /// </summary>
         /// <param name="scopes">Array of scopes requested for resource</param>
-        /// <param name="user">User for which the token is requested <see cref="IUser"/></param>
+        /// <param name="user">User for which the token is requested <see cref="IAccount"/></param>
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <param name="forceRefresh">If TRUE, API will ignore the access token in the cache and attempt to acquire new access token using the refresh token if available</param>
         Task<AuthenticationResult> AcquireTokenSilentAsync(
             IEnumerable<string> scopes,
-            IUser user,
+            IAccount user,
             string authority,
             bool forceRefresh);
 
@@ -110,6 +110,6 @@ namespace Microsoft.Identity.Client
         /// Removes all cached tokens for the specified user.
         /// </summary>
         /// <param name="user">instance of the user that needs to be removed</param>
-        Task RemoveAsync(IUser user);
+        Task RemoveAsync(IAccount user);
    }
 }

--- a/msal/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing token of the user</returns>
         Task<AuthenticationResult> AcquireTokenAsync(
             IEnumerable<string> scopes,
-            IUser user);
+            IAccount user);
 
         /// <summary>
         /// Interactive request to acquire token. 
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing token of the user</returns>
         Task<AuthenticationResult> AcquireTokenAsync(
             IEnumerable<string> scopes,
-            IUser user,
+            IAccount user,
             UIBehavior behavior,
             string extraQueryParameters);
 
@@ -131,7 +131,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing token of the user</returns>
         Task<AuthenticationResult> AcquireTokenAsync(
             IEnumerable<string> scopes,
-            IUser user,
+            IAccount user,
             UIBehavior behavior,
             string extraQueryParameters,
             IEnumerable<string> extraScopesToConsent,
@@ -168,7 +168,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing token of the user</returns>
         Task<AuthenticationResult> AcquireTokenAsync(
             IEnumerable<string> scopes,
-            IUser user, UIParent parent);
+            IAccount user, UIParent parent);
 
         /// <summary>
         /// Interactive request to acquire token. 
@@ -196,7 +196,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing token of the user</returns>
         Task<AuthenticationResult> AcquireTokenAsync(
             IEnumerable<string> scopes,
-            IUser user,
+            IAccount user,
             UIBehavior behavior,
             string extraQueryParameters, UIParent parent);
 
@@ -231,7 +231,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing token of the user</returns>
         Task<AuthenticationResult> AcquireTokenAsync(
             IEnumerable<string> scopes,
-            IUser user,
+            IAccount user,
             UIBehavior behavior,
             string extraQueryParameters,
             IEnumerable<string> extraScopesToConsent,

--- a/msal/src/Microsoft.Identity.Client/Internal/ModuleInitializer.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/ModuleInitializer.cs
@@ -50,15 +50,13 @@ namespace Microsoft.Identity.Client.Internal
         }
 
         public static void EnsureModuleInitialized()
-        {
+        {            
             lock (lockObj)
             {
                 if (!isInitialized)
                 {
                     CoreExceptionFactory.Instance = new MsalExceptionFactory();
-#if !FACADE
                     CoreLoggerBase.Default = new MsalLogger(Guid.Empty, null);
-#endif
                     isInitialized = true;
                 }
             }

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/AuthenticationRequestParameters.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         public string ExtraQueryParameters { get; set; }
 
-        public IUser User { get; set; }
+        public IAccount Account { get; set; }
 
         public ClientInfo ClientInfo { get; set; }
 
@@ -127,7 +127,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             builder.AppendLine("Redirect Uri - " + RedirectUri?.OriginalString);
             builder.AppendLine("Validate Authority? - " + ValidateAuthority);
             builder.AppendLine("LoginHint provided? - " + !string.IsNullOrEmpty(LoginHint));
-            builder.AppendLine("User provided? - " + (User != null));
+            builder.AppendLine("User provided? - " + (Account != null));
             var dict = CoreHelpers.ParseKeyValueList(ExtraQueryParameters, '&', true, RequestContext);
             builder.AppendLine("Extra Query Params Keys (space separated) - " + dict.Keys.AsSingleString());
             dict = CoreHelpers.ParseKeyValueList(SliceParameters, '&', true, RequestContext);
@@ -148,7 +148,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             builder.AppendLine("Scopes - " + Scope?.AsSingleString());
             builder.AppendLine("Validate Authority? - " + ValidateAuthority);
             builder.AppendLine("LoginHint provided? - " + !string.IsNullOrEmpty(LoginHint));
-            builder.AppendLine("User provided? - " + (User != null));
+            builder.AppendLine("User provided? - " + (Account != null));
             dict = CoreHelpers.ParseKeyValueList(ExtraQueryParameters, '&', true, RequestContext);
             builder.AppendLine("Extra Query Params Keys (space separated) - " + dict.Keys.AsSingleString());
             dict = CoreHelpers.ParseKeyValueList(SliceParameters, '&', true, RequestContext);

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         public InteractiveRequest(AuthenticationRequestParameters authenticationRequestParameters,
             IEnumerable<string> extraScopesToConsent, UIBehavior UIBehavior, IWebUI webUI)
             : this(
-                authenticationRequestParameters, extraScopesToConsent, authenticationRequestParameters.User?.DisplayableId,
+                authenticationRequestParameters, extraScopesToConsent, authenticationRequestParameters.Account?.Username,
                 UIBehavior, webUI)
         {
         }
@@ -159,18 +159,18 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 requestParameters[OAuth2Parameter.State] = _state;
             }
             //add uid/utid values to QP if user object was passed in.
-            if (AuthenticationRequestParameters.User != null)
+            if (AuthenticationRequestParameters.Account != null)
             {
-                if (!string.IsNullOrEmpty(AuthenticationRequestParameters.User.DisplayableId))
+                if (!string.IsNullOrEmpty(AuthenticationRequestParameters.Account.Username))
                 {
-                    requestParameters[OAuth2Parameter.LoginHint] = AuthenticationRequestParameters.User.DisplayableId;
+                    requestParameters[OAuth2Parameter.LoginHint] = AuthenticationRequestParameters.Account.Username;
                 }
 
-                AuthenticationRequestParameters.ClientInfo = ClientInfo.CreateFromUserIdentifier(AuthenticationRequestParameters.User.Identifier);
+                AuthenticationRequestParameters.ClientInfo = MsalAccountId.ToClientInfo(AuthenticationRequestParameters.Account.HomeAccountId);
 
-                if (!string.IsNullOrEmpty(AuthenticationRequestParameters.ClientInfo.UniqueIdentifier))
+                if (!string.IsNullOrEmpty(AuthenticationRequestParameters.ClientInfo.UniqueObjectIdentifier))
                 {
-                    requestParameters[OAuth2Parameter.LoginReq] = AuthenticationRequestParameters.ClientInfo.UniqueIdentifier;
+                    requestParameters[OAuth2Parameter.LoginReq] = AuthenticationRequestParameters.ClientInfo.UniqueObjectIdentifier;
                 }
 
                 if (!string.IsNullOrEmpty(AuthenticationRequestParameters.ClientInfo.UniqueTenantIdentifier))

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     requestParameters[OAuth2Parameter.LoginHint] = AuthenticationRequestParameters.Account.Username;
                 }
 
-                AuthenticationRequestParameters.ClientInfo = MsalAccountId.ToClientInfo(AuthenticationRequestParameters.Account.HomeAccountId);
+                AuthenticationRequestParameters.ClientInfo = AccountId.ToClientInfo(AuthenticationRequestParameters.Account.HomeAccountId);
 
                 if (!string.IsNullOrEmpty(AuthenticationRequestParameters.ClientInfo.UniqueObjectIdentifier))
                 {

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -133,11 +133,12 @@ namespace Microsoft.Identity.Client.Internal.Requests
         {
             //this method is the common entrance for all token requests, so it is a good place to put the generic Telemetry logic here
             AuthenticationRequestParameters.RequestContext.TelemetryRequestId = Telemetry.GetInstance().GenerateNewRequestId();
+            string accountId = AuthenticationRequestParameters.Account?.HomeAccountId?.Identifier;
             var apiEvent = new ApiEvent()
             {
                 ApiId = ApiId,
                 ValidationStatus = AuthenticationRequestParameters.ValidateAuthority.ToString(),
-                UserId = AuthenticationRequestParameters.User != null ? AuthenticationRequestParameters.User.Identifier : "",
+                AccountId = accountId ?? "",
                 CorrelationId = AuthenticationRequestParameters.RequestContext.Logger.CorrelationId.ToString(),
                 RequestId = AuthenticationRequestParameters.RequestContext.TelemetryRequestId,
                 IsConfidentialClient = IsConfidentialClient,
@@ -162,7 +163,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 await PostRunAsync(result).ConfigureAwait(false);
 
                 apiEvent.TenantId = result.TenantId;
-                apiEvent.UserId = result.UniqueId;
+                apiEvent.AccountId = result.UniqueId;
                 apiEvent.WasSuccessful = true;
                 return result;
             }
@@ -205,7 +206,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             if (fromServer!= null && AuthenticationRequestParameters.ClientInfo != null)
             {
-                if (!fromServer.UniqueIdentifier.Equals(AuthenticationRequestParameters.ClientInfo.UniqueIdentifier, StringComparison.OrdinalIgnoreCase) ||
+                if (!fromServer.UniqueObjectIdentifier.Equals(AuthenticationRequestParameters.ClientInfo.UniqueObjectIdentifier, StringComparison.OrdinalIgnoreCase) ||
                     !fromServer.UniqueTenantIdentifier.Equals(AuthenticationRequestParameters.ClientInfo.UniqueTenantIdentifier, StringComparison.OrdinalIgnoreCase))
                 {
                     AuthenticationRequestParameters.RequestContext.Logger.Error("Returned user identifiers do not match the sent user" +
@@ -214,8 +215,8 @@ namespace Microsoft.Identity.Client.Internal.Requests
                     AuthenticationRequestParameters.RequestContext.Logger.ErrorPii(String.Format(
                         CultureInfo.InvariantCulture,
                         "Returned user identifiers (uid:{0} utid:{1}) does not meatch the sent user identifier (uid:{2} utid:{3})",
-                        fromServer.UniqueIdentifier, fromServer.UniqueTenantIdentifier,
-                        AuthenticationRequestParameters.ClientInfo.UniqueIdentifier,
+                        fromServer.UniqueObjectIdentifier, fromServer.UniqueTenantIdentifier,
+                        AuthenticationRequestParameters.ClientInfo.UniqueObjectIdentifier,
                         AuthenticationRequestParameters.ClientInfo.UniqueTenantIdentifier));
 
                     throw new MsalServiceException("user_mismatch", "Returned user identifier does not match the sent user identifier");

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
         public SilentRequest(AuthenticationRequestParameters authenticationRequestParameters, bool forceRefresh)
             : base(authenticationRequestParameters)
         {
-            if (authenticationRequestParameters.User == null)
+            if (authenticationRequestParameters.Account == null)
             {
                 throw new MsalUiRequiredException(MsalUiRequiredException.UserNullError, "Null user was passed in AcquiretokenSilent API. Pass in " +
                                                                                          "a user object or call acquireToken authenticate.");

--- a/msal/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/msal/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -59,6 +59,7 @@
     <None Include="**\*.cs;**\*.xml;**\*.axml" Exclude="obj\**\*.*;bin\**\*.*" />
     <Compile Remove="Platforms\**\*.*" />
     <Compile Remove="Features\**\*.*" />
+    <None Remove="MsalAccountId.cs" />
     <EmbeddedResource Include="Properties\Microsoft.Identity.Client.rd.xml" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3'">
@@ -173,6 +174,6 @@
     <CodeAnalysisRuleSet>../../../core/ConfigureAwait.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="All"/>
+    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/msal/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
+++ b/msal/src/Microsoft.Identity.Client/Microsoft.Identity.Client.csproj
@@ -59,7 +59,6 @@
     <None Include="**\*.cs;**\*.xml;**\*.axml" Exclude="obj\**\*.*;bin\**\*.*" />
     <Compile Remove="Platforms\**\*.*" />
     <Compile Remove="Features\**\*.*" />
-    <None Remove="MsalAccountId.cs" />
     <EmbeddedResource Include="Properties\Microsoft.Identity.Client.rd.xml" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.1' or '$(TargetFramework)' == 'netstandard1.3'">

--- a/msal/src/Microsoft.Identity.Client/MsalAccountId.cs
+++ b/msal/src/Microsoft.Identity.Client/MsalAccountId.cs
@@ -113,7 +113,6 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// GetHashCode implementation to match <see cref="Equals(object)"/>
         /// </summary>
-        /// <returns></returns>
         public override int GetHashCode()
         {
             return this.Identifier.GetHashCode();

--- a/msal/src/Microsoft.Identity.Client/MsalAccountId.cs
+++ b/msal/src/Microsoft.Identity.Client/MsalAccountId.cs
@@ -1,0 +1,122 @@
+﻿//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+
+using Microsoft.Identity.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client
+{
+    /// <summary>
+    /// An identifier for an account in a specific tenant
+    /// </summary>
+    public class MsalAccountId
+    {
+        /// <summary>
+        /// An identifier for an account in a specific tenant
+        /// </summary>
+        public string Identifier { get; }
+
+        /// <summary>
+        /// The object id associated with the user that owns the account
+        /// </summary>
+        public string ObjectId { get;  }
+
+        /// <summary>
+        /// The tenant id where the account resides
+        /// </summary>
+        public string TenantId { get;  }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        public MsalAccountId(string identifier, string objectId, string tenantId)
+        {
+            if (identifier == null)
+            {
+                throw new ArgumentNullException(nameof(identifier));
+            }
+
+            this.Identifier = identifier;
+            this.ObjectId = objectId;
+            this.TenantId = tenantId;
+        }
+
+        internal static MsalAccountId FromClientInfo(ClientInfo clientInfo)
+        {
+            if (clientInfo == null)
+            {
+                throw new ArgumentNullException(nameof(clientInfo));
+            }
+
+            return new MsalAccountId(
+                clientInfo.ToAccountIdentifier(),
+                clientInfo.UniqueObjectIdentifier,
+                clientInfo.UniqueTenantIdentifier);
+        }
+
+        internal static ClientInfo ToClientInfo(MsalAccountId msalAccountId)
+        {
+            if (msalAccountId == null)
+            {
+                throw new ArgumentNullException(nameof(msalAccountId));
+            }
+
+            return new ClientInfo()
+            {
+                UniqueObjectIdentifier = msalAccountId.ObjectId,
+                UniqueTenantIdentifier = msalAccountId.TenantId
+            };
+        }
+
+        /// <summary>
+        /// Two accounts are equal when their <see cref="Identifier"/> properties match
+        /// </summary>
+        public override bool Equals(object obj)
+        {
+            if (obj == null) { return false; }
+
+            var otherMsalAccountId = obj as MsalAccountId;
+            if (otherMsalAccountId == null) { return false; }
+
+            return this.Identifier == otherMsalAccountId.Identifier;
+        }
+
+        /// <summary>
+        /// GetHashCode implementation to match <see cref="Equals(object)"/>
+        /// </summary>
+        /// <returns></returns>
+        public override int GetHashCode()
+        {
+            return this.Identifier.GetHashCode();
+        }
+    }
+}

--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing token of the user</returns>
         public async Task<AuthenticationResult> AcquireTokenAsync(
             IEnumerable<string> scopes,
-            IUser user)
+            IAccount user)
         {
             Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             return
@@ -151,7 +151,7 @@ namespace Microsoft.Identity.Client
         /// <param name="behavior">Enumeration to control UI behavior.</param>
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IUser user,
+        public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IAccount user,
             UIBehavior behavior, string extraQueryParameters)
         {
             Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
@@ -191,7 +191,7 @@ namespace Microsoft.Identity.Client
         /// <param name="extraScopesToConsent">Array of scopes for which a developer can request consent upfront.</param>
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IUser user,
+        public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IAccount user,
             UIBehavior behavior, string extraQueryParameters, IEnumerable<string> extraScopesToConsent, string authority)
         {
             Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
@@ -242,7 +242,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing token of the user</returns>
         public async Task<AuthenticationResult> AcquireTokenAsync(
             IEnumerable<string> scopes,
-            IUser user, UIParent parent)
+            IAccount user, UIParent parent)
         {
             Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
             return
@@ -279,7 +279,7 @@ namespace Microsoft.Identity.Client
         /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
         /// <param name="parent">Object contains reference to parent window/activity. REQUIRED for Xamarin.Android only.</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IUser user,
+        public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IAccount user,
             UIBehavior behavior, string extraQueryParameters, UIParent parent)
         {
             Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
@@ -321,7 +321,7 @@ namespace Microsoft.Identity.Client
         /// <param name="authority">Specific authority for which the token is requested. Passing a different value than configured does not change the configured value</param>
         /// <param name="parent">Object contains reference to parent window/activity. REQUIRED for Xamarin.Android only.</param>
         /// <returns>Authentication result containing token of the user</returns>
-        public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IUser user,
+        public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IAccount user,
             UIBehavior behavior, string extraQueryParameters, IEnumerable<string> extraScopesToConsent, string authority, UIParent parent)
         {
             Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
@@ -371,7 +371,7 @@ namespace Microsoft.Identity.Client
         }
 
         private async Task<AuthenticationResult> AcquireTokenForUserCommonAsync(Authority authority, IEnumerable<string> scopes,
-            IEnumerable<string> extraScopesToConsent, IUser user, UIBehavior behavior, string extraQueryParameters, UIParent parent, ApiEvent.ApiIds apiId)
+            IEnumerable<string> extraScopesToConsent, IAccount user, UIBehavior behavior, string extraQueryParameters, UIParent parent, ApiEvent.ApiIds apiId)
         {
             var requestParams = CreateRequestParameters(authority, scopes, user, UserTokenCache);
             requestParams.ExtraQueryParameters = extraQueryParameters;
@@ -390,7 +390,7 @@ namespace Microsoft.Identity.Client
         }
 
         internal override AuthenticationRequestParameters CreateRequestParameters(Authority authority,
-            IEnumerable<string> scopes, IUser user, TokenCache cache)
+            IEnumerable<string> scopes, IAccount user, TokenCache cache)
         {
             AuthenticationRequestParameters parameters = base.CreateRequestParameters(authority, scopes, user, cache);
             return parameters;

--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Identity.Client
         public PublicClientApplication(string clientId, string authority)
             : base(clientId, authority, PlatformPlugin.PlatformInformation.GetDefaultRedirectUri(clientId), true)
         {
-            UserTokenCache = new TokenCache()
+            AccountTokenCache = new TokenCache()
             {
                 ClientId = clientId
             };
@@ -354,7 +354,7 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> extraScopesToConsent, string loginHint, UIBehavior behavior,
             string extraQueryParameters, UIParent parent, ApiEvent.ApiIds apiId)
         {
-            var requestParams = CreateRequestParameters(authority, scopes, null, UserTokenCache);
+            var requestParams = CreateRequestParameters(authority, scopes, null, AccountTokenCache);
             requestParams.ExtraQueryParameters = extraQueryParameters;
 
 #if iOS || ANDROID
@@ -373,7 +373,7 @@ namespace Microsoft.Identity.Client
         private async Task<AuthenticationResult> AcquireTokenForUserCommonAsync(Authority authority, IEnumerable<string> scopes,
             IEnumerable<string> extraScopesToConsent, IAccount user, UIBehavior behavior, string extraQueryParameters, UIParent parent, ApiEvent.ApiIds apiId)
         {
-            var requestParams = CreateRequestParameters(authority, scopes, user, UserTokenCache);
+            var requestParams = CreateRequestParameters(authority, scopes, user, AccountTokenCache);
             requestParams.ExtraQueryParameters = extraQueryParameters;
 
 #if iOS || ANDROID

--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Identity.Client
         public PublicClientApplication(string clientId, string authority)
             : base(clientId, authority, PlatformPlugin.PlatformInformation.GetDefaultRedirectUri(clientId), true)
         {
-            AccountTokenCache = new TokenCache()
+            UserTokenCache = new TokenCache()
             {
                 ClientId = clientId
             };
@@ -354,7 +354,7 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> extraScopesToConsent, string loginHint, UIBehavior behavior,
             string extraQueryParameters, UIParent parent, ApiEvent.ApiIds apiId)
         {
-            var requestParams = CreateRequestParameters(authority, scopes, null, AccountTokenCache);
+            var requestParams = CreateRequestParameters(authority, scopes, null, UserTokenCache);
             requestParams.ExtraQueryParameters = extraQueryParameters;
 
 #if iOS || ANDROID
@@ -373,7 +373,7 @@ namespace Microsoft.Identity.Client
         private async Task<AuthenticationResult> AcquireTokenForUserCommonAsync(Authority authority, IEnumerable<string> scopes,
             IEnumerable<string> extraScopesToConsent, IAccount user, UIBehavior behavior, string extraQueryParameters, UIParent parent, ApiEvent.ApiIds apiId)
         {
-            var requestParams = CreateRequestParameters(authority, scopes, user, AccountTokenCache);
+            var requestParams = CreateRequestParameters(authority, scopes, user, UserTokenCache);
             requestParams.ExtraQueryParameters = extraQueryParameters;
 
 #if iOS || ANDROID

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Identity.Client
                         ClientId = ClientId,
                         Account = msalAccessTokenCacheItem.HomeAccountId != null ?
                                     new Account(
-                                        MsalAccountId.FromClientInfo(msalAccessTokenCacheItem.ClientInfo),
+                                        AccountId.FromClientInfo(msalAccessTokenCacheItem.ClientInfo),
                                         idToken?.PreferredUsername,
                                         idToken?.Name) : 
                                     null
@@ -584,7 +584,7 @@ namespace Microsoft.Identity.Client
                         TokenCache = this,
                         ClientId = ClientId,
                         Account = new Account(
-                            MsalAccountId.FromClientInfo(msalIdTokenCacheItem.ClientInfo),
+                            AccountId.FromClientInfo(msalIdTokenCacheItem.ClientInfo),
                             msalIdTokenCacheItem?.IdToken?.PreferredUsername, msalRefreshTokenCacheItem.Environment)
                     };
 
@@ -611,7 +611,7 @@ namespace Microsoft.Identity.Client
                     {
                         TokenCache = this,
                         ClientId = ClientId,
-                        Account = new Account(MsalAccountId.FromClientInfo(msalAccessTokenCacheItem.ClientInfo),
+                        Account = new Account(AccountId.FromClientInfo(msalAccessTokenCacheItem.ClientInfo),
                             msalIdTokenCacheItem?.IdToken?.PreferredUsername, msalAccessTokenCacheItem.Environment)
                     };
 
@@ -797,7 +797,7 @@ namespace Microsoft.Identity.Client
                             if (rtItem.HomeAccountId.Equals(account.HomeAccountId, StringComparison.OrdinalIgnoreCase) &&
                                 authorityHostAliases.Contains(account.Environment))
                             {
-                                Account user = new Account(MsalAccountId.FromClientInfo(account.ClientInfo), account.PreferredUsername, new Uri(authority).Host);
+                                Account user = new Account(AccountId.FromClientInfo(account.ClientInfo), account.PreferredUsername, new Uri(authority).Host);
                                 allUsers[rtItem.HomeAccountId] = user;
                                 break;
                             }
@@ -814,7 +814,7 @@ namespace Microsoft.Identity.Client
                     if (!allUsers.ContainsKey(userIdentifier))
                     {
                         allUsers[userIdentifier] = new Account(
-                             MsalAccountId.FromClientInfo(clientInfo), 
+                             AccountId.FromClientInfo(clientInfo), 
                             pair.Value.DisplayableId, 
                             new Uri(authority).Host);
                     }
@@ -1169,7 +1169,7 @@ namespace Microsoft.Identity.Client
                     TokenCache = this,
                     ClientId = ClientId,
                     Account = msalIdTokenCacheItem != null ? new Account(
-                        MsalAccountId.FromClientInfo(msalIdTokenCacheItem.ClientInfo),
+                        AccountId.FromClientInfo(msalIdTokenCacheItem.ClientInfo),
                         msalIdTokenCacheItem.IdToken?.PreferredUsername, 
                         msalAccessTokenCacheItem.Environment) : null
                 };
@@ -1207,7 +1207,7 @@ namespace Microsoft.Identity.Client
                     ClientId = ClientId,
                     Account = msalIdTokenCacheItem != null ? 
                            new Account(
-                               MsalAccountId.FromClientInfo(msalIdTokenCacheItem.ClientInfo),
+                               AccountId.FromClientInfo(msalIdTokenCacheItem.ClientInfo),
                                msalIdTokenCacheItem.IdToken.PreferredUsername, 
                                msalIdTokenCacheItem.IdToken.Name) : null
                 };

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -140,8 +140,11 @@ namespace Microsoft.Identity.Client
                     {
                         TokenCache = this,
                         ClientId = ClientId,
-                        User = msalAccessTokenCacheItem.HomeAccountId != null ?
-                                    new User(msalAccessTokenCacheItem.HomeAccountId, idToken?.PreferredUsername, idToken?.Name) : 
+                        Account = msalAccessTokenCacheItem.HomeAccountId != null ?
+                                    new Account(
+                                        MsalAccountId.FromClientInfo(msalAccessTokenCacheItem.ClientInfo),
+                                        idToken?.PreferredUsername,
+                                        idToken?.Name) : 
                                     null
                     };
 
@@ -287,7 +290,7 @@ namespace Microsoft.Identity.Client
                 {
                     TokenCache = this,
                     ClientId = ClientId,
-                    User = requestParams.User
+                    Account = requestParams.Account
                 };
 
                 OnBeforeAccess(args);
@@ -319,7 +322,7 @@ namespace Microsoft.Identity.Client
                         //filter by identifier of the user instead
                         tokenCacheItems =
                             tokenCacheItems
-                                .Where(item => item.HomeAccountId.Equals(requestParams.User?.Identifier, StringComparison.OrdinalIgnoreCase))
+                                .Where(item => item.HomeAccountId.Equals(requestParams.Account?.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase))
                                 .ToList();
                     }
                 }
@@ -507,11 +510,11 @@ namespace Microsoft.Identity.Client
                 {
                     TokenCache = this,
                     ClientId = ClientId,
-                    User = requestParam.User
+                    Account = requestParam.Account
                 };
 
                 MsalRefreshTokenCacheKey key = new MsalRefreshTokenCacheKey(
-                    preferredEnvironmentHost, requestParam.ClientId, requestParam.User?.Identifier);
+                    preferredEnvironmentHost, requestParam.ClientId, requestParam.Account?.HomeAccountId?.Identifier);
 
                 OnBeforeAccess(args);
                 MsalRefreshTokenCacheItem msalRefreshTokenCacheItem =
@@ -534,7 +537,7 @@ namespace Microsoft.Identity.Client
                         if (msalRefreshToken != null &&
                             msalRefreshToken.ClientId.Equals(requestParam.ClientId, StringComparison.OrdinalIgnoreCase) &&
                             authorityHostAliases.Contains(msalRefreshToken.Environment) &&
-                            requestParam.User?.Identifier == msalRefreshToken.HomeAccountId)
+                            requestParam.Account?.HomeAccountId.Identifier == msalRefreshToken.HomeAccountId)
                         {
                             msalRefreshTokenCacheItem = msalRefreshToken;
                             continue;
@@ -554,13 +557,18 @@ namespace Microsoft.Identity.Client
                 requestParam.RequestContext.Logger.Info("Checking ADAL cache for matching RT");
                 requestParam.RequestContext.Logger.InfoPii("Checking ADAL cache for matching RT");
 
-                if (requestParam.User == null)
+                if (requestParam.Account == null)
                 {
                     return null;
                 }
-                return CacheFallbackOperations.GetAdalEntryForMsal(legacyCachePersistance,
-                    preferredEnvironmentHost, authorityHostAliases, 
-                    requestParam.ClientId, requestParam.LoginHint, requestParam.User.Identifier, null);
+                return CacheFallbackOperations.GetAdalEntryForMsal(
+                    legacyCachePersistance,
+                    preferredEnvironmentHost,
+                    authorityHostAliases, 
+                    requestParam.ClientId, 
+                    requestParam.LoginHint, 
+                    requestParam.Account.HomeAccountId?.Identifier, 
+                    null);
             }
         }
 
@@ -575,7 +583,8 @@ namespace Microsoft.Identity.Client
                     {
                         TokenCache = this,
                         ClientId = ClientId,
-                        User = new User(msalIdTokenCacheItem.HomeAccountId,
+                        Account = new Account(
+                            MsalAccountId.FromClientInfo(msalIdTokenCacheItem.ClientInfo),
                             msalIdTokenCacheItem?.IdToken?.PreferredUsername, msalRefreshTokenCacheItem.Environment)
                     };
 
@@ -602,7 +611,7 @@ namespace Microsoft.Identity.Client
                     {
                         TokenCache = this,
                         ClientId = ClientId,
-                        User = new User(msalAccessTokenCacheItem.HomeAccountId,
+                        Account = new Account(MsalAccountId.FromClientInfo(msalAccessTokenCacheItem.ClientInfo),
                             msalIdTokenCacheItem?.IdToken?.PreferredUsername, msalAccessTokenCacheItem.Environment)
                     };
 
@@ -625,7 +634,7 @@ namespace Microsoft.Identity.Client
                 {
                     TokenCache = this,
                     ClientId = ClientId,
-                    User = null
+                    Account = null
                 };
 
                 OnBeforeAccess(args);
@@ -644,7 +653,7 @@ namespace Microsoft.Identity.Client
                 {
                     TokenCache = this,
                     ClientId = ClientId,
-                    User = null
+                    Account = null
                 };
 
                 OnBeforeAccess(args);
@@ -663,7 +672,7 @@ namespace Microsoft.Identity.Client
                 {
                     TokenCache = this,
                     ClientId = ClientId,
-                    User = null
+                    Account = null
                 };
 
                 OnBeforeAccess(args);
@@ -682,7 +691,7 @@ namespace Microsoft.Identity.Client
                 {
                     TokenCache = this,
                     ClientId = ClientId,
-                    User = null
+                    Account = null
                 };
 
                 OnBeforeAccess(args);
@@ -757,7 +766,7 @@ namespace Microsoft.Identity.Client
             return preferredEnvironmentHost;
         }
 
-        internal async Task<IEnumerable<IUser>> GetUsersAsync(string authority, bool validateAuthority, RequestContext requestContext)
+        internal async Task<IEnumerable<IAccount>> GetAccountsAsync(string authority, bool validateAuthority, RequestContext requestContext)
         {
             var instanceDiscoveryMetadataEntry = 
                 await GetCachedOrDiscoverAuthorityMetaDataAsync(authority, validateAuthority, requestContext).ConfigureAwait(false);
@@ -770,7 +779,7 @@ namespace Microsoft.Identity.Client
                 {
                     TokenCache = this,
                     ClientId = ClientId,
-                    User = null
+                    Account = null
                 };
 
                 OnBeforeAccess(args);
@@ -778,7 +787,7 @@ namespace Microsoft.Identity.Client
                 ICollection<MsalAccountCacheItem> accountCacheItems = GetAllAccounts(requestContext);
                 OnAfterAccess(args);
 
-                IDictionary<string, User> allUsers = new Dictionary<string, User>();
+                IDictionary<string, Account> allUsers = new Dictionary<string, Account>();
                 foreach (MsalRefreshTokenCacheItem rtItem in tokenCacheItems)
                 {
                     if (authorityHostAliases.Contains(rtItem.Environment))
@@ -788,7 +797,7 @@ namespace Microsoft.Identity.Client
                             if (rtItem.HomeAccountId.Equals(account.HomeAccountId, StringComparison.OrdinalIgnoreCase) &&
                                 authorityHostAliases.Contains(account.Environment))
                             {
-                                User user = new User(account.HomeAccountId, account.PreferredUsername, new Uri(authority).Host);
+                                Account user = new Account(MsalAccountId.FromClientInfo(account.ClientInfo), account.PreferredUsername, new Uri(authority).Host);
                                 allUsers[rtItem.HomeAccountId] = user;
                                 break;
                             }
@@ -799,11 +808,15 @@ namespace Microsoft.Identity.Client
                 foreach (KeyValuePair<string, AdalUserInfo> pair in CacheFallbackOperations.GetAllAdalUsersForMsal(
                     legacyCachePersistance, authorityHostAliases, ClientId))
                 {
-                    string userIdentifier = ClientInfo.CreateFromJson(pair.Key).ToUserIdentifier();
+                    ClientInfo clientInfo = ClientInfo.CreateFromJson(pair.Key);
+                    string userIdentifier = clientInfo.ToAccountIdentifier();
 
                     if (!allUsers.ContainsKey(userIdentifier))
                     {
-                        allUsers[userIdentifier] = new User(userIdentifier, pair.Value.DisplayableId, new Uri(authority).Host);
+                        allUsers[userIdentifier] = new Account(
+                             MsalAccountId.FromClientInfo(clientInfo), 
+                            pair.Value.DisplayableId, 
+                            new Uri(authority).Host);
                     }
                 }
 
@@ -876,7 +889,7 @@ namespace Microsoft.Identity.Client
             {
                 TokenCache = this,
                 ClientId = ClientId,
-                User = null
+                Account = null
             };
 
             OnBeforeAccess(args);
@@ -914,7 +927,7 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        internal async Task RemoveAsync(string authority, bool validateAuthority, IUser user, RequestContext requestContext)
+        internal async Task RemoveAsync(string authority, bool validateAuthority, IAccount account, RequestContext requestContext)
         {
             var instanceDiscoveryMetadataEntry =
                 await GetCachedOrDiscoverAuthorityMetaDataAsync(authority, validateAuthority, requestContext).ConfigureAwait(false);
@@ -927,12 +940,12 @@ namespace Microsoft.Identity.Client
                 requestContext.Logger.Info(msg);
                 requestContext.Logger.InfoPii(msg);
 
-                RemoveMsalUser(user, authorityHostAliases, requestContext);
-                RemoveAdalUser(user, authorityHostAliases);
+                RemoveMsalAccount(account, authorityHostAliases, requestContext);
+                RemoveAdalUser(account, authorityHostAliases);
             }
         }
 
-        internal void RemoveMsalUser(IUser user, ISet<string> authorityHostAliases, RequestContext requestContext)
+        internal void RemoveMsalAccount(IAccount account, ISet<string> authorityHostAliases, RequestContext requestContext)
         {
             lock (LockObject)
             {
@@ -946,13 +959,13 @@ namespace Microsoft.Identity.Client
                     {
                         TokenCache = this,
                         ClientId = ClientId,
-                        User = user
+                        Account = account
                     };
 
                     OnBeforeAccess(args);
                     OnBeforeWrite(args);
                     IList<MsalRefreshTokenCacheItem> allRefreshTokens = GetAllRefreshTokensForClient(requestContext)
-                        .Where(item => item.HomeAccountId.Equals(user.Identifier, StringComparison.OrdinalIgnoreCase) &&
+                        .Where(item => item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase) &&
                                        authorityHostAliases.Contains(item.Environment))
                         .ToList();
                     foreach (MsalRefreshTokenCacheItem refreshTokenCacheItem in allRefreshTokens)
@@ -964,7 +977,7 @@ namespace Microsoft.Identity.Client
                     requestContext.Logger.Info(msg);
                     requestContext.Logger.InfoPii(msg);
                     IList<MsalAccessTokenCacheItem> allAccessTokens = GetAllAccessTokensForClient(requestContext)
-                        .Where(item => item.HomeAccountId.Equals(user.Identifier, StringComparison.OrdinalIgnoreCase) &&
+                        .Where(item => item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase) &&
                                        authorityHostAliases.Contains(item.Environment))
                         .ToList();
                     foreach (MsalAccessTokenCacheItem accessTokenCacheItem in allAccessTokens)
@@ -977,7 +990,7 @@ namespace Microsoft.Identity.Client
                     requestContext.Logger.InfoPii(msg);
 
                     IList<MsalIdTokenCacheItem> allIdTokens = GetAllIdTokensForClient(requestContext)
-                        .Where(item => item.HomeAccountId.Equals(user.Identifier, StringComparison.OrdinalIgnoreCase) &&
+                        .Where(item => item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase) &&
                                        authorityHostAliases.Contains(item.Environment))
                         .ToList();
                     foreach (MsalIdTokenCacheItem idTokenCacheItem in allIdTokens)
@@ -990,7 +1003,7 @@ namespace Microsoft.Identity.Client
                     requestContext.Logger.InfoPii(msg);
 
                     IList<MsalAccountCacheItem> allAccounts = GetAllAccounts(requestContext)
-                        .Where(item => item.HomeAccountId.Equals(user.Identifier, StringComparison.OrdinalIgnoreCase) &&
+                        .Where(item => item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase) &&
                                        authorityHostAliases.Contains(item.Environment))
                         .ToList();
                     foreach (MsalAccountCacheItem accountCacheItem in allAccounts)
@@ -1011,9 +1024,9 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        internal void RemoveAdalUser(IUser user, ISet<string> authorityHostAliases)
+        internal void RemoveAdalUser(IAccount account, ISet<string> authorityHostAliases)
         {
-            CacheFallbackOperations.RemoveAdalUser(legacyCachePersistance, user.DisplayableId, authorityHostAliases, user.Identifier);
+            CacheFallbackOperations.RemoveAdalUser(legacyCachePersistance, account.Username, authorityHostAliases, account.HomeAccountId.Identifier);
         }
 
         internal ICollection<string> GetAllAccessTokenCacheItems(RequestContext requestContext)
@@ -1128,7 +1141,7 @@ namespace Microsoft.Identity.Client
                 {
                     TokenCache = this,
                     ClientId = ClientId,
-                    User = null
+                    Account = null
                 };
 
                 OnBeforeAccess(args);
@@ -1155,8 +1168,10 @@ namespace Microsoft.Identity.Client
                 {
                     TokenCache = this,
                     ClientId = ClientId,
-                    User = msalIdTokenCacheItem != null ? new User(msalIdTokenCacheItem.HomeAccountId,
-                        msalIdTokenCacheItem.IdToken?.PreferredUsername, msalAccessTokenCacheItem.Environment) : null
+                    Account = msalIdTokenCacheItem != null ? new Account(
+                        MsalAccountId.FromClientInfo(msalIdTokenCacheItem.ClientInfo),
+                        msalIdTokenCacheItem.IdToken?.PreferredUsername, 
+                        msalAccessTokenCacheItem.Environment) : null
                 };
 
                 try
@@ -1190,9 +1205,11 @@ namespace Microsoft.Identity.Client
                 {
                     TokenCache = this,
                     ClientId = ClientId,
-                    User = msalIdTokenCacheItem != null ? 
-                           new User(msalIdTokenCacheItem.HomeAccountId, msalIdTokenCacheItem.IdToken.PreferredUsername, 
-                                msalIdTokenCacheItem.IdToken.Name) : null
+                    Account = msalIdTokenCacheItem != null ? 
+                           new Account(
+                               MsalAccountId.FromClientInfo(msalIdTokenCacheItem.ClientInfo),
+                               msalIdTokenCacheItem.IdToken.PreferredUsername, 
+                               msalIdTokenCacheItem.IdToken.Name) : null
                 };
 
                 try

--- a/msal/src/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -45,6 +45,6 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Gets the user object.
         /// </summary>
-        public IUser User { get; internal set; }
+        public IAccount Account { get; internal set; }
     }
 }

--- a/msal/src/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -38,12 +38,12 @@ namespace Microsoft.Identity.Client
         public TokenCache TokenCache { get; internal set; }
 
         /// <summary>
-        /// Gets the ClientId.
+        /// Gets the ClientId
         /// </summary>
         public string ClientId { get; internal set; }
 
         /// <summary>
-        /// Gets the user object.
+        /// Gets the account associated with this notification
         /// </summary>
         public IAccount Account { get; internal set; }
     }

--- a/msal/tests/AutomationApp/AutomationUI.cs
+++ b/msal/tests/AutomationApp/AutomationUI.cs
@@ -111,7 +111,7 @@ namespace AutomationApp
             accessTokenResult.Text = authenticationResult.AccessToken;
             expiresOnResult.Text = authenticationResult.ExpiresOn.ToString();
             tenantIdResult.Text = authenticationResult.TenantId;
-            userResult.Text = authenticationResult.User.DisplayableId;
+            userResult.Text = authenticationResult.Account.Username;
             idTokenResult.Text = authenticationResult.IdToken;
             scopeResult.DataSource = authenticationResult.Scopes;
         }

--- a/msal/tests/AutomationApp/TokenHandler.cs
+++ b/msal/tests/AutomationApp/TokenHandler.cs
@@ -34,7 +34,7 @@ namespace AutomationApp
     public class TokenHandler
     {
         #region Properties
-        public IUser CurrentUser { get; set; }
+        public IAccount CurrentUser { get; set; }
 
         private PublicClientApplication _publicClientApplication;
         #endregion
@@ -58,7 +58,7 @@ namespace AutomationApp
                 await
                     _publicClientApplication.AcquireTokenAsync(scope)
                         .ConfigureAwait(false);
-            CurrentUser = result.User;
+            CurrentUser = result.Account;
             return result;
         }
 

--- a/msal/tests/Test.MSAL.NET.Unit/AccountTest.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/AccountTest.cs
@@ -1,4 +1,4 @@
-﻿//------------------------------------------------------------------------------
+﻿//----------------------------------------------------------------------
 //
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
@@ -25,23 +25,23 @@
 //
 //------------------------------------------------------------------------------
 
-using Microsoft.Identity.Client.Internal;
 
-namespace Microsoft.Identity.Client
+using Microsoft.Identity.Client;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+namespace Test.MSAL.NET.Unit
 {
-    public sealed partial class PublicClientApplication : ClientApplicationBase
+    [TestClass]
+    public class AccountTest
     {
-
-        /// <summary>
-        /// Constructor to create application instance. This constructor is only available for Desktop and NetCore apps
-        /// </summary>
-        /// <param name="clientId">Client id of the application</param>
-        /// <param name="authority">Default authority to be used for the application</param>
-        /// <param name="userTokenCache">Instance of TokenCache.</param>
-        public PublicClientApplication(string clientId, string authority, TokenCache userTokenCache) : base(clientId,
-            authority, PlatformPlugin.PlatformInformation.GetDefaultRedirectUri(clientId), true)
+        [TestMethod]
+        public void EqualityTest()
         {
-            UserTokenCache = userTokenCache;
+            AccountId accountId1 = new AccountId("a.b", "c", "d");
+            AccountId accountId2 = new AccountId("a.b", "e", "f");
+
+            Assert.AreEqual(accountId1, accountId2);
         }
     }
 }

--- a/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
@@ -120,7 +120,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 ClientId = TestConstants.ClientId,
                 Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
                 Scope = TestConstants.Scope,
-                User = TestConstants.User
+                Account = TestConstants.User
             }).Result;
 
             Assert.IsNotNull(item);
@@ -158,7 +158,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 ClientId = TestConstants.ClientId,
                 Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
                 Scope = new SortedSet<string>(),
-                User = TestConstants.User
+                Account = TestConstants.User
             };
 
             param.Scope.Add("r1/scope1");
@@ -200,11 +200,11 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 ClientId = TestConstants.ClientId,
                 Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
                 Scope = new SortedSet<string>(),
-                User =
-                    new User()
+                Account =
+                    new Account()
                     {
-                        DisplayableId = TestConstants.DisplayableId,
-                        Identifier = TestConstants.UserIdentifier
+                        Username = TestConstants.DisplayableId,
+                        HomeAccountId = TestConstants.UserIdentifier
                     }
             };
 
@@ -245,11 +245,11 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 ClientId = TestConstants.ClientId,
                 Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
                 Scope = TestConstants.Scope,
-                User =
-                    new User()
+                Account =
+                    new Account()
                     {
-                        DisplayableId = TestConstants.DisplayableId,
-                        Identifier = TestConstants.UserIdentifier
+                        Username = TestConstants.DisplayableId,
+                        HomeAccountId = TestConstants.UserIdentifier
                     }
             }).Result);
         }
@@ -283,11 +283,11 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 ClientId = TestConstants.ClientId,
                 Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
                 Scope = TestConstants.Scope,
-                User =
-                    new User()
+                Account =
+                    new Account()
                     {
-                        DisplayableId = TestConstants.DisplayableId,
-                        Identifier = TestConstants.UserIdentifier
+                        Username = TestConstants.DisplayableId,
+                        HomeAccountId = TestConstants.UserIdentifier
                     }
             }).Result);
         }
@@ -312,7 +312,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 ClientId = TestConstants.ClientId,
                 Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
                 Scope = TestConstants.Scope,
-                User = TestConstants.User
+                Account = TestConstants.User
             };
             Assert.IsNotNull(cache.FindRefreshTokenAsync(authParams));
 
@@ -325,7 +325,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 ClientId = TestConstants.ClientId,
                 Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant + "more", false),
                 Scope = TestConstants.Scope,
-                User = TestConstants.User
+                Account = TestConstants.User
             }));
         }
 
@@ -348,7 +348,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 ClientId = TestConstants.ClientId,
                 Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
                 Scope = TestConstants.Scope,
-                User = TestConstants.User
+                Account = TestConstants.User
             };
             var rt = cache.FindRefreshTokenAsync(authParams).Result;
             Assert.IsNull(rt);
@@ -850,7 +850,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
             MsalRefreshTokenCacheItem rtItem = cache.GetAllRefreshTokensForClient(requestContext).First();
             Assert.AreEqual(response.RefreshToken, rtItem.Secret);
             Assert.AreEqual(TestConstants.ClientId, rtItem.ClientId);
-            Assert.AreEqual(TestConstants.UserIdentifier, rtItem.HomeAccountId);
+            Assert.AreEqual(TestConstants.UserIdentifier.Identifier, rtItem.HomeAccountId);
             Assert.AreEqual(TestConstants.ProductionPrefNetworkEnvironment, rtItem.Environment);
         }
 
@@ -871,7 +871,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 ClientId = TestConstants.ClientId,
                 Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
                 Scope = new SortedSet<string>(),
-                User = TestConstants.User
+                Account = TestConstants.User
             };
 
             var scopeInCache = TestConstants.Scope.FirstOrDefault();

--- a/msal/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -106,27 +106,27 @@ namespace Test.MSAL.NET.Unit
         {
             // Setup up a confidential client application with mocked users
             var mockApp = Substitute.For<IConfidentialClientApplication>();
-            IList<IUser> users = new List<IUser>();
+            IList<IAccount> users = new List<IAccount>();
 
-            IUser mockUser1 = Substitute.For<IUser>();
-            mockUser1.DisplayableId.Returns("DisplayableId_1");
+            IAccount mockUser1 = Substitute.For<IAccount>();
+            mockUser1.Username.Returns("DisplayableId_1");
 
-            IUser mockUser2 = Substitute.For<IUser>();
-            mockUser2.DisplayableId.Returns("DisplayableId_2");
+            IAccount mockUser2 = Substitute.For<IAccount>();
+            mockUser2.Username.Returns("DisplayableId_2");
 
             users.Add(mockUser1);
             users.Add(mockUser2);
-            mockApp.GetUsersAsync().Returns(users);
+            mockApp.GetAccountsAsync().Returns(users);
 
             // Now call the substitute
-            IEnumerable<IUser> actualUsers = mockApp.GetUsersAsync().Result;
+            IEnumerable<IAccount> actualUsers = mockApp.GetAccountsAsync().Result;
 
             // Check the users property
             Assert.IsNotNull(actualUsers);
             Assert.AreEqual(2, actualUsers.Count());
 
-            Assert.AreEqual("DisplayableId_1", users.First().DisplayableId);
-            Assert.AreEqual("DisplayableId_2", users.Last().DisplayableId);
+            Assert.AreEqual("DisplayableId_1", users.First().Username);
+            Assert.AreEqual("DisplayableId_2", users.Last().Username);
         }
 
         [TestMethod]
@@ -674,7 +674,7 @@ namespace Test.MSAL.NET.Unit
                 ValidateAuthority = false
             };
 
-            var users = app.GetUsersAsync().Result;
+            var users = app.GetAccountsAsync().Result;
             Assert.AreEqual(1, users.Count());
         }
 

--- a/msal/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -155,7 +155,7 @@ namespace Test.MSAL.NET.Unit
                 TestConstants.RedirectUri, new ClientCredential(TestConstants.ClientSecret),
                 new TokenCache(), new TokenCache());
             Assert.IsNotNull(app);
-            Assert.IsNotNull(app.UserTokenCache);
+            Assert.IsNotNull(app.AccountTokenCache);
             Assert.IsNotNull(app.AppTokenCache);
             Assert.AreEqual("https://login.microsoftonline.com/common/", app.Authority);
             Assert.AreEqual(TestConstants.ClientId, app.ClientId);
@@ -205,7 +205,7 @@ namespace Test.MSAL.NET.Unit
             Assert.IsNotNull("header.payload.signature", result.AccessToken);
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
 
-            Assert.IsNull(app.UserTokenCache);
+            Assert.IsNull(app.AccountTokenCache);
             Assert.IsNull(app.AppTokenCache);
             Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
         }
@@ -241,8 +241,8 @@ namespace Test.MSAL.NET.Unit
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
 
             //make sure user token cache is empty
-            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
-            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
 
             //check app token cache count to be 1
             Assert.AreEqual(1, app.AppTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -258,8 +258,8 @@ namespace Test.MSAL.NET.Unit
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
 
             //make sure user token cache is empty
-            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
-            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
 
             //check app token cache count to be 1
             Assert.AreEqual(1, app.AppTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -311,8 +311,8 @@ namespace Test.MSAL.NET.Unit
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
 
             //make sure user token cache is empty
-            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
-            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
 
             //check app token cache count to be 1
             Assert.AreEqual(1, app.AppTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -659,8 +659,8 @@ namespace Test.MSAL.NET.Unit
 
             AuthenticationResult result = await app.AcquireTokenByAuthorizationCodeAsync("some-code", TestConstants.Scope).ConfigureAwait(false);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
-            Assert.AreEqual(1, app.UserTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(1, app.AccountTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+            Assert.AreEqual(1, app.AccountTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
 
             cache = new TokenCache()
             {

--- a/msal/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -155,7 +155,7 @@ namespace Test.MSAL.NET.Unit
                 TestConstants.RedirectUri, new ClientCredential(TestConstants.ClientSecret),
                 new TokenCache(), new TokenCache());
             Assert.IsNotNull(app);
-            Assert.IsNotNull(app.AccountTokenCache);
+            Assert.IsNotNull(app.UserTokenCache);
             Assert.IsNotNull(app.AppTokenCache);
             Assert.AreEqual("https://login.microsoftonline.com/common/", app.Authority);
             Assert.AreEqual(TestConstants.ClientId, app.ClientId);
@@ -205,7 +205,7 @@ namespace Test.MSAL.NET.Unit
             Assert.IsNotNull("header.payload.signature", result.AccessToken);
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
 
-            Assert.IsNull(app.AccountTokenCache);
+            Assert.IsNull(app.UserTokenCache);
             Assert.IsNull(app.AppTokenCache);
             Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
         }
@@ -241,8 +241,8 @@ namespace Test.MSAL.NET.Unit
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
 
             //make sure user token cache is empty
-            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
-            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
 
             //check app token cache count to be 1
             Assert.AreEqual(1, app.AppTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -258,8 +258,8 @@ namespace Test.MSAL.NET.Unit
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
 
             //make sure user token cache is empty
-            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
-            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
 
             //check app token cache count to be 1
             Assert.AreEqual(1, app.AppTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -311,8 +311,8 @@ namespace Test.MSAL.NET.Unit
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
 
             //make sure user token cache is empty
-            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
-            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
 
             //check app token cache count to be 1
             Assert.AreEqual(1, app.AppTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -659,8 +659,8 @@ namespace Test.MSAL.NET.Unit
 
             AuthenticationResult result = await app.AcquireTokenByAuthorizationCodeAsync("some-code", TestConstants.Scope).ConfigureAwait(false);
             Assert.IsNotNull(result);
-            Assert.AreEqual(1, app.AccountTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
-            Assert.AreEqual(1, app.AccountTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(1, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+            Assert.AreEqual(1, app.UserTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
 
             cache = new TokenCache()
             {

--- a/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -310,10 +310,10 @@ namespace Test.MSAL.NET.Unit
 
             AuthenticationResult result = app.AcquireTokenAsync(TestConstants.Scope).Result;
             Assert.IsNotNull(result);
-            Assert.IsNotNull(result.User);
+            Assert.IsNotNull(result.Account);
             Assert.AreEqual(TestConstants.UniqueId, result.UniqueId);
-            Assert.AreEqual(TestConstants.CreateUserIdentifer(), result.User.Identifier);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.CreateUserIdentifer(), result.Account.HomeAccountId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
 
             // repeat interactive call and pass in the same user
             MsalMockHelpers.ConfigureMockWebUI(new AuthorizationResult(AuthorizationStatus.Success,
@@ -327,10 +327,10 @@ namespace Test.MSAL.NET.Unit
 
             result = app.AcquireTokenAsync(TestConstants.Scope).Result;
             Assert.IsNotNull(result);
-            Assert.IsNotNull(result.User);
+            Assert.IsNotNull(result.Account);
             Assert.AreEqual(TestConstants.UniqueId, result.UniqueId);
-            Assert.AreEqual(TestConstants.CreateUserIdentifer(), result.User.Identifier);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.CreateUserIdentifer(), result.Account.HomeAccountId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
 
             Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
         }
@@ -365,10 +365,10 @@ namespace Test.MSAL.NET.Unit
 
             AuthenticationResult result = app.AcquireTokenAsync(TestConstants.Scope).Result;
             Assert.IsNotNull(result);
-            Assert.IsNotNull(result.User);
+            Assert.IsNotNull(result.Account);
             Assert.AreEqual(TestConstants.UniqueId, result.UniqueId);
-            Assert.AreEqual(TestConstants.CreateUserIdentifer(), result.User.Identifier);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.CreateUserIdentifer(), result.Account.HomeAccountId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
             Assert.AreEqual(TestConstants.Utid, result.TenantId);
 
             // repeat interactive call and pass in the same user
@@ -387,11 +387,11 @@ namespace Test.MSAL.NET.Unit
 
             result = app.AcquireTokenAsync(TestConstants.Scope).Result;
             Assert.IsNotNull(result);
-            Assert.IsNotNull(result.User);
+            Assert.IsNotNull(result.Account);
             Assert.AreEqual(TestConstants.UniqueId + "more", result.UniqueId);
             Assert.AreEqual(TestConstants.CreateUserIdentifer(TestConstants.Uid + "more",
-                TestConstants.Utid + "more"), result.User.Identifier);
-            Assert.AreEqual(TestConstants.DisplayableId + "more", result.User.DisplayableId);
+                TestConstants.Utid + "more"), result.Account.HomeAccountId);
+            Assert.AreEqual(TestConstants.DisplayableId + "more", result.Account.Username);
             Assert.AreEqual(TestConstants.Utid + "more", result.TenantId);
 
             Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
@@ -431,10 +431,10 @@ namespace Test.MSAL.NET.Unit
 
             AuthenticationResult result = app.AcquireTokenAsync(TestConstants.Scope).Result;
             Assert.IsNotNull(result);
-            Assert.IsNotNull(result.User);
+            Assert.IsNotNull(result.Account);
             Assert.AreEqual(TestConstants.UniqueId, result.UniqueId);
-            Assert.AreEqual(TestConstants.CreateUserIdentifer(), result.User.Identifier);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.CreateUserIdentifer(), result.Account.HomeAccountId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
 
             Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
 
@@ -456,7 +456,7 @@ namespace Test.MSAL.NET.Unit
 
             try
             {
-                result = app.AcquireTokenAsync(TestConstants.Scope, result.User, UIBehavior.SelectAccount, null).Result;
+                result = app.AcquireTokenAsync(TestConstants.Scope, result.Account, UIBehavior.SelectAccount, null).Result;
                 Assert.Fail("API should have failed here");
             }
             catch (AggregateException ex)
@@ -470,7 +470,7 @@ namespace Test.MSAL.NET.Unit
                 && anEvent[ApiEvent.WasSuccessfulKey] == "false" && anEvent[ApiEvent.ApiErrorCodeKey] == "user_mismatch"
                 ));
 
-            var users = app.GetUsersAsync().Result;
+            var users = app.GetAccountsAsync().Result;
             Assert.AreEqual(1, users.Count());
             Assert.AreEqual(1, cache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
 
@@ -511,10 +511,10 @@ namespace Test.MSAL.NET.Unit
 
             AuthenticationResult result = app.AcquireTokenAsync(TestConstants.Scope).Result;
             Assert.IsNotNull(result);
-            Assert.IsNotNull(result.User);
+            Assert.IsNotNull(result.Account);
             Assert.AreEqual(TestConstants.UniqueId, result.UniqueId);
-            Assert.AreEqual(TestConstants.CreateUserIdentifer(), result.User.Identifier);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.CreateUserIdentifer(), result.Account.HomeAccountId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
             Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
 
             // repeat interactive call and pass in the same user
@@ -529,14 +529,14 @@ namespace Test.MSAL.NET.Unit
                     MockHelpers.CreateClientInfo(TestConstants.Uid, TestConstants.Utid + "more"))
             });
 
-            result = app.AcquireTokenAsync(TestConstants.Scope, (IUser)null, UIBehavior.SelectAccount, null).Result;
+            result = app.AcquireTokenAsync(TestConstants.Scope, (IAccount)null, UIBehavior.SelectAccount, null).Result;
             Assert.IsNotNull(result);
-            Assert.IsNotNull(result.User);
+            Assert.IsNotNull(result.Account);
             Assert.AreEqual(TestConstants.UniqueId, result.UniqueId);
             Assert.AreEqual(TestConstants.CreateUserIdentifer(TestConstants.Uid, TestConstants.Utid + "more"),
-                result.User.Identifier);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
-            var users = app.GetUsersAsync().Result;
+                result.Account.HomeAccountId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
+            var users = app.GetAccountsAsync().Result;
             Assert.AreEqual(2, users.Count());
             Assert.AreEqual(2, cache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
             Assert.IsTrue(HttpMessageHandlerFactory.IsMocksQueueEmpty, "All mocks should have been consumed");
@@ -547,7 +547,7 @@ namespace Test.MSAL.NET.Unit
         public void GetUsersTest()
         {
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId);
-            IEnumerable<IUser> users = app.GetUsersAsync().Result;
+            IEnumerable<IAccount> users = app.GetAccountsAsync().Result;
             Assert.IsNotNull(users);
             Assert.IsFalse(users.Any());
             cache = new TokenCache()
@@ -557,7 +557,7 @@ namespace Test.MSAL.NET.Unit
 
             app.UserTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
-            users = app.GetUsersAsync().Result;
+            users = app.GetAccountsAsync().Result;
             Assert.IsNotNull(users);
             Assert.AreEqual(1, users.Count());
 
@@ -601,7 +601,7 @@ namespace Test.MSAL.NET.Unit
 
 
             Assert.AreEqual(2, cache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
-            users = app.GetUsersAsync().Result;
+            users = app.GetAccountsAsync().Result;
             Assert.IsNotNull(users);
             Assert.AreEqual(2, users.Count());
 
@@ -612,7 +612,7 @@ namespace Test.MSAL.NET.Unit
             cache.tokenCacheAccessor.RefreshTokenCacheDictionary[rtItem.GetKey().ToString()] =
                 JsonHelper.SerializeToJson(rtItem);
             Assert.AreEqual(3, cache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
-            users = app.GetUsersAsync().Result;
+            users = app.GetAccountsAsync().Result;
             Assert.IsNotNull(users);
             Assert.AreEqual(2, users.Count());
         }
@@ -629,9 +629,9 @@ namespace Test.MSAL.NET.Unit
             };
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
 
-            foreach (var user in app.GetUsersAsync().Result)
+            foreach (var user in app.GetAccountsAsync().Result)
             {
-                app.RemoveAsync(user);
+                app.RemoveAsync(user).Wait();
             }
 
             Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -657,10 +657,10 @@ namespace Test.MSAL.NET.Unit
             try
             {
                 AuthenticationResult result = await app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(),
-                        new User()
+                        new Account()
                         {
-                            DisplayableId = TestConstants.DisplayableId,
-                            Identifier = TestConstants.UserIdentifier,
+                            Username = TestConstants.DisplayableId,
+                            HomeAccountId = TestConstants.UserIdentifier,
                         })
                     .ConfigureAwait(false);
             }
@@ -694,10 +694,10 @@ namespace Test.MSAL.NET.Unit
             try
             {
                 AuthenticationResult result = await app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(),
-                        new User()
+                        new Account()
                         {
-                            DisplayableId = TestConstants.DisplayableId,
-                            Identifier = TestConstants.UserIdentifier,
+                            Username = TestConstants.DisplayableId,
+                            HomeAccountId = TestConstants.UserIdentifier,
                         })
                     .ConfigureAwait(false);
             }
@@ -745,19 +745,19 @@ namespace Test.MSAL.NET.Unit
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
                 TestConstants.Utid,
-                TestConstants.UserIdentifier,
+                TestConstants.UserIdentifier.Identifier,
                 TestConstants.ClientId,
                 TestConstants.ScopeForAnotherResourceStr).ToString());
 
-            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.ScopeForAnotherResource.ToArray(), new User()
+            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.ScopeForAnotherResource.ToArray(), new Account()
             {
-                DisplayableId = TestConstants.DisplayableId,
-                Identifier = TestConstants.UserIdentifier,
+                Username = TestConstants.DisplayableId,
+                HomeAccountId = TestConstants.UserIdentifier,
             });
 
             AuthenticationResult result = task.Result;
             Assert.IsNotNull(result);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
             Assert.AreEqual(TestConstants.ScopeForAnotherResource.AsSingleString(), result.Scopes.AsSingleString());
             Assert.AreEqual(2, cache.tokenCacheAccessor.GetAllAccessTokensAsString().Count());
         }
@@ -782,18 +782,18 @@ namespace Test.MSAL.NET.Unit
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
                 TestConstants.Utid,
-                TestConstants.UserIdentifier,
+                TestConstants.UserIdentifier.Identifier,
                 TestConstants.ClientId,
                 TestConstants.ScopeForAnotherResourceStr).ToString());
 
-            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(), new User()
+            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(), new Account()
             {
-                DisplayableId = TestConstants.DisplayableId,
-                Identifier = TestConstants.UserIdentifier,
+                Username = TestConstants.DisplayableId,
+                HomeAccountId = TestConstants.UserIdentifier,
             });
             AuthenticationResult result = task.Result;
             Assert.IsNotNull(result);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
         }
 
@@ -817,18 +817,18 @@ namespace Test.MSAL.NET.Unit
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
                 TestConstants.Utid,
-                TestConstants.UserIdentifier,
+                TestConstants.UserIdentifier.Identifier,
                 TestConstants.ClientId,
                 TestConstants.ScopeForAnotherResourceStr).ToString());
 
-            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(), new User()
+            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(), new Account()
             {
-                DisplayableId = TestConstants.DisplayableId,
-                Identifier = TestConstants.UserIdentifier,
+                Username = TestConstants.DisplayableId,
+                HomeAccountId = TestConstants.UserIdentifier,
             });
             AuthenticationResult result = task.Result;
             Assert.IsNotNull(result);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
         }
 
@@ -852,19 +852,19 @@ namespace Test.MSAL.NET.Unit
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
                 TestConstants.Utid,
-                TestConstants.UserIdentifier,
+                TestConstants.UserIdentifier.Identifier,
                 TestConstants.ClientId,
                 TestConstants.ScopeForAnotherResourceStr).ToString());
 
-            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(), new User()
+            Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(), new Account()
             {
-                DisplayableId = TestConstants.DisplayableId,
-                Identifier = TestConstants.UserIdentifier,
+                Username = TestConstants.DisplayableId,
+                HomeAccountId = TestConstants.UserIdentifier,
             }, app.Authority, false);
 
             AuthenticationResult result = task.Result;
             Assert.IsNotNull(result);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
             Assert.AreEqual(TestConstants.Scope.AsSingleString(), result.Scopes.AsSingleString());
             Assert.IsNotNull(_myReceiver.EventsReceived.Find(anEvent =>  // Expect finding such an event
                 anEvent[EventBase.EventNameKey].EndsWith("api_event") && anEvent[ApiEvent.WasSuccessfulKey] == "true"
@@ -911,14 +911,14 @@ namespace Test.MSAL.NET.Unit
             });
 
             Task<AuthenticationResult> task = app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(),
-                new User()
+                new Account()
                 {
-                    DisplayableId = TestConstants.DisplayableId,
-                    Identifier = TestConstants.UserIdentifier,
+                    Username = TestConstants.DisplayableId,
+                    HomeAccountId = TestConstants.UserIdentifier,
                 }, null, true);
             AuthenticationResult result = task.Result;
             Assert.IsNotNull(result);
-            Assert.AreEqual(TestConstants.DisplayableId, result.User.DisplayableId);
+            Assert.AreEqual(TestConstants.DisplayableId, result.Account.Username);
             Assert.AreEqual(
                 TestConstants.Scope.ToArray().AsSingleString(),
                 result.Scopes.AsSingleString());
@@ -964,10 +964,10 @@ namespace Test.MSAL.NET.Unit
             {
                 Task<AuthenticationResult> task =
                     app.AcquireTokenSilentAsync(TestConstants.ScopeForAnotherResource.ToArray(),
-                        new User()
+                        new Account()
                         {
-                            DisplayableId = TestConstants.DisplayableId,
-                            Identifier = TestConstants.UserIdentifier,
+                            Username = TestConstants.DisplayableId,
+                            HomeAccountId = TestConstants.UserIdentifier,
                         }, app.Authority, false);
                 AuthenticationResult result = task.Result;
                 Assert.Fail("MsalUiRequiredException was expected");
@@ -1051,15 +1051,15 @@ namespace Test.MSAL.NET.Unit
         public void GetUserTest()
         {
             var app = new PublicClientApplication(TestConstants.ClientId);
-            var users = app.GetUsersAsync().Result;
+            var users = app.GetAccountsAsync().Result;
             Assert.IsNotNull(users);
             // no users in the cache
             Assert.AreEqual(0, users.Count());
 
-            var fetchedUser = app.GetUserAsync(null).Result;
+            var fetchedUser = app.GetAccountAsync(null).Result;
             Assert.IsNull(fetchedUser);
 
-            fetchedUser = app.GetUserAsync("").Result;
+            fetchedUser = app.GetAccountAsync("").Result;
             Assert.IsNull(fetchedUser);
 
             TokenCacheHelper.AddRefreshTokenToCache(app.UserTokenCache.tokenCacheAccessor, TestConstants.Uid,
@@ -1072,17 +1072,17 @@ namespace Test.MSAL.NET.Unit
             TokenCacheHelper.AddAccountToCache(app.UserTokenCache.tokenCacheAccessor, TestConstants.Uid + "1",
                 TestConstants.Utid);
 
-            users = app.GetUsersAsync().Result;
+            users = app.GetAccountsAsync().Result;
             Assert.IsNotNull(users);
             // two users in the cache
             Assert.AreEqual(2, users.Count());
 
             var userToFind = users.First();
 
-            fetchedUser = app.GetUserAsync(userToFind.Identifier).Result;
+            fetchedUser = app.GetAccountAsync(userToFind.HomeAccountId.Identifier).Result;
 
-            Assert.AreEqual(userToFind.DisplayableId, fetchedUser.DisplayableId);
-            Assert.AreEqual(userToFind.Identifier, fetchedUser.Identifier);
+            Assert.AreEqual(userToFind.Username, fetchedUser.Username);
+            Assert.AreEqual(userToFind.HomeAccountId, fetchedUser.HomeAccountId);
             Assert.AreEqual(userToFind.Environment, fetchedUser.Environment);
         }
 

--- a/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -404,7 +404,7 @@ namespace Test.MSAL.NET.Unit
             cache.ClientId = TestConstants.ClientId;
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId)
             {
-                UserTokenCache = cache
+                AccountTokenCache = cache
             };
 
             MockWebUI ui = new MockWebUI()
@@ -484,7 +484,7 @@ namespace Test.MSAL.NET.Unit
             cache.ClientId = TestConstants.ClientId;
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId)
             {
-                UserTokenCache = cache
+                AccountTokenCache = cache
             };
 
             MockWebUI ui = new MockWebUI()
@@ -555,7 +555,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.UserTokenCache = cache;
+            app.AccountTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             users = app.GetAccountsAsync().Result;
             Assert.IsNotNull(users);
@@ -623,7 +623,7 @@ namespace Test.MSAL.NET.Unit
         public void GetUsersAndSignThemOutTest()
         {
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId);
-            app.UserTokenCache = new TokenCache()
+            app.AccountTokenCache = new TokenCache()
             {
                 ClientId = TestConstants.ClientId
             };
@@ -634,8 +634,8 @@ namespace Test.MSAL.NET.Unit
                 app.RemoveAsync(user).Wait();
             }
 
-            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
-            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
         }
 
         [TestMethod]
@@ -653,7 +653,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.UserTokenCache = cache;
+            app.AccountTokenCache = cache;
             try
             {
                 AuthenticationResult result = await app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(),
@@ -689,7 +689,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.UserTokenCache = cache;
+            app.AccountTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             try
             {
@@ -740,7 +740,7 @@ namespace Test.MSAL.NET.Unit
                         TestConstants.ScopeForAnotherResource.ToArray())
             });
 
-            app.UserTokenCache = cache;
+            app.AccountTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -777,7 +777,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.UserTokenCache = cache;
+            app.AccountTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -812,7 +812,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.UserTokenCache = cache;
+            app.AccountTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -847,7 +847,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.UserTokenCache = cache;
+            app.AccountTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -887,7 +887,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.UserTokenCache = cache;
+            app.AccountTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
 
             HttpMessageHandlerFactory.AddMockHandler(
@@ -951,7 +951,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.UserTokenCache = cache;
+            app.AccountTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
 
             MockHttpMessageHandler mockHandler = new MockHttpMessageHandler
@@ -1011,7 +1011,7 @@ namespace Test.MSAL.NET.Unit
             cache.ClientId = TestConstants.ClientId;
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId)
             {
-                UserTokenCache = cache
+                AccountTokenCache = cache
             };
 
             //add mock response for tenant endpoint discovery
@@ -1062,14 +1062,14 @@ namespace Test.MSAL.NET.Unit
             fetchedUser = app.GetAccountAsync("").Result;
             Assert.IsNull(fetchedUser);
 
-            TokenCacheHelper.AddRefreshTokenToCache(app.UserTokenCache.tokenCacheAccessor, TestConstants.Uid,
+            TokenCacheHelper.AddRefreshTokenToCache(app.AccountTokenCache.tokenCacheAccessor, TestConstants.Uid,
                 TestConstants.Utid, TestConstants.Name);
-            TokenCacheHelper.AddAccountToCache(app.UserTokenCache.tokenCacheAccessor, TestConstants.Uid,
+            TokenCacheHelper.AddAccountToCache(app.AccountTokenCache.tokenCacheAccessor, TestConstants.Uid,
                 TestConstants.Utid);
 
-            TokenCacheHelper.AddRefreshTokenToCache(app.UserTokenCache.tokenCacheAccessor, TestConstants.Uid + "1",
+            TokenCacheHelper.AddRefreshTokenToCache(app.AccountTokenCache.tokenCacheAccessor, TestConstants.Uid + "1",
                 TestConstants.Utid, TestConstants.Name + "1");
-            TokenCacheHelper.AddAccountToCache(app.UserTokenCache.tokenCacheAccessor, TestConstants.Uid + "1",
+            TokenCacheHelper.AddAccountToCache(app.AccountTokenCache.tokenCacheAccessor, TestConstants.Uid + "1",
                 TestConstants.Utid);
 
             users = app.GetAccountsAsync().Result;

--- a/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -404,7 +404,7 @@ namespace Test.MSAL.NET.Unit
             cache.ClientId = TestConstants.ClientId;
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId)
             {
-                AccountTokenCache = cache
+                UserTokenCache = cache
             };
 
             MockWebUI ui = new MockWebUI()
@@ -484,7 +484,7 @@ namespace Test.MSAL.NET.Unit
             cache.ClientId = TestConstants.ClientId;
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId)
             {
-                AccountTokenCache = cache
+                UserTokenCache = cache
             };
 
             MockWebUI ui = new MockWebUI()
@@ -555,7 +555,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.AccountTokenCache = cache;
+            app.UserTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             users = app.GetAccountsAsync().Result;
             Assert.IsNotNull(users);
@@ -623,7 +623,7 @@ namespace Test.MSAL.NET.Unit
         public void GetUsersAndSignThemOutTest()
         {
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId);
-            app.AccountTokenCache = new TokenCache()
+            app.UserTokenCache = new TokenCache()
             {
                 ClientId = TestConstants.ClientId
             };
@@ -634,8 +634,8 @@ namespace Test.MSAL.NET.Unit
                 app.RemoveAsync(user).Wait();
             }
 
-            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
-            Assert.AreEqual(0, app.AccountTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+            Assert.AreEqual(0, app.UserTokenCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
         }
 
         [TestMethod]
@@ -653,7 +653,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.AccountTokenCache = cache;
+            app.UserTokenCache = cache;
             try
             {
                 AuthenticationResult result = await app.AcquireTokenSilentAsync(TestConstants.Scope.ToArray(),
@@ -689,7 +689,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.AccountTokenCache = cache;
+            app.UserTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             try
             {
@@ -740,7 +740,7 @@ namespace Test.MSAL.NET.Unit
                         TestConstants.ScopeForAnotherResource.ToArray())
             });
 
-            app.AccountTokenCache = cache;
+            app.UserTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -777,7 +777,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.AccountTokenCache = cache;
+            app.UserTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -812,7 +812,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.AccountTokenCache = cache;
+            app.UserTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -847,7 +847,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.AccountTokenCache = cache;
+            app.UserTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Remove(new MsalAccessTokenCacheKey(
                 TestConstants.ProductionPrefNetworkEnvironment,
@@ -887,7 +887,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.AccountTokenCache = cache;
+            app.UserTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
 
             HttpMessageHandlerFactory.AddMockHandler(
@@ -951,7 +951,7 @@ namespace Test.MSAL.NET.Unit
                 ClientId = TestConstants.ClientId
             };
 
-            app.AccountTokenCache = cache;
+            app.UserTokenCache = cache;
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
 
             MockHttpMessageHandler mockHandler = new MockHttpMessageHandler
@@ -1011,7 +1011,7 @@ namespace Test.MSAL.NET.Unit
             cache.ClientId = TestConstants.ClientId;
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId)
             {
-                AccountTokenCache = cache
+                UserTokenCache = cache
             };
 
             //add mock response for tenant endpoint discovery
@@ -1062,14 +1062,14 @@ namespace Test.MSAL.NET.Unit
             fetchedUser = app.GetAccountAsync("").Result;
             Assert.IsNull(fetchedUser);
 
-            TokenCacheHelper.AddRefreshTokenToCache(app.AccountTokenCache.tokenCacheAccessor, TestConstants.Uid,
+            TokenCacheHelper.AddRefreshTokenToCache(app.UserTokenCache.tokenCacheAccessor, TestConstants.Uid,
                 TestConstants.Utid, TestConstants.Name);
-            TokenCacheHelper.AddAccountToCache(app.AccountTokenCache.tokenCacheAccessor, TestConstants.Uid,
+            TokenCacheHelper.AddAccountToCache(app.UserTokenCache.tokenCacheAccessor, TestConstants.Uid,
                 TestConstants.Utid);
 
-            TokenCacheHelper.AddRefreshTokenToCache(app.AccountTokenCache.tokenCacheAccessor, TestConstants.Uid + "1",
+            TokenCacheHelper.AddRefreshTokenToCache(app.UserTokenCache.tokenCacheAccessor, TestConstants.Uid + "1",
                 TestConstants.Utid, TestConstants.Name + "1");
-            TokenCacheHelper.AddAccountToCache(app.AccountTokenCache.tokenCacheAccessor, TestConstants.Uid + "1",
+            TokenCacheHelper.AddAccountToCache(app.UserTokenCache.tokenCacheAccessor, TestConstants.Uid + "1",
                 TestConstants.Utid);
 
             users = app.GetAccountsAsync().Result;

--- a/msal/tests/Test.MSAL.NET.Unit/RequestsTests/SilentRequestTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/RequestsTests/SilentRequestTests.cs
@@ -83,7 +83,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                 RequestContext = new RequestContext(new MsalLogger(Guid.NewGuid(), null))
             };
 
-            parameters.User = null;
+            parameters.Account = null;
             try
             {
                 new SilentRequest(parameters, false);
@@ -94,14 +94,14 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                 Assert.AreEqual(exc.ErrorCode, MsalUiRequiredException.UserNullError);
             }
 
-            parameters.User = new User()
+            parameters.Account = new Account()
             {
-                DisplayableId = TestConstants.DisplayableId
+                Username = TestConstants.DisplayableId
             };
             SilentRequest request = new SilentRequest(parameters, false);
             Assert.IsNotNull(request);
 
-            parameters.User = new User()
+            parameters.Account = new Account()
             {
             };
             request = new SilentRequest(parameters, false);
@@ -129,10 +129,10 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                 Scope = new[] { "some-scope1", "some-scope2" }.CreateSetFromEnumerable(),
                 TokenCache = cache,
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
-                User = new User()
+                Account = new Account()
                 {
-                    Identifier = TestConstants.UserIdentifier,
-                    DisplayableId = TestConstants.DisplayableId
+                    HomeAccountId = TestConstants.UserIdentifier,
+                    Username = TestConstants.DisplayableId
                 }
             };
             
@@ -180,7 +180,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                 ClientId = TestConstants.ClientId,
                 Scope = new[] { "some-scope1", "some-scope2" }.CreateSetFromEnumerable(),
                 TokenCache = cache,
-                User = new User(),
+                Account = new Account(),
                 RequestContext = new RequestContext(new MsalLogger(Guid.NewGuid(), null))
             };
 
@@ -222,7 +222,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                 ClientId = TestConstants.ClientId,
                 Scope = new[] { "some-scope1", "some-scope2" }.CreateSetFromEnumerable(),
                 TokenCache = cache,
-                User = new User(),
+                Account = new Account(),
                 RequestContext = new RequestContext(new MsalLogger(Guid.NewGuid(), null))
             };
             

--- a/msal/tests/Test.MSAL.NET.Unit/TestConstants.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/TestConstants.cs
@@ -60,21 +60,21 @@ namespace Test.MSAL.NET.Unit
         public static readonly string AuthorityTestTenant = "https://" + ProductionPrefNetworkEnvironment + "/" + Utid + "/";
         public static readonly string DiscoveryEndPoint = "discovery/instance";
 
-        public static readonly MsalAccountId UserIdentifier = CreateUserIdentifer();
+        public static readonly AccountId UserIdentifier = CreateUserIdentifer();
 
         public static string GetDiscoveryEndpoint(string Authority)
         {
             return Authority + DiscoveryEndPoint;
         }
 
-        public static MsalAccountId CreateUserIdentifer()
+        public static AccountId CreateUserIdentifer()
         {
             return CreateUserIdentifer(Uid, Utid);
         }
 
-        public static MsalAccountId CreateUserIdentifer(string uid, string utid)
+        public static AccountId CreateUserIdentifer(string uid, string utid)
         {
-            return new MsalAccountId(string.Format(CultureInfo.InvariantCulture, "{0}.{1}", uid, utid), uid, utid);
+            return new AccountId(string.Format(CultureInfo.InvariantCulture, "{0}.{1}", uid, utid), uid, utid);
         }
 
         public static readonly Account User = new Account
@@ -99,7 +99,7 @@ namespace Test.MSAL.NET.Unit
         public static readonly Account OnPremiseUser = new Account
         {
             Username = OnPremiseDisplayableId,
-            HomeAccountId = new MsalAccountId(OnPremiseHomeObjectId, "", "")
+            HomeAccountId = new AccountId(OnPremiseHomeObjectId, "", "")
         };
     }
 }

--- a/msal/tests/Test.MSAL.NET.Unit/TestConstants.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/TestConstants.cs
@@ -60,30 +60,27 @@ namespace Test.MSAL.NET.Unit
         public static readonly string AuthorityTestTenant = "https://" + ProductionPrefNetworkEnvironment + "/" + Utid + "/";
         public static readonly string DiscoveryEndPoint = "discovery/instance";
 
-        public static readonly string UserIdentifier = CreateUserIdentifer();
+        public static readonly MsalAccountId UserIdentifier = CreateUserIdentifer();
 
         public static string GetDiscoveryEndpoint(string Authority)
         {
             return Authority + DiscoveryEndPoint;
         }
 
-        public static string CreateUserIdentifer()
+        public static MsalAccountId CreateUserIdentifer()
         {
             return CreateUserIdentifer(Uid, Utid);
         }
 
-        public static string CreateUserIdentifer(string uid, string utid)
+        public static MsalAccountId CreateUserIdentifer(string uid, string utid)
         {
-            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}",
-                //Base64UrlHelpers.Encode(uid),
-                //Base64UrlHelpers.Encode(utid));
-                uid, utid);
+            return new MsalAccountId(string.Format(CultureInfo.InvariantCulture, "{0}.{1}", uid, utid), uid, utid);
         }
 
-        public static readonly User User = new User
+        public static readonly Account User = new Account
         {
-            DisplayableId = DisplayableId,
-            Identifier = UserIdentifier,
+            Username = DisplayableId,
+            HomeAccountId = UserIdentifier,
             Environment = ProductionPrefNetworkEnvironment,
         };
 
@@ -99,10 +96,10 @@ namespace Test.MSAL.NET.Unit
         public static readonly string OnPremiseUid = "my-OnPremise-UID";
         public static readonly string OnPremiseUtid = "my-OnPremise-UTID";
         public static readonly ClientCredential OnPremiseCredentialWithSecret = new ClientCredential(ClientSecret);
-        public static readonly User OnPremiseUser = new User
+        public static readonly Account OnPremiseUser = new Account
         {
-            DisplayableId = OnPremiseDisplayableId,
-            Identifier = OnPremiseHomeObjectId
+            Username = OnPremiseDisplayableId,
+            HomeAccountId = new MsalAccountId(OnPremiseHomeObjectId, "", "")
         };
     }
 }

--- a/msal/tests/Test.MSAL.NET.Unit/UnifiedCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/UnifiedCacheTests.cs
@@ -126,13 +126,13 @@ namespace Test.MSAL.NET.Unit
             Assert.IsTrue(adalCacheDictionary.Count == 1);
 
             var requestContext = new RequestContext(new MsalLogger(Guid.Empty, null));
-            var users = app.UserTokenCache.GetUsersAsync(TestConstants.AuthorityCommonTenant, false, requestContext).Result;
-            foreach (IUser user in users)
+            var users = app.UserTokenCache.GetAccountsAsync(TestConstants.AuthorityCommonTenant, false, requestContext).Result;
+            foreach (IAccount user in users)
             {
                 ISet<string> authorityHostAliases = new HashSet<string>();
                 authorityHostAliases.Add(TestConstants.ProductionPrefNetworkEnvironment);
 
-                app.UserTokenCache.RemoveMsalUser(user, authorityHostAliases, requestContext);
+                app.UserTokenCache.RemoveMsalAccount(user, authorityHostAliases, requestContext);
             }
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()
@@ -150,7 +150,7 @@ namespace Test.MSAL.NET.Unit
 
             // Using RT from Adal cache for silent call
             AuthenticationResult result1 = app.AcquireTokenSilentAsync
-                (TestConstants.Scope, result.User, TestConstants.AuthorityCommonTenant, false).Result;
+                (TestConstants.Scope, result.Account, TestConstants.AuthorityCommonTenant, false).Result;
 
             Assert.IsNotNull(result1);
         }

--- a/msal/tests/Test.MSAL.NET.Unit/UnifiedCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/UnifiedCacheTests.cs
@@ -92,7 +92,7 @@ namespace Test.MSAL.NET.Unit
         {
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId);
 
-            app.AccountTokenCache.legacyCachePersistance = new TestLegacyCachePersistance();
+            app.UserTokenCache.legacyCachePersistance = new TestLegacyCachePersistance();
 
             MockWebUI ui = new MockWebUI()
             {
@@ -121,18 +121,18 @@ namespace Test.MSAL.NET.Unit
 
             // make sure Msal stored RT in Adal cache
             IDictionary<AdalTokenCacheKey, AdalResultWrapper> adalCacheDictionary = 
-                AdalCacheOperations.Deserialize(app.AccountTokenCache.legacyCachePersistance.LoadCache());
+                AdalCacheOperations.Deserialize(app.UserTokenCache.legacyCachePersistance.LoadCache());
 
             Assert.IsTrue(adalCacheDictionary.Count == 1);
 
             var requestContext = new RequestContext(new MsalLogger(Guid.Empty, null));
-            var users = app.AccountTokenCache.GetAccountsAsync(TestConstants.AuthorityCommonTenant, false, requestContext).Result;
+            var users = app.UserTokenCache.GetAccountsAsync(TestConstants.AuthorityCommonTenant, false, requestContext).Result;
             foreach (IAccount user in users)
             {
                 ISet<string> authorityHostAliases = new HashSet<string>();
                 authorityHostAliases.Add(TestConstants.ProductionPrefNetworkEnvironment);
 
-                app.AccountTokenCache.RemoveMsalAccount(user, authorityHostAliases, requestContext);
+                app.UserTokenCache.RemoveMsalAccount(user, authorityHostAliases, requestContext);
             }
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()

--- a/msal/tests/Test.MSAL.NET.Unit/UnifiedCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/UnifiedCacheTests.cs
@@ -92,7 +92,7 @@ namespace Test.MSAL.NET.Unit
         {
             PublicClientApplication app = new PublicClientApplication(TestConstants.ClientId);
 
-            app.UserTokenCache.legacyCachePersistance = new TestLegacyCachePersistance();
+            app.AccountTokenCache.legacyCachePersistance = new TestLegacyCachePersistance();
 
             MockWebUI ui = new MockWebUI()
             {
@@ -121,18 +121,18 @@ namespace Test.MSAL.NET.Unit
 
             // make sure Msal stored RT in Adal cache
             IDictionary<AdalTokenCacheKey, AdalResultWrapper> adalCacheDictionary = 
-                AdalCacheOperations.Deserialize(app.UserTokenCache.legacyCachePersistance.LoadCache());
+                AdalCacheOperations.Deserialize(app.AccountTokenCache.legacyCachePersistance.LoadCache());
 
             Assert.IsTrue(adalCacheDictionary.Count == 1);
 
             var requestContext = new RequestContext(new MsalLogger(Guid.Empty, null));
-            var users = app.UserTokenCache.GetAccountsAsync(TestConstants.AuthorityCommonTenant, false, requestContext).Result;
+            var users = app.AccountTokenCache.GetAccountsAsync(TestConstants.AuthorityCommonTenant, false, requestContext).Result;
             foreach (IAccount user in users)
             {
                 ISet<string> authorityHostAliases = new HashSet<string>();
                 authorityHostAliases.Add(TestConstants.ProductionPrefNetworkEnvironment);
 
-                app.UserTokenCache.RemoveMsalAccount(user, authorityHostAliases, requestContext);
+                app.AccountTokenCache.RemoveMsalAccount(user, authorityHostAliases, requestContext);
             }
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler()

--- a/msal/tests/Test.MSAL.NET.Unit/UserTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/UserTests.cs
@@ -42,14 +42,14 @@ namespace Test.MSAL.NET.Unit
             AssertException.Throws<ArgumentNullException>(() => new Account(null, "d", "n"));
 
             // 2. Other properties are optional
-            new Account(new MsalAccountId("a.b", "a", "b"), null, null);
+            new Account(new AccountId("a.b", "a", "b"), null, null);
         }
 
         [TestMethod]
         [TestCategory("UserTests")]
         public void Constructor_PropertiesSet()
         {
-            Account actual = new Account(new MsalAccountId("a.b", "a", "b"), "disp", "env");
+            Account actual = new Account(new AccountId("a.b", "a", "b"), "disp", "env");
 
             Assert.AreEqual("a.b", actual.HomeAccountId.Identifier);
             Assert.AreEqual("a", actual.HomeAccountId.ObjectId);

--- a/msal/tests/Test.MSAL.NET.Unit/UserTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/UserTests.cs
@@ -39,20 +39,22 @@ namespace Test.MSAL.NET.Unit
         public void Constructor_IdIsRequired()
         {
             // 1. Id is required
-            AssertException.Throws<ArgumentNullException>(() => new User(null, "d", "n"));
+            AssertException.Throws<ArgumentNullException>(() => new Account(null, "d", "n"));
 
             // 2. Other properties are optional
-            new User("id", null, null);
+            new Account(new MsalAccountId("a.b", "a", "b"), null, null);
         }
 
         [TestMethod]
         [TestCategory("UserTests")]
         public void Constructor_PropertiesSet()
         {
-            User actual = new User("id", "disp", "env");
+            Account actual = new Account(new MsalAccountId("a.b", "a", "b"), "disp", "env");
 
-            Assert.AreEqual("id", actual.Identifier);
-            Assert.AreEqual("disp", actual.DisplayableId);
+            Assert.AreEqual("a.b", actual.HomeAccountId.Identifier);
+            Assert.AreEqual("a", actual.HomeAccountId.ObjectId);
+            Assert.AreEqual("b", actual.HomeAccountId.TenantId);
+            Assert.AreEqual("disp", actual.Username);
             Assert.AreEqual("env", actual.Environment);
         }
     }

--- a/msal/tests/dev apps/DesktopTestApp/MainForm.cs
+++ b/msal/tests/dev apps/DesktopTestApp/MainForm.cs
@@ -82,10 +82,10 @@ namespace DesktopTestApp
 
         public void RefreshUserList()
         {
-            List<IUser> userListDataSource = _publicClientHandler.PublicClientApplication.GetUsersAsync().Result.ToList();
+            List<IAccount> userListDataSource = _publicClientHandler.PublicClientApplication.GetAccountsAsync().Result.ToList();
             if (userListDataSource.Count > 0)
             {
-                userListDataSource.Insert(0, new User() { DisplayableId = string.Empty });
+                userListDataSource.Insert(0, new Account() { Username = string.Empty });
             }
 
             userList.DataSource = userListDataSource;
@@ -102,7 +102,7 @@ namespace DesktopTestApp
 
         private void userList_SelectedIndexChanged(object sender, EventArgs e)
         {
-            _publicClientHandler.CurrentUser = (IUser)userList.SelectedItem;
+            _publicClientHandler.CurrentUser = (IAccount)userList.SelectedItem;
         }
 
         private void overriddenAuthority_TextChanged(object sender, EventArgs e)
@@ -148,7 +148,7 @@ namespace DesktopTestApp
             }
             else
             {
-                _publicClientHandler.CurrentUser = userList.SelectedItem as User;
+                _publicClientHandler.CurrentUser = userList.SelectedItem as Account;
             }
 
             try
@@ -175,7 +175,7 @@ namespace DesktopTestApp
             }
             else
             {
-                _publicClientHandler.CurrentUser = userList.SelectedItem as User;
+                _publicClientHandler.CurrentUser = userList.SelectedItem as Account;
             }
 
             try
@@ -204,7 +204,7 @@ namespace DesktopTestApp
             }
             else
             {
-                _publicClientHandler.CurrentUser = userList.SelectedItem as User;
+                _publicClientHandler.CurrentUser = userList.SelectedItem as Account;
             }
 
             try
@@ -273,7 +273,7 @@ namespace DesktopTestApp
             callResult.Text = @"Access Token: " + authenticationResult.AccessToken + Environment.NewLine +
                               @"Expires On: " + authenticationResult.ExpiresOn + Environment.NewLine +
                               @"Tenant Id: " + authenticationResult.TenantId + Environment.NewLine +
-                              @"User: " + authenticationResult.User.DisplayableId + Environment.NewLine +
+                              @"User: " + authenticationResult.Account.Username + Environment.NewLine +
                               @"Id Token: " + authenticationResult.IdToken;
         }
         

--- a/msal/tests/dev apps/DesktopTestApp/MainForm.cs
+++ b/msal/tests/dev apps/DesktopTestApp/MainForm.cs
@@ -293,7 +293,7 @@ namespace DesktopTestApp
             }
 
             cachePageTableLayout.RowCount = 0;
-            foreach (MsalRefreshTokenCacheItem rtItem in _publicClientHandler.PublicClientApplication.AccountTokenCache
+            foreach (MsalRefreshTokenCacheItem rtItem in _publicClientHandler.PublicClientApplication.UserTokenCache
                 .GetAllRefreshTokensForClient(new RequestContext(new MsalLogger(Guid.NewGuid(), null))))
             {
                 AddControlToCachePageTableLayout(
@@ -302,13 +302,13 @@ namespace DesktopTestApp
                         RefreshViewDelegate = LoadCacheTabPage
                     });
 
-                foreach (MsalAccessTokenCacheItem atItem in _publicClientHandler.PublicClientApplication.AccountTokenCache
+                foreach (MsalAccessTokenCacheItem atItem in _publicClientHandler.PublicClientApplication.UserTokenCache
                     .GetAllAccessTokensForClient(new RequestContext(new MsalLogger(Guid.NewGuid(), null))))
                 {
                     if (atItem.HomeAccountId.Equals(rtItem.HomeAccountId, StringComparison.OrdinalIgnoreCase))
                     {
                         AddControlToCachePageTableLayout(
-                            new MsalUserAccessTokenControl(_publicClientHandler.PublicClientApplication.AccountTokenCache,
+                            new MsalUserAccessTokenControl(_publicClientHandler.PublicClientApplication.UserTokenCache,
                                 atItem)
                             {
                                 RefreshViewDelegate = LoadCacheTabPage

--- a/msal/tests/dev apps/DesktopTestApp/MainForm.cs
+++ b/msal/tests/dev apps/DesktopTestApp/MainForm.cs
@@ -293,7 +293,7 @@ namespace DesktopTestApp
             }
 
             cachePageTableLayout.RowCount = 0;
-            foreach (MsalRefreshTokenCacheItem rtItem in _publicClientHandler.PublicClientApplication.UserTokenCache
+            foreach (MsalRefreshTokenCacheItem rtItem in _publicClientHandler.PublicClientApplication.AccountTokenCache
                 .GetAllRefreshTokensForClient(new RequestContext(new MsalLogger(Guid.NewGuid(), null))))
             {
                 AddControlToCachePageTableLayout(
@@ -302,13 +302,13 @@ namespace DesktopTestApp
                         RefreshViewDelegate = LoadCacheTabPage
                     });
 
-                foreach (MsalAccessTokenCacheItem atItem in _publicClientHandler.PublicClientApplication.UserTokenCache
+                foreach (MsalAccessTokenCacheItem atItem in _publicClientHandler.PublicClientApplication.AccountTokenCache
                     .GetAllAccessTokensForClient(new RequestContext(new MsalLogger(Guid.NewGuid(), null))))
                 {
                     if (atItem.HomeAccountId.Equals(rtItem.HomeAccountId, StringComparison.OrdinalIgnoreCase))
                     {
                         AddControlToCachePageTableLayout(
-                            new MsalUserAccessTokenControl(_publicClientHandler.PublicClientApplication.UserTokenCache,
+                            new MsalUserAccessTokenControl(_publicClientHandler.PublicClientApplication.AccountTokenCache,
                                 atItem)
                             {
                                 RefreshViewDelegate = LoadCacheTabPage

--- a/msal/tests/dev apps/DesktopTestApp/MsalUserRefreshTokenControl.cs
+++ b/msal/tests/dev apps/DesktopTestApp/MsalUserRefreshTokenControl.cs
@@ -47,7 +47,10 @@ namespace DesktopTestApp
         private async void signOutUserOneBtn_Click(object sender, System.EventArgs e)
         {
             await publicClient.RemoveAsync(
-                new User(rtItem.HomeAccountId, accountItem.PreferredUsername, accountItem.Environment)).ConfigureAwait(false);
+                new Account(
+                    MsalAccountId.FromClientInfo(rtItem.ClientInfo), 
+                    accountItem.PreferredUsername, 
+                    accountItem.Environment)).ConfigureAwait(false);
 
             RefreshViewDelegate?.Invoke();
         }

--- a/msal/tests/dev apps/DesktopTestApp/MsalUserRefreshTokenControl.cs
+++ b/msal/tests/dev apps/DesktopTestApp/MsalUserRefreshTokenControl.cs
@@ -23,7 +23,7 @@ namespace DesktopTestApp
         internal MsalUserRefreshTokenControl(PublicClientApplication publicClient, MsalRefreshTokenCacheItem rtIitem) : this()
         {
             this.publicClient = publicClient;
-            cache = publicClient.UserTokenCache;
+            cache = publicClient.AccountTokenCache;
             rtItem = rtIitem;
 
             accountItem = cache.GetAccount(rtIitem, new RequestContext(new MsalLogger(Guid.NewGuid(), null)));

--- a/msal/tests/dev apps/DesktopTestApp/MsalUserRefreshTokenControl.cs
+++ b/msal/tests/dev apps/DesktopTestApp/MsalUserRefreshTokenControl.cs
@@ -23,7 +23,7 @@ namespace DesktopTestApp
         internal MsalUserRefreshTokenControl(PublicClientApplication publicClient, MsalRefreshTokenCacheItem rtIitem) : this()
         {
             this.publicClient = publicClient;
-            cache = publicClient.AccountTokenCache;
+            cache = publicClient.UserTokenCache;
             rtItem = rtIitem;
 
             accountItem = cache.GetAccount(rtIitem, new RequestContext(new MsalLogger(Guid.NewGuid(), null)));
@@ -48,7 +48,7 @@ namespace DesktopTestApp
         {
             await publicClient.RemoveAsync(
                 new Account(
-                    MsalAccountId.FromClientInfo(rtItem.ClientInfo), 
+                    AccountId.FromClientInfo(rtItem.ClientInfo), 
                     accountItem.PreferredUsername, 
                     accountItem.Environment)).ConfigureAwait(false);
 

--- a/msal/tests/dev apps/DesktopTestApp/PublicClientHandler.cs
+++ b/msal/tests/dev apps/DesktopTestApp/PublicClientHandler.cs
@@ -55,7 +55,7 @@ namespace DesktopTestApp
 
         public string LoginHint { get; set; }
 
-        public IUser CurrentUser { get; set; }
+        public IAccount CurrentUser { get; set; }
 
         public PublicClientApplication PublicClientApplication { get; set; }
 
@@ -80,7 +80,7 @@ namespace DesktopTestApp
                         uiParent);
             }
 
-            CurrentUser = result.User;
+            CurrentUser = result.Account;
             return result;
         }
 
@@ -103,7 +103,7 @@ namespace DesktopTestApp
                         uiParent);
             }
 
-            CurrentUser = result.User;
+            CurrentUser = result.Account;
             return result;
         }
 

--- a/msal/tests/dev apps/DesktopTestApp/PublicClientHandler.cs
+++ b/msal/tests/dev apps/DesktopTestApp/PublicClientHandler.cs
@@ -39,7 +39,7 @@ namespace DesktopTestApp
             ApplicationId = clientId;
             PublicClientApplication = new PublicClientApplication(ApplicationId)
             {
-                UserTokenCache = TokenCacheHelper.GetUserCache(),
+                AccountTokenCache = TokenCacheHelper.GetUserCache(),
                 Component = _component
             };
         }
@@ -120,7 +120,7 @@ namespace DesktopTestApp
                 // Use default authority
                 PublicClientApplication = new PublicClientApplication(applicationId)
                 {
-                    UserTokenCache = TokenCacheHelper.GetUserCache(),
+                    AccountTokenCache = TokenCacheHelper.GetUserCache(),
                     Component = _component
                 };
             }
@@ -129,7 +129,7 @@ namespace DesktopTestApp
                 // Use the override authority provided
                 PublicClientApplication = new PublicClientApplication(applicationId, interactiveAuthority)
                 {
-                    UserTokenCache = TokenCacheHelper.GetUserCache(),
+                    AccountTokenCache = TokenCacheHelper.GetUserCache(),
                     Component = _component
                 };
             }

--- a/msal/tests/dev apps/DesktopTestApp/PublicClientHandler.cs
+++ b/msal/tests/dev apps/DesktopTestApp/PublicClientHandler.cs
@@ -39,7 +39,7 @@ namespace DesktopTestApp
             ApplicationId = clientId;
             PublicClientApplication = new PublicClientApplication(ApplicationId)
             {
-                AccountTokenCache = TokenCacheHelper.GetUserCache(),
+                UserTokenCache = TokenCacheHelper.GetUserCache(),
                 Component = _component
             };
         }
@@ -120,7 +120,7 @@ namespace DesktopTestApp
                 // Use default authority
                 PublicClientApplication = new PublicClientApplication(applicationId)
                 {
-                    AccountTokenCache = TokenCacheHelper.GetUserCache(),
+                    UserTokenCache = TokenCacheHelper.GetUserCache(),
                     Component = _component
                 };
             }
@@ -129,7 +129,7 @@ namespace DesktopTestApp
                 // Use the override authority provided
                 PublicClientApplication = new PublicClientApplication(applicationId, interactiveAuthority)
                 {
-                    AccountTokenCache = TokenCacheHelper.GetUserCache(),
+                    UserTokenCache = TokenCacheHelper.GetUserCache(),
                     Component = _component
                 };
             }

--- a/msal/tests/dev apps/WebTestApp/WebApp/Utils/ConfidentialClientUtils.cs
+++ b/msal/tests/dev apps/WebTestApp/WebApp/Utils/ConfidentialClientUtils.cs
@@ -98,8 +98,8 @@ namespace WebApp.Utils
             ClientCredential clientCredential, string userId)
         {
             var confidentialClient = GetConfidentialClientWithExtraParams(clientCredential, Startup.Configuration["AzureAd:CommonAuthority"], userId, session);
-            var users = await confidentialClient.GetUsersAsync().ConfigureAwait(false);
-            var user = users.FirstOrDefault(u => u.DisplayableId.Equals(userName, StringComparison.OrdinalIgnoreCase));
+            var users = await confidentialClient.GetAccountsAsync().ConfigureAwait(false);
+            var user = users.FirstOrDefault(u => u.Username.Equals(userName, StringComparison.OrdinalIgnoreCase));
 
             return await confidentialClient.AcquireTokenSilentAsync(scopes, user);
         }

--- a/msal/tests/dev apps/XForms/XForms/AccessTokenCacheItemDetails.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/AccessTokenCacheItemDetails.xaml.cs
@@ -55,7 +55,7 @@ namespace XForms
             cachedAtLabel.Text = CoreHelpers.UnixTimestampToDateTime(msalAccessTokenCacheItem.CachedAt).ToString();
 
             rawClientInfoLabel.Text = msalAccessTokenCacheItem.RawClientInfo;
-            clientInfoUniqueIdentifierLabel.Text = msalAccessTokenCacheItem.ClientInfo.UniqueIdentifier;
+            clientInfoUniqueIdentifierLabel.Text = msalAccessTokenCacheItem.ClientInfo.UniqueObjectIdentifier;
             clientInfoUniqueTenantIdentifierLabel.Text = msalAccessTokenCacheItem.ClientInfo.UniqueTenantIdentifier;
 
             secretLabel.Text = StringShortenerConverter.GetShortStr(msalAccessTokenCacheItem.Secret, 100);

--- a/msal/tests/dev apps/XForms/XForms/AccountCacheItemDetails.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/AccountCacheItemDetails.xaml.cs
@@ -25,7 +25,7 @@ namespace XForms
             localAccountIdLabel.Text = msalAccountCacheItem.LocalAccountId;
 
             rawClientInfoLabel.Text = msalAccountCacheItem.RawClientInfo;
-            clientInfoUniqueIdentifierLabel.Text = msalAccountCacheItem.ClientInfo.UniqueIdentifier;
+            clientInfoUniqueIdentifierLabel.Text = msalAccountCacheItem.ClientInfo.UniqueObjectIdentifier;
             clientInfoUniqueTenantIdentifierLabel.Text = msalAccountCacheItem.ClientInfo.UniqueTenantIdentifier;
         }
 	}

--- a/msal/tests/dev apps/XForms/XForms/AcquirePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/AcquirePage.xaml.cs
@@ -58,8 +58,8 @@ namespace XForms
 
         private void RefreshUsers()
         {
-            var userIds = App.MsalPublicClient.GetUsersAsync().Result.
-                Select(x => x.DisplayableId).ToList();
+            var userIds = App.MsalPublicClient.GetAccountsAsync().Result.
+                Select(x => x.Username).ToList();
 
             userIds.Add(UserNotSelected);
             usersPicker.ItemsSource = userIds;
@@ -96,11 +96,11 @@ namespace XForms
             return ExtraQueryParametersEntry.Text.Trim();
         }
 
-        private string ToString(IUser user)
+        private string ToString(IAccount user)
         {
             var sb = new StringBuilder();
 
-            sb.AppendLine("user.DisplayableId : " + user.DisplayableId);
+            sb.AppendLine("user.DisplayableId : " + user.Username);
             //sb.AppendLine("user.IdentityProvider : " + user.IdentityProvider);
             sb.AppendLine("user.Environment : " + user.Environment);
 
@@ -117,15 +117,15 @@ namespace XForms
             sb.AppendLine("TenantId : " + result.TenantId);
             sb.AppendLine("Scope : " + string.Join(",", result.Scopes));
             sb.AppendLine("User :");
-            sb.Append(ToString(result.User));
+            sb.Append(ToString(result.Account));
 
             return sb.ToString();
         }
 
-        private IUser getUserByDisplayableId(string str)
+        private IAccount getUserByDisplayableId(string str)
         {
             return string.IsNullOrWhiteSpace(str) ? null : 
-                App.MsalPublicClient.GetUsersAsync().Result.FirstOrDefault(user => user.DisplayableId.Equals(str, StringComparison.OrdinalIgnoreCase));
+                App.MsalPublicClient.GetAccountsAsync().Result.FirstOrDefault(user => user.Username.Equals(str, StringComparison.OrdinalIgnoreCase));
         }
 
         private string[] GetScopes()
@@ -211,7 +211,7 @@ namespace XForms
         private async Task OnClearCacheClickedAsync(object sender, EventArgs e)
         {
             var tokenCache = App.MsalPublicClient.UserTokenCache;
-            var users = await tokenCache.GetUsersAsync
+            var users = await tokenCache.GetAccountsAsync
                 (new Uri(App.Authority).Host, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
             foreach (var user in users)
             {

--- a/msal/tests/dev apps/XForms/XForms/AcquirePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/AcquirePage.xaml.cs
@@ -210,7 +210,7 @@ namespace XForms
 
         private async Task OnClearCacheClickedAsync(object sender, EventArgs e)
         {
-            var tokenCache = App.MsalPublicClient.AccountTokenCache;
+            var tokenCache = App.MsalPublicClient.UserTokenCache;
             var users = await tokenCache.GetAccountsAsync
                 (new Uri(App.Authority).Host, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
             foreach (var user in users)

--- a/msal/tests/dev apps/XForms/XForms/AcquirePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/AcquirePage.xaml.cs
@@ -210,7 +210,7 @@ namespace XForms
 
         private async Task OnClearCacheClickedAsync(object sender, EventArgs e)
         {
-            var tokenCache = App.MsalPublicClient.UserTokenCache;
+            var tokenCache = App.MsalPublicClient.AccountTokenCache;
             var users = await tokenCache.GetAccountsAsync
                 (new Uri(App.Authority).Host, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
             foreach (var user in users)

--- a/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
@@ -95,7 +95,7 @@ namespace XForms
         private async Task OnClearClickedAsync(object sender, EventArgs e)
         {
             var tokenCache = App.MsalPublicClient.UserTokenCache;
-            var users = await tokenCache.GetUsersAsync
+            var users = await tokenCache.GetAccountsAsync
                 (new Uri(App.Authority).Host, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
             foreach (var user in users)
             {

--- a/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
@@ -50,7 +50,7 @@ namespace XForms
 
         private void RefreshCacheView()
         {
-            var tokenCache = App.MsalPublicClient.UserTokenCache;
+            var tokenCache = App.MsalPublicClient.AccountTokenCache;
 
             var requestContext = new RequestContext(new MsalLogger(Guid.NewGuid(), null));
 
@@ -94,7 +94,7 @@ namespace XForms
 
         private async Task OnClearClickedAsync(object sender, EventArgs e)
         {
-            var tokenCache = App.MsalPublicClient.UserTokenCache;
+            var tokenCache = App.MsalPublicClient.AccountTokenCache;
             var users = await tokenCache.GetAccountsAsync
                 (new Uri(App.Authority).Host, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
             foreach (var user in users)
@@ -114,7 +114,7 @@ namespace XForms
         {
             var mi = ((MenuItem) sender);
             var accessTokenCacheItem = (MsalAccessTokenCacheItem) mi.CommandParameter;
-            var tokenCache = App.MsalPublicClient.UserTokenCache;
+            var tokenCache = App.MsalPublicClient.AccountTokenCache;
 
             // set access token as expired
             accessTokenCacheItem.ExpiresOnUnixTimestamp = GetCurrentTimestamp();
@@ -130,7 +130,7 @@ namespace XForms
             var mi = ((MenuItem)sender);
             var accessTokenCacheItem = (MsalAccessTokenCacheItem)mi.CommandParameter;
 
-            var tokenCache = App.MsalPublicClient.UserTokenCache;
+            var tokenCache = App.MsalPublicClient.AccountTokenCache;
             // todo pass idToken instead of null
             var requestContext = new RequestContext(new MsalLogger(Guid.NewGuid(), null));
 
@@ -143,7 +143,7 @@ namespace XForms
         {
             var mi = ((MenuItem) sender);
             var refreshTokenCacheItem = (MsalRefreshTokenCacheItem) mi.CommandParameter;
-            var tokenCache = App.MsalPublicClient.UserTokenCache;
+            var tokenCache = App.MsalPublicClient.AccountTokenCache;
 
             // invalidate refresh token
             refreshTokenCacheItem.Secret = "InvalidValue";

--- a/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
@@ -50,7 +50,7 @@ namespace XForms
 
         private void RefreshCacheView()
         {
-            var tokenCache = App.MsalPublicClient.AccountTokenCache;
+            var tokenCache = App.MsalPublicClient.UserTokenCache;
 
             var requestContext = new RequestContext(new MsalLogger(Guid.NewGuid(), null));
 
@@ -94,7 +94,7 @@ namespace XForms
 
         private async Task OnClearClickedAsync(object sender, EventArgs e)
         {
-            var tokenCache = App.MsalPublicClient.AccountTokenCache;
+            var tokenCache = App.MsalPublicClient.UserTokenCache;
             var users = await tokenCache.GetAccountsAsync
                 (new Uri(App.Authority).Host, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
             foreach (var user in users)
@@ -114,7 +114,7 @@ namespace XForms
         {
             var mi = ((MenuItem) sender);
             var accessTokenCacheItem = (MsalAccessTokenCacheItem) mi.CommandParameter;
-            var tokenCache = App.MsalPublicClient.AccountTokenCache;
+            var tokenCache = App.MsalPublicClient.UserTokenCache;
 
             // set access token as expired
             accessTokenCacheItem.ExpiresOnUnixTimestamp = GetCurrentTimestamp();
@@ -130,7 +130,7 @@ namespace XForms
             var mi = ((MenuItem)sender);
             var accessTokenCacheItem = (MsalAccessTokenCacheItem)mi.CommandParameter;
 
-            var tokenCache = App.MsalPublicClient.AccountTokenCache;
+            var tokenCache = App.MsalPublicClient.UserTokenCache;
             // todo pass idToken instead of null
             var requestContext = new RequestContext(new MsalLogger(Guid.NewGuid(), null));
 
@@ -143,7 +143,7 @@ namespace XForms
         {
             var mi = ((MenuItem) sender);
             var refreshTokenCacheItem = (MsalRefreshTokenCacheItem) mi.CommandParameter;
-            var tokenCache = App.MsalPublicClient.AccountTokenCache;
+            var tokenCache = App.MsalPublicClient.UserTokenCache;
 
             // invalidate refresh token
             refreshTokenCacheItem.Secret = "InvalidValue";

--- a/msal/tests/dev apps/XForms/XForms/IdTokenCacheItemDetails.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/IdTokenCacheItemDetails.xaml.cs
@@ -33,7 +33,7 @@ namespace XForms
             idTokenLabel.Text = JsonHelper.SerializeToJson(msalIdTokenCacheItem.IdToken);
 
             rawClientInfoLabel.Text = msalIdTokenCacheItem.RawClientInfo;
-            clientInfoUniqueIdentifierLabel.Text = msalIdTokenCacheItem.ClientInfo.UniqueIdentifier;
+            clientInfoUniqueIdentifierLabel.Text = msalIdTokenCacheItem.ClientInfo.UniqueObjectIdentifier;
             clientInfoUniqueTenantIdentifierLabel.Text = msalIdTokenCacheItem.ClientInfo.UniqueTenantIdentifier;
 
 

--- a/msal/tests/dev apps/XForms/XForms/RefreshTokenCacheItemDetails.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/RefreshTokenCacheItemDetails.xaml.cs
@@ -50,7 +50,7 @@ namespace XForms
             userIdentifierLabel.Text = msalRefreshTokenCacheItem.HomeAccountId;
             rawClientInfoLabel.Text = msalRefreshTokenCacheItem.RawClientInfo;
 
-            clientInfoUniqueIdentifierLabel.Text = msalRefreshTokenCacheItem.ClientInfo.UniqueIdentifier;
+            clientInfoUniqueIdentifierLabel.Text = msalRefreshTokenCacheItem.ClientInfo.UniqueObjectIdentifier;
             clientInfoUniqueTenantIdentifierLabel.Text = msalRefreshTokenCacheItem.ClientInfo.UniqueTenantIdentifier;
 
             secretLabel.Text = StringShortenerConverter.GetShortStr(msalRefreshTokenCacheItem.Secret, 100);

--- a/msal/tests/dev apps/XForms/XForms/SettingsPage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/SettingsPage.xaml.cs
@@ -49,13 +49,13 @@ namespace XForms
             authority.Text = App.Authority;
             clientIdEntry.Text = App.ClientId;
 
-            numOfAtItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllAccessTokensAsString()
+            numOfAtItems.Text = App.MsalPublicClient.AccountTokenCache.tokenCacheAccessor.GetAllAccessTokensAsString()
                 .Count.ToString();
-            numOfRtItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllRefreshTokensAsString()
+            numOfRtItems.Text = App.MsalPublicClient.AccountTokenCache.tokenCacheAccessor.GetAllRefreshTokensAsString()
                 .Count.ToString();
-            numOfIdItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllIdTokensAsString()
+            numOfIdItems.Text = App.MsalPublicClient.AccountTokenCache.tokenCacheAccessor.GetAllIdTokensAsString()
                 .Count.ToString();
-            numOfAccountItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllAccountsAsString()
+            numOfAccountItems.Text = App.MsalPublicClient.AccountTokenCache.tokenCacheAccessor.GetAllAccountsAsString()
                 .Count.ToString();
 
             validateAuthority.IsToggled = App.ValidateAuthority;
@@ -71,19 +71,19 @@ namespace XForms
 
         private void OnClearAllCache(object sender, EventArgs e)
         {
-            App.MsalPublicClient.UserTokenCache.Clear();
+            App.MsalPublicClient.AccountTokenCache.Clear();
             RefreshView();
         }
 
         private void OnClearAdalCache(object sender, EventArgs e)
         {
-            App.MsalPublicClient.UserTokenCache.ClearAdalCache();
+            App.MsalPublicClient.AccountTokenCache.ClearAdalCache();
             RefreshView();
         }
 
         private void OnClearMsalCache(object sender, EventArgs e)
         {
-            App.MsalPublicClient.UserTokenCache.ClearMsalCache();
+            App.MsalPublicClient.AccountTokenCache.ClearMsalCache();
             RefreshView();
         }
 

--- a/msal/tests/dev apps/XForms/XForms/SettingsPage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/SettingsPage.xaml.cs
@@ -49,13 +49,13 @@ namespace XForms
             authority.Text = App.Authority;
             clientIdEntry.Text = App.ClientId;
 
-            numOfAtItems.Text = App.MsalPublicClient.AccountTokenCache.tokenCacheAccessor.GetAllAccessTokensAsString()
+            numOfAtItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllAccessTokensAsString()
                 .Count.ToString();
-            numOfRtItems.Text = App.MsalPublicClient.AccountTokenCache.tokenCacheAccessor.GetAllRefreshTokensAsString()
+            numOfRtItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllRefreshTokensAsString()
                 .Count.ToString();
-            numOfIdItems.Text = App.MsalPublicClient.AccountTokenCache.tokenCacheAccessor.GetAllIdTokensAsString()
+            numOfIdItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllIdTokensAsString()
                 .Count.ToString();
-            numOfAccountItems.Text = App.MsalPublicClient.AccountTokenCache.tokenCacheAccessor.GetAllAccountsAsString()
+            numOfAccountItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllAccountsAsString()
                 .Count.ToString();
 
             validateAuthority.IsToggled = App.ValidateAuthority;
@@ -71,19 +71,19 @@ namespace XForms
 
         private void OnClearAllCache(object sender, EventArgs e)
         {
-            App.MsalPublicClient.AccountTokenCache.Clear();
+            App.MsalPublicClient.UserTokenCache.Clear();
             RefreshView();
         }
 
         private void OnClearAdalCache(object sender, EventArgs e)
         {
-            App.MsalPublicClient.AccountTokenCache.ClearAdalCache();
+            App.MsalPublicClient.UserTokenCache.ClearAdalCache();
             RefreshView();
         }
 
         private void OnClearMsalCache(object sender, EventArgs e)
         {
-            App.MsalPublicClient.AccountTokenCache.ClearMsalCache();
+            App.MsalPublicClient.UserTokenCache.ClearMsalCache();
             RefreshView();
         }
 


### PR DESCRIPTION
This is a partial fix, please do not merge it. I'd like to get an opinion on the current approach and how the new API looks like. 

This contains: 

- functional code
- existing unit test pass
- some public comments

Remaining: 

- more unit tests
- another pass through internal code for references to "user" which should be renamed to "account" 
- E2E manual testing