### PR TITLE
Make WebBrowserNavigateErrorEventHandler internal in both ADAL and MSAL

### DIFF
--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/CustomWebBrowser.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/CustomWebBrowser.cs
@@ -267,5 +267,5 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
     /// </summary>
     /// <param name="sender">object type</param>
     /// <param name="e">WebBrowserNavigateErrorEventArgs type</param>
-    public delegate void WebBrowserNavigateErrorEventHandler(object sender, WebBrowserNavigateErrorEventArgs e);
+    internal delegate void WebBrowserNavigateErrorEventHandler(object sender, WebBrowserNavigateErrorEventArgs e);
 }

--- a/msal/src/Microsoft.Identity.Client/Platforms/net45/CustomWebBrowser.cs
+++ b/msal/src/Microsoft.Identity.Client/Platforms/net45/CustomWebBrowser.cs
@@ -261,5 +261,5 @@ namespace Microsoft.Identity.Client.Internal.UI
 
     /// <summary>
     /// </summary>
-    public delegate void WebBrowserNavigateErrorEventHandler(object sender, WebBrowserNavigateErrorEventArgs e);
+    internal delegate void WebBrowserNavigateErrorEventHandler(object sender, WebBrowserNavigateErrorEventArgs e);
 }


### PR DESCRIPTION
I tested by running net45 samples with interactive auth