### PR TITLE
Does not expose the interactive overrides in .NET Core

### DIFF
--- a/msal/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Client
 
         // expose the interactive API without UIParent only for platforms that 
         // do not need it to operate like desktop, UWP, iOS.
-#if !ANDROID && !FACADE
+#if !ANDROID && !NETSTANDARD1_1 && !NETSTANDARD1_3
         /// <summary>
         /// Interactive request to acquire token. 
         /// </summary>
@@ -139,7 +139,7 @@ namespace Microsoft.Identity.Client
 
 #endif
 
-#if !FACADE
+#if !NETSTANDARD1_1 && !NETSTANDARD1_3
         // these API methods are exposed on other platforms.
         /// <summary>
         /// Interactive request to acquire token. 

--- a/msal/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Client
 
         // expose the interactive API without UIParent only for platforms that 
         // do not need it to operate like desktop, UWP, iOS.
-#if !ANDROID
+#if !ANDROID && !FACADE
         /// <summary>
         /// Interactive request to acquire token. 
         /// </summary>
@@ -138,7 +138,8 @@ namespace Microsoft.Identity.Client
             string authority);
 
 #endif
-        
+
+#if !FACADE
         // these API methods are exposed on other platforms.
         /// <summary>
         /// Interactive request to acquire token. 
@@ -236,5 +237,6 @@ namespace Microsoft.Identity.Client
             string extraQueryParameters,
             IEnumerable<string> extraScopesToConsent,
             string authority, UIParent parent);
+#endif
     }
 }

--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Client
         public bool UseCorporateNetwork { get; set; }
 #endif
 
-#if !ANDROID && !FACADE
+#if !ANDROID && !NETSTANDARD1_1 && !NETSTANDARD1_3
         /// <summary>
         /// Interactive request to acquire token. 
         /// </summary>
@@ -202,7 +202,7 @@ namespace Microsoft.Identity.Client
         }
 #endif
 
-#if !FACADE
+#if !NETSTANDARD1_1 && !NETSTANDARD1_3
         /// <summary>
         /// Interactive request to acquire token. 
         /// </summary>

--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Client
         public bool UseCorporateNetwork { get; set; }
 #endif
 
-#if !ANDROID
+#if !ANDROID && !FACADE
         /// <summary>
         /// Interactive request to acquire token. 
         /// </summary>
@@ -202,6 +202,7 @@ namespace Microsoft.Identity.Client
         }
 #endif
 
+#if !FACADE
         /// <summary>
         /// Interactive request to acquire token. 
         /// </summary>
@@ -330,6 +331,7 @@ namespace Microsoft.Identity.Client
                     AcquireTokenForUserCommonAsync(authorityInstance, scopes, extraScopesToConsent, user,
                         behavior, extraQueryParameters, parent, ApiEvent.ApiIds.AcquireTokenWithScopeUserBehaviorAuthority).ConfigureAwait(false);
         }
+#endif
 
         internal IWebUI CreateWebAuthenticationDialog(UIParent parent, UIBehavior behavior, RequestContext requestContext)
         {


### PR DESCRIPTION
Does not expose the interactive overrides in .NET Core of AcquireTokenAsync in .NET Core.

See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/557