### PR TITLE
b2c fixes, refactoring, addressing pr comments

### DIFF
--- a/core/src/Cache/CacheFallbackOperations.cs
+++ b/core/src/Cache/CacheFallbackOperations.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.Core.Cache
         }
 
         public static Dictionary<String, AdalUserInfo> RemoveAdalUser(ILegacyCachePersistance legacyCachePersistance,
-            string displayableId, ISet<string> authorityHostAliases, string identifier)
+            string displayableId, ISet<string> environmentAliases, string identifier)
         {
             Dictionary<String, AdalUserInfo> users = new Dictionary<String, AdalUserInfo>();
             try
@@ -158,7 +158,7 @@ namespace Microsoft.Identity.Core.Cache
                 List<AdalTokenCacheKey> keysToRemove = new List<AdalTokenCacheKey>();
                 foreach (KeyValuePair<AdalTokenCacheKey, AdalResultWrapper> pair in dictionary)
                 {
-                    if (authorityHostAliases.Contains(new Uri(pair.Key.Authority).Host) &&
+                    if (environmentAliases.Contains(new Uri(pair.Key.Authority).Host) &&
                          displayableId.Equals(pair.Key.DisplayableId) &&
                          identifier.Equals(ClientInfo.CreateFromJson(pair.Value.RawClientInfo).ToAccountIdentifier()))
                     {

--- a/core/src/Cache/MsalAccessTokenCacheItem.cs
+++ b/core/src/Cache/MsalAccessTokenCacheItem.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Identity.Core.Cache
                 return string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/", Environment, TenantId ?? "common");
             }
         }
-
+        
         internal SortedSet<string> ScopeSet
         {
             get

--- a/core/src/Instance/AadAuthority.cs
+++ b/core/src/Instance/AadAuthority.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Core.Instance
             "login.cloudgovapi.us" // Microsoft Azure US Government
         };
 
-        public const string DefaultTrustedAuthority = "login.microsoftonline.com";
+        public const string DefaultTrustedHost = "login.microsoftonline.com";
 
         private const string AadInstanceDiscoveryEndpoint = "https://login.microsoftonline.com/common/discovery/instance";
 
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Core.Instance
             AuthorityType = AuthorityType.Aad;
         }
 
-        protected async Task UpdateCanonicalAuthorityAsync(RequestContext requestContext)
+        internal override async Task UpdateCanonicalAuthorityAsync(RequestContext requestContext)
         {
             var metadata = await AadInstanceDiscovery.Instance.
                 GetMetadataEntryAsync(new Uri(CanonicalAuthority), this.ValidateAuthority, requestContext).ConfigureAwait(false);
@@ -102,10 +102,11 @@ namespace Microsoft.Identity.Core.Instance
                 !string.IsNullOrEmpty(
                     TrustedHostList.FirstOrDefault(a => string.Compare(host, a, StringComparison.OrdinalIgnoreCase) == 0));
         }
-
-        internal override async Task InitAsync(RequestContext requestContext)
+        
+        internal override string GetTenantId()
         {
-            await UpdateCanonicalAuthorityAsync(requestContext).ConfigureAwait(false);
+            return GetFirstPathSegment(CanonicalAuthority);
         }
+        
     }
 }

--- a/core/src/Instance/AdfsAuthority.cs
+++ b/core/src/Instance/AdfsAuthority.cs
@@ -170,5 +170,10 @@ namespace Microsoft.Identity.Core.Instance
 
             return upn.Split('@')[1];
         }
+
+        internal override string GetTenantId()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/core/src/Instance/Authority.cs
+++ b/core/src/Instance/Authority.cs
@@ -80,6 +80,11 @@ namespace Microsoft.Identity.Core.Instance
 
         public string Host { get; set; }
 
+        internal virtual async Task UpdateCanonicalAuthorityAsync(RequestContext requestContext)
+        {
+            await Task.FromResult(0).ConfigureAwait(false);
+        }
+
         public static void ValidateAsUri(string authority)
         {
             if (string.IsNullOrWhiteSpace(authority))
@@ -120,11 +125,11 @@ namespace Microsoft.Identity.Core.Instance
         {
             var firstPathSegment = GetFirstPathSegment(authority);
 
-            if (string.Compare(firstPathSegment, "adfs", StringComparison.OrdinalIgnoreCase) == 0)
+            if (string.Equals(firstPathSegment, "adfs", StringComparison.OrdinalIgnoreCase))
             {
                 return AuthorityType.Adfs;
             }
-            else if (string.Compare(firstPathSegment, B2CAuthority.Prefix, StringComparison.OrdinalIgnoreCase) == 0)
+            else if (string.Equals(firstPathSegment, B2CAuthority.Prefix, StringComparison.OrdinalIgnoreCase))
             {
                 return AuthorityType.B2C;
             }
@@ -236,6 +241,8 @@ namespace Microsoft.Identity.Core.Instance
 
         protected abstract string GetDefaultOpenIdConfigurationEndpoint();
 
+        internal abstract string GetTenantId();
+
         private async Task<TenantDiscoveryResponse> DiscoverEndpointsAsync(string openIdConfigurationEndpoint,
             RequestContext requestContext)
         {
@@ -278,11 +285,6 @@ namespace Microsoft.Identity.Core.Instance
             }
 
             return uri.ToLowerInvariant();
-        }
-
-        internal virtual async Task InitAsync(RequestContext requestContext)
-        {
-            await Task.FromResult(0).ConfigureAwait(false);
         }
     }
 }

--- a/core/src/Instance/B2CAuthority.cs
+++ b/core/src/Instance/B2CAuthority.cs
@@ -58,5 +58,10 @@ namespace Microsoft.Identity.Core.Instance
 
             return await Task.Run(() => GetDefaultOpenIdConfigurationEndpoint()).ConfigureAwait(false);
         }
+        
+        internal override string GetTenantId()
+        {
+            return new Uri(CanonicalAuthority).Segments[2].TrimEnd('/');
+        }
     }
 }

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/InstanceTests/AadAuthorityTests.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/InstanceTests/AadAuthorityTests.cs
@@ -54,7 +54,7 @@ namespace Test.Microsoft.Identity.Unit.InstanceTests
             CoreExceptionFactory.Instance = new TestExceptionFactory();
             HttpMessageHandlerFactory.ClearMockHandlers();
 
-            AadInstanceDiscovery.Instance.InstanceCache.Clear();
+            AadInstanceDiscovery.Instance.Cache.Clear();
         }
 
         [TestCleanup]

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -124,7 +124,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         internal async Task<Uri> CreateAuthorizationUriAsync()
         {
-            await AuthenticationRequestParameters.Authority.InitAsync
+            await AuthenticationRequestParameters.Authority.UpdateCanonicalAuthorityAsync
                 (AuthenticationRequestParameters.RequestContext).ConfigureAwait(false);
 
             //this method is used in confidential clients to create authorization URLs.

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -224,7 +224,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             }
 
             IdToken idToken = IdToken.Parse(Response.IdToken);
-            // todo throw Exception when IdToken or client_info in null
+
             AuthenticationRequestParameters.TenantUpdatedCanonicalAuthority = Authority.UpdateTenantId(
                 AuthenticationRequestParameters.Authority.CanonicalAuthority, idToken?.TenantId);
 
@@ -234,10 +234,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 AuthenticationRequestParameters.RequestContext.Logger.Info(msg);
                 AuthenticationRequestParameters.RequestContext.Logger.InfoPii(msg);
 
-                // todo should we return idToken from SaveAccessAndRefreshToken as well ?
-                // problem - if AT is not stored we will fail  ?
-                MsalAccessTokenItem = TokenCache.SaveAccessAndRefreshToken(AuthenticationRequestParameters, Response);
-                MsalIdTokenItem = TokenCache.GetIdTokenCacheItem(MsalAccessTokenItem.GetIdTokenItemKey(), AuthenticationRequestParameters.RequestContext);
+                var tuple = TokenCache.SaveAccessAndRefreshToken(AuthenticationRequestParameters, Response);
+                MsalAccessTokenItem = tuple.Item1;
+                MsalIdTokenItem = tuple.Item2;
             }
             else{
                 MsalAccessTokenItem = new MsalAccessTokenCacheItem(AuthenticationRequestParameters.Authority.Host,
@@ -262,7 +261,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         internal async Task ResolveAuthorityEndpointsAsync()
         {
-            await AuthenticationRequestParameters.Authority.InitAsync
+            await AuthenticationRequestParameters.Authority.UpdateCanonicalAuthorityAsync
                 (AuthenticationRequestParameters.RequestContext).ConfigureAwait(false);
 
             await AuthenticationRequestParameters.Authority
@@ -280,8 +279,6 @@ namespace Microsoft.Identity.Client.Internal.Requests
             {
                 SaveTokenResponseToCache();
             }
-
-            //MsalIdTokenCacheItem msalIdTokenCacheItem = TokenCache?.GetIdTokenCacheItem(MsalAccessTokenItem.GetIdTokenItemKey());
 
             return new AuthenticationResult(MsalAccessTokenItem, MsalIdTokenItem);
         }

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -112,39 +112,54 @@ namespace Microsoft.Identity.Client
             BeforeWrite?.Invoke(args);
         }
 
-        internal MsalAccessTokenCacheItem SaveAccessAndRefreshToken(AuthenticationRequestParameters requestParams,
-            MsalTokenResponse response)
+        internal Tuple<MsalAccessTokenCacheItem, MsalIdTokenCacheItem> SaveAccessAndRefreshToken
+            (AuthenticationRequestParameters requestParams, MsalTokenResponse response)
         {
+            var tenantId = Authority.CreateAuthority(requestParams.TenantUpdatedCanonicalAuthority, false)
+                .GetTenantId();
+
+            var instanceDiscoveryMetadataEntry = GetCachedAuthorityMetaData(requestParams.TenantUpdatedCanonicalAuthority);
+
+            var environmentAliases = GetEnvironmentAliases(requestParams.TenantUpdatedCanonicalAuthority,
+                instanceDiscoveryMetadataEntry);
+
+            var preferredEnvironmentHost = GetPreferredEnvironmentHost(requestParams.Authority.Host,
+                instanceDiscoveryMetadataEntry);
+
+            IdToken idToken = IdToken.Parse(response.IdToken);
+
+            var msalAccessTokenCacheItem =
+                new MsalAccessTokenCacheItem(preferredEnvironmentHost, requestParams.ClientId, response, tenantId)
+                {
+                    UserAssertionHash = requestParams.UserAssertion?.AssertionHash
+                };
+
+            MsalRefreshTokenCacheItem msalRefreshTokenCacheItem = null;
+
+            MsalIdTokenCacheItem msalIdTokenCacheItem = null;
+            if (idToken != null)
+            {
+                msalIdTokenCacheItem = new MsalIdTokenCacheItem
+                    (preferredEnvironmentHost, requestParams.ClientId, response, idToken?.TenantId);
+            }
+
+            if (!requestParams.IsClientCredentialRequest && 
+                !ContainsClaimsRequiredToStoreInCahce(idToken, requestParams.RequestContext))
+            {
+                return Tuple.Create(msalAccessTokenCacheItem, msalIdTokenCacheItem);
+            }
+
             lock (LockObject)
             {
                 try
                 {
-                    var instanceDiscoveryMetadataEntry = GetCachedAuthorityMetaData(requestParams.TenantUpdatedCanonicalAuthority);
-
-                    var authorityAliases = GetAuthorityAliases(requestParams.TenantUpdatedCanonicalAuthority,
-                        instanceDiscoveryMetadataEntry);
-
-                    var preferredEnvironmentHost = GetPreferredEnvironmentHost(requestParams.Authority.Host,
-                        instanceDiscoveryMetadataEntry);
-
-                    IdToken idToken = IdToken.Parse(response.IdToken);
-
-                    MsalRefreshTokenCacheItem msalRefreshTokenCacheItem = null;
-                    // create the access token cache item
-                    var msalAccessTokenCacheItem =
-                        new MsalAccessTokenCacheItem(preferredEnvironmentHost, requestParams.ClientId,
-                                response, idToken?.TenantId)
-                            {UserAssertionHash = requestParams.UserAssertion?.AssertionHash};
-
                     var args = new TokenCacheNotificationArgs
                     {
                         TokenCache = this,
                         ClientId = ClientId,
                         Account = msalAccessTokenCacheItem.HomeAccountId != null ?
-                                    new Account(
-                                        AccountId.FromClientInfo(msalAccessTokenCacheItem.ClientInfo),
-                                        idToken?.PreferredUsername,
-                                        idToken?.Name) : 
+                                    new Account(AccountId.FromClientInfo(msalAccessTokenCacheItem.ClientInfo),
+                                    idToken?.PreferredUsername, preferredEnvironmentHost) : 
                                     null
                     };
 
@@ -152,65 +167,16 @@ namespace Microsoft.Identity.Client
                     OnBeforeAccess(args);
                     OnBeforeWrite(args);
 
-                    //delete all cache entries with intersecting scopes.
-                    //this should not happen but we have this as a safe guard
-                    //against multiple matches.
-                    var msg = "Looking for scopes for the authority in the cache which intersect with " +
-                              requestParams.Scope.AsSingleString();
-                    requestParams.RequestContext.Logger.Info(msg);
-                    requestParams.RequestContext.Logger.InfoPii(msg);
-                    IList<MsalAccessTokenCacheItem> accessTokenItemList = new List<MsalAccessTokenCacheItem>();
-                    foreach (var accessTokenString in tokenCacheAccessor.GetAllAccessTokensAsString())
-                    {
-                        MsalAccessTokenCacheItem msalAccessTokenItem =
-                            JsonHelper.TryToDeserializeFromJson<MsalAccessTokenCacheItem>(accessTokenString, requestParams.RequestContext);
-
-                        if (msalAccessTokenItem != null && msalAccessTokenItem.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase) &&
-                            authorityAliases.Contains(msalAccessTokenItem.Authority) &&
-                            msalAccessTokenItem.ScopeSet.ScopeIntersects(msalAccessTokenCacheItem.ScopeSet))
-                        {
-                            msg = "Intersecting scopes found - " + msalAccessTokenItem.Scopes;
-                            requestParams.RequestContext.Logger.Verbose(msg);
-                            requestParams.RequestContext.Logger.VerbosePii(msg);
-                            accessTokenItemList.Add(msalAccessTokenItem);
-                        }
-                    }
-
-                    msg = "Intersecting scope entries count - " + accessTokenItemList.Count;
-                    requestParams.RequestContext.Logger.Info(msg);
-                    requestParams.RequestContext.Logger.InfoPii(msg);
-
-                    if (!requestParams.IsClientCredentialRequest)
-                    {
-                        //filter by identifer of the user instead
-                        accessTokenItemList =
-                            accessTokenItemList.Where(
-                                    item => item.HomeAccountId.Equals(msalAccessTokenCacheItem.HomeAccountId, StringComparison.OrdinalIgnoreCase))
-                                .ToList();
-                        msg = "Matching entries after filtering by user - " + accessTokenItemList.Count;
-                        requestParams.RequestContext.Logger.Info(msg);
-                        requestParams.RequestContext.Logger.InfoPii(msg);
-                    }
-
-                    foreach (var cacheItem in accessTokenItemList)
-                    {
-                        tokenCacheAccessor.DeleteAccessToken(cacheItem.GetKey(), requestParams.RequestContext);
-                    }
+                    DeleteAccessTokensWithIntersectingScopes(requestParams, environmentAliases, tenantId, 
+                        msalAccessTokenCacheItem.ScopeSet, msalAccessTokenCacheItem.HomeAccountId);
 
                     tokenCacheAccessor.SaveAccessToken(msalAccessTokenCacheItem, requestParams.RequestContext);
 
-                    MsalIdTokenCacheItem msalIdTokenCacheItem = null;
                     if (idToken != null)
                     {
-                        // create the id token cache item
-                        msalIdTokenCacheItem =
-                            new MsalIdTokenCacheItem(preferredEnvironmentHost, requestParams.ClientId,
-                                response, idToken?.TenantId);
-
                         tokenCacheAccessor.SaveIdToken(msalIdTokenCacheItem, requestParams.RequestContext);
 
-                        var msalAccountCacheItem =
-                            new MsalAccountCacheItem(preferredEnvironmentHost, response);
+                        var msalAccountCacheItem = new MsalAccountCacheItem(preferredEnvironmentHost, response);
 
                         tokenCacheAccessor.SaveAccount(msalAccountCacheItem, requestParams.RequestContext);
                     }
@@ -218,17 +184,12 @@ namespace Microsoft.Identity.Client
                     // if server returns the refresh token back, save it in the cache.
                     if (response.RefreshToken != null)
                     {
-                        // create the refresh token cache item
-                       msalRefreshTokenCacheItem = new MsalRefreshTokenCacheItem(
-                            preferredEnvironmentHost,
-                            requestParams.ClientId,
-                            response);
-                        msg = "Saving RT in cache...";
+                        msalRefreshTokenCacheItem = new MsalRefreshTokenCacheItem(preferredEnvironmentHost, requestParams.ClientId, response);
+                        var msg = "Saving RT in cache...";
                         requestParams.RequestContext.Logger.Info(msg);
                         requestParams.RequestContext.Logger.InfoPii(msg);
                         tokenCacheAccessor.SaveRefreshToken(msalRefreshTokenCacheItem, requestParams.RequestContext);
                     }
-
                     OnAfterAccess(args);
 
                     //save RT in ADAL cache for public clients
@@ -239,14 +200,83 @@ namespace Microsoft.Identity.Client
                             Authority.UpdateHost(requestParams.TenantUpdatedCanonicalAuthority, preferredEnvironmentHost),
                             msalIdTokenCacheItem.IdToken.ObjectId, response.Scope);
                     }
-
-                    return msalAccessTokenCacheItem;
+                    return Tuple.Create(msalAccessTokenCacheItem, msalIdTokenCacheItem);
                 }
                 finally
                 {
                     HasStateChanged = false;
                 }
             }
+        }
+        private void DeleteAccessTokensWithIntersectingScopes(AuthenticationRequestParameters requestParams,
+           ISet<string> environmentAliases, string tenantId, SortedSet<string> scopeSet, string homeAccountId)
+        {
+            //delete all cache entries with intersecting scopes.
+            //this should not happen but we have this as a safe guard
+            //against multiple matches.
+            var msg = "Looking for scopes for the authority in the cache which intersect with " +
+                      requestParams.Scope.AsSingleString();
+            requestParams.RequestContext.Logger.Info(msg);
+            requestParams.RequestContext.Logger.InfoPii(msg);
+            IList<MsalAccessTokenCacheItem> accessTokenItemList = new List<MsalAccessTokenCacheItem>();
+            foreach (var accessTokenString in tokenCacheAccessor.GetAllAccessTokensAsString())
+            {
+                MsalAccessTokenCacheItem msalAccessTokenItem =
+                    JsonHelper.TryToDeserializeFromJson<MsalAccessTokenCacheItem>(accessTokenString, requestParams.RequestContext);
+
+                if (msalAccessTokenItem != null && msalAccessTokenItem.ClientId.Equals(ClientId, StringComparison.OrdinalIgnoreCase) &&
+                    environmentAliases.Contains(msalAccessTokenItem.Environment) &&
+                    msalAccessTokenItem.TenantId.Equals(tenantId, StringComparison.OrdinalIgnoreCase) &&
+                    msalAccessTokenItem.ScopeSet.ScopeIntersects(scopeSet))
+                {
+                    msg = "Intersecting scopes found - " + msalAccessTokenItem.Scopes;
+                    requestParams.RequestContext.Logger.Verbose(msg);
+                    requestParams.RequestContext.Logger.VerbosePii(msg);
+                    accessTokenItemList.Add(msalAccessTokenItem);
+                }
+            }
+
+            msg = "Intersecting scope entries count - " + accessTokenItemList.Count;
+            requestParams.RequestContext.Logger.Info(msg);
+            requestParams.RequestContext.Logger.InfoPii(msg);
+
+            if (!requestParams.IsClientCredentialRequest)
+            {
+                //filter by identifer of the user instead
+                accessTokenItemList =
+                    accessTokenItemList.Where(
+                            item => item.HomeAccountId.Equals(homeAccountId, StringComparison.OrdinalIgnoreCase))
+                        .ToList();
+                msg = "Matching entries after filtering by user - " + accessTokenItemList.Count;
+                requestParams.RequestContext.Logger.Info(msg);
+                requestParams.RequestContext.Logger.InfoPii(msg);
+            }
+
+            foreach (var cacheItem in accessTokenItemList)
+            {
+                tokenCacheAccessor.DeleteAccessToken(cacheItem.GetKey(), requestParams.RequestContext);
+            }
+        }
+
+        private bool ContainsClaimsRequiredToStoreInCahce(IdToken idToken, RequestContext requestContext)
+        {
+            if (idToken == null || string.IsNullOrEmpty(idToken.TenantId) || string.IsNullOrEmpty(idToken.PreferredUsername))
+            {
+                string msg;
+                if (idToken == null)
+                {
+                    msg = "Skipping storing tokens in the cahe - no IdToken in token response";
+                }
+                else
+                {
+                    msg = "Skipping storing tokens in the cahe - IdToken does not contain required claims";
+                }
+                requestContext.Logger.Warning(msg);
+                requestContext.Logger.WarningPii(msg);
+
+                return false;
+            }
+            return true;
         }
 
         internal async Task<MsalAccessTokenCacheItem> FindAccessTokenAsync(AuthenticationRequestParameters requestParams)
@@ -255,21 +285,22 @@ namespace Microsoft.Identity.Client
             Telemetry.GetInstance().StartEvent(requestParams.RequestContext.TelemetryRequestId, cacheEvent);
             try
             {   
-                ISet<string> authorityAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                string preferredAlias = null;
+                ISet<string> environmentAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                string preferredEnvironmentAlias = null;
+
                 if (requestParams.Authority != null)
                 {
                     var instanceDiscoveryMetadataEntry = await GetCachedOrDiscoverAuthorityMetaDataAsync(requestParams.Authority.CanonicalAuthority,
                         requestParams.ValidateAuthority, requestParams.RequestContext).ConfigureAwait(false);
 
-                    authorityAliases.UnionWith
-                        (GetAuthorityAliases(requestParams.Authority.CanonicalAuthority, instanceDiscoveryMetadataEntry));
+                    environmentAliases.UnionWith
+                        (GetEnvironmentAliases(requestParams.Authority.CanonicalAuthority, instanceDiscoveryMetadataEntry));
 
-                    preferredAlias = 
-                        Authority.UpdateHost(requestParams.Authority.CanonicalAuthority, instanceDiscoveryMetadataEntry.PreferredCache);
+                    preferredEnvironmentAlias = instanceDiscoveryMetadataEntry.PreferredCache;
                 }
 
-                return FindAccessTokenCommon(requestParams, preferredAlias, authorityAliases);
+                return FindAccessTokenCommon
+                    (requestParams, preferredEnvironmentAlias, environmentAliases);
             }
             finally
             {
@@ -278,7 +309,7 @@ namespace Microsoft.Identity.Client
         }
 
         private MsalAccessTokenCacheItem FindAccessTokenCommon
-            (AuthenticationRequestParameters requestParams, string prefferedAlias, ISet<string> authorityAliases)
+            (AuthenticationRequestParameters requestParams, string preferredEnvironmentAlias, ISet<string> environmentAliases)
         {
             lock (LockObject)
             {
@@ -350,11 +381,12 @@ namespace Microsoft.Identity.Client
                 requestParams.RequestContext.Logger.Info(msg);
                 requestParams.RequestContext.Logger.InfoPii(msg);
                 //no authority passed
-                if (authorityAliases.Count == 0)
+                if (environmentAliases.Count == 0)
                 {
                     msg = "No authority provided..";
                     requestParams.RequestContext.Logger.Info(msg);
                     requestParams.RequestContext.Logger.InfoPii(msg);
+                    
                     //if only one cached token found
                     if (filteredItems.Count() == 1)
                     {
@@ -412,7 +444,7 @@ namespace Microsoft.Identity.Client
                     //authority was passed in the API
                     IEnumerable<MsalAccessTokenCacheItem> filteredByPrefferedAlias = 
                         filteredItems.Where
-                        (item => item.Authority.Equals(prefferedAlias, StringComparison.OrdinalIgnoreCase))
+                        (item => item.Environment.Equals(preferredEnvironmentAlias, StringComparison.OrdinalIgnoreCase))
                         .ToList();
 
                     if (filteredByPrefferedAlias.Any())
@@ -421,7 +453,9 @@ namespace Microsoft.Identity.Client
                     }
                     else
                     {
-                        filteredItems = filteredItems.Where(item => authorityAliases.Contains(item.Authority)).ToList();
+                        filteredItems = filteredItems.Where(
+                            item => environmentAliases.Contains(item.Environment) && 
+                            item.TenantId.Equals(requestParams.Authority.GetTenantId(), StringComparison.OrdinalIgnoreCase)).ToList();
                     }
 
                     //no match
@@ -494,7 +528,7 @@ namespace Microsoft.Identity.Client
             var instanceDiscoveryMetadataEntry = await GetCachedOrDiscoverAuthorityMetaDataAsync(requestParam.Authority.CanonicalAuthority,
                 requestParam.ValidateAuthority, requestParam.RequestContext).ConfigureAwait(false);
 
-            var authorityHostAliases = GetAuthorityHostAliases(requestParam.Authority.CanonicalAuthority,
+            var environmentAliases = GetEnvironmentAliases(requestParam.Authority.CanonicalAuthority,
                 instanceDiscoveryMetadataEntry);
 
             var preferredEnvironmentHost = GetPreferredEnvironmentHost(requestParam.Authority.Host,
@@ -536,7 +570,7 @@ namespace Microsoft.Identity.Client
 
                         if (msalRefreshToken != null &&
                             msalRefreshToken.ClientId.Equals(requestParam.ClientId, StringComparison.OrdinalIgnoreCase) &&
-                            authorityHostAliases.Contains(msalRefreshToken.Environment) &&
+                            environmentAliases.Contains(msalRefreshToken.Environment) &&
                             requestParam.Account?.HomeAccountId.Identifier == msalRefreshToken.HomeAccountId)
                         {
                             msalRefreshTokenCacheItem = msalRefreshToken;
@@ -564,7 +598,7 @@ namespace Microsoft.Identity.Client
                 return CacheFallbackOperations.GetAdalEntryForMsal(
                     legacyCachePersistance,
                     preferredEnvironmentHost,
-                    authorityHostAliases, 
+                    environmentAliases, 
                     requestParam.ClientId, 
                     requestParam.LoginHint, 
                     requestParam.Account.HomeAccountId?.Identifier, 
@@ -723,35 +757,28 @@ namespace Microsoft.Identity.Client
             var authorityType = Authority.GetAuthorityType(authority);
             if (authorityType == Core.Instance.AuthorityType.Aad || authorityType == Core.Instance.AuthorityType.B2C)
             {
-                AadInstanceDiscovery.Instance.InstanceCache.TryGetValue
+                AadInstanceDiscovery.Instance.Cache.TryGetValue
                     (new Uri(authority).Host, out instanceDiscoveryMetadata);
             }
             return instanceDiscoveryMetadata;
         }
 
-        private ISet<string> GetAuthorityHostAliases(string authority, InstanceDiscoveryMetadataEntry metadata)
+        private ISet<string> GetEnvironmentAliases(string authority, InstanceDiscoveryMetadataEntry metadata)
         {
-            ISet<string> authorityHostAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            ISet<string> environmentAliases = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
             {
                 new Uri(authority).Host
             };
 
             if (metadata != null)
             {
-                foreach (string authorityHostAlias in metadata.Aliases ?? Enumerable.Empty<string>())
+                foreach (string environmentAlias in metadata.Aliases ?? Enumerable.Empty<string>())
                 {
-                    authorityHostAliases.Add(authorityHostAlias);
+                    environmentAliases.Add(environmentAlias);
                 }
             }
 
-            return authorityHostAliases;
-        }
-        private ISet<string> GetAuthorityAliases(string authority, InstanceDiscoveryMetadataEntry metadata)
-        {
-            ISet<string> authorityHostAliases = GetAuthorityHostAliases(authority, metadata);
-
-            return new HashSet<string>
-                (authorityHostAliases.Select(e => Authority.UpdateHost(authority, e)).ToList());
+            return environmentAliases;
         }
 
         private string GetPreferredEnvironmentHost(string environmentHost, InstanceDiscoveryMetadataEntry metadata)
@@ -771,7 +798,7 @@ namespace Microsoft.Identity.Client
             var instanceDiscoveryMetadataEntry = 
                 await GetCachedOrDiscoverAuthorityMetaDataAsync(authority, validateAuthority, requestContext).ConfigureAwait(false);
 
-            var authorityHostAliases = GetAuthorityHostAliases(authority, instanceDiscoveryMetadataEntry);
+            var environmentAliases = GetEnvironmentAliases(authority, instanceDiscoveryMetadataEntry);
 
             lock (LockObject)
             {
@@ -790,12 +817,12 @@ namespace Microsoft.Identity.Client
                 IDictionary<string, Account> allUsers = new Dictionary<string, Account>();
                 foreach (MsalRefreshTokenCacheItem rtItem in tokenCacheItems)
                 {
-                    if (authorityHostAliases.Contains(rtItem.Environment))
+                    if (environmentAliases.Contains(rtItem.Environment))
                     {
                         foreach (MsalAccountCacheItem account in accountCacheItems)
                         {
                             if (rtItem.HomeAccountId.Equals(account.HomeAccountId, StringComparison.OrdinalIgnoreCase) &&
-                                authorityHostAliases.Contains(account.Environment))
+                                environmentAliases.Contains(account.Environment))
                             {
                                 Account user = new Account(AccountId.FromClientInfo(account.ClientInfo), account.PreferredUsername, new Uri(authority).Host);
                                 allUsers[rtItem.HomeAccountId] = user;
@@ -806,7 +833,7 @@ namespace Microsoft.Identity.Client
                 }
 
                 foreach (KeyValuePair<string, AdalUserInfo> pair in CacheFallbackOperations.GetAllAdalUsersForMsal(
-                    legacyCachePersistance, authorityHostAliases, ClientId))
+                    legacyCachePersistance, environmentAliases, ClientId))
                 {
                     ClientInfo clientInfo = ClientInfo.CreateFromJson(pair.Key);
                     string userIdentifier = clientInfo.ToAccountIdentifier();
@@ -932,7 +959,7 @@ namespace Microsoft.Identity.Client
             var instanceDiscoveryMetadataEntry =
                 await GetCachedOrDiscoverAuthorityMetaDataAsync(authority, validateAuthority, requestContext).ConfigureAwait(false);
 
-            var authorityHostAliases = GetAuthorityHostAliases(authority, instanceDiscoveryMetadataEntry);
+            var environmentAliases = GetEnvironmentAliases(authority, instanceDiscoveryMetadataEntry);
 
             lock (LockObject)
             {
@@ -940,12 +967,12 @@ namespace Microsoft.Identity.Client
                 requestContext.Logger.Info(msg);
                 requestContext.Logger.InfoPii(msg);
 
-                RemoveMsalAccount(account, authorityHostAliases, requestContext);
-                RemoveAdalUser(account, authorityHostAliases);
+                RemoveMsalAccount(account, environmentAliases, requestContext);
+                RemoveAdalUser(account, environmentAliases);
             }
         }
 
-        internal void RemoveMsalAccount(IAccount account, ISet<string> authorityHostAliases, RequestContext requestContext)
+        internal void RemoveMsalAccount(IAccount account, ISet<string> environmnetAliases, RequestContext requestContext)
         {
             lock (LockObject)
             {
@@ -966,7 +993,7 @@ namespace Microsoft.Identity.Client
                     OnBeforeWrite(args);
                     IList<MsalRefreshTokenCacheItem> allRefreshTokens = GetAllRefreshTokensForClient(requestContext)
                         .Where(item => item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase) &&
-                                       authorityHostAliases.Contains(item.Environment))
+                                       environmnetAliases.Contains(item.Environment))
                         .ToList();
                     foreach (MsalRefreshTokenCacheItem refreshTokenCacheItem in allRefreshTokens)
                     {
@@ -978,7 +1005,7 @@ namespace Microsoft.Identity.Client
                     requestContext.Logger.InfoPii(msg);
                     IList<MsalAccessTokenCacheItem> allAccessTokens = GetAllAccessTokensForClient(requestContext)
                         .Where(item => item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase) &&
-                                       authorityHostAliases.Contains(item.Environment))
+                                       environmnetAliases.Contains(item.Environment))
                         .ToList();
                     foreach (MsalAccessTokenCacheItem accessTokenCacheItem in allAccessTokens)
                     {
@@ -991,7 +1018,7 @@ namespace Microsoft.Identity.Client
 
                     IList<MsalIdTokenCacheItem> allIdTokens = GetAllIdTokensForClient(requestContext)
                         .Where(item => item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase) &&
-                                       authorityHostAliases.Contains(item.Environment))
+                                       environmnetAliases.Contains(item.Environment))
                         .ToList();
                     foreach (MsalIdTokenCacheItem idTokenCacheItem in allIdTokens)
                     {
@@ -1004,7 +1031,7 @@ namespace Microsoft.Identity.Client
 
                     IList<MsalAccountCacheItem> allAccounts = GetAllAccounts(requestContext)
                         .Where(item => item.HomeAccountId.Equals(account.HomeAccountId.Identifier, StringComparison.OrdinalIgnoreCase) &&
-                                       authorityHostAliases.Contains(item.Environment))
+                                       environmnetAliases.Contains(item.Environment))
                         .ToList();
                     foreach (MsalAccountCacheItem accountCacheItem in allAccounts)
                     {
@@ -1024,9 +1051,9 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        internal void RemoveAdalUser(IAccount account, ISet<string> authorityHostAliases)
+        internal void RemoveAdalUser(IAccount account, ISet<string> environmentAliases)
         {
-            CacheFallbackOperations.RemoveAdalUser(legacyCachePersistance, account.Username, authorityHostAliases, account.HomeAccountId.Identifier);
+            CacheFallbackOperations.RemoveAdalUser(legacyCachePersistance, account.Username, environmentAliases, account.HomeAccountId.Identifier);
         }
 
         internal ICollection<string> GetAllAccessTokenCacheItems(RequestContext requestContext)

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -144,7 +144,7 @@ namespace Microsoft.Identity.Client
             }
 
             if (!requestParams.IsClientCredentialRequest && 
-                !ContainsClaimsRequiredToStoreInCahce(idToken, requestParams.RequestContext))
+                !ContainsClaimsRequiredToStoreInCache(idToken, requestParams.RequestContext))
             {
                 return Tuple.Create(msalAccessTokenCacheItem, msalIdTokenCacheItem);
             }
@@ -258,18 +258,18 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        private bool ContainsClaimsRequiredToStoreInCahce(IdToken idToken, RequestContext requestContext)
+        private bool ContainsClaimsRequiredToStoreInCache(IdToken idToken, RequestContext requestContext)
         {
             if (idToken == null || string.IsNullOrEmpty(idToken.TenantId) || string.IsNullOrEmpty(idToken.PreferredUsername))
             {
                 string msg;
                 if (idToken == null)
                 {
-                    msg = "Skipping storing tokens in the cahe - no IdToken in token response";
+                    msg = "Skipping storing tokens in the cache - no IdToken in token response";
                 }
                 else
                 {
-                    msg = "Skipping storing tokens in the cahe - IdToken does not contain required claims";
+                    msg = "Skipping storing tokens in the cache - IdToken does not contain required claims";
                 }
                 requestContext.Logger.Warning(msg);
                 requestContext.Logger.WarningPii(msg);

--- a/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
@@ -66,7 +66,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
             HttpClientFactory.ReturnHttpClientForMocks = true;
             HttpMessageHandlerFactory.ClearMockHandlers();
 
-            AadInstanceDiscovery.Instance.InstanceCache.Clear();
+            AadInstanceDiscovery.Instance.Cache.Clear();
 
             HttpMessageHandlerFactory.AddMockHandler(
                 MockHelpers.CreateInstanceDiscoveryMockHandler(
@@ -75,7 +75,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
         
         void AddHostToInstanceCache(String host)
         {
-            AadInstanceDiscovery.Instance.InstanceCache.TryAdd(host, new InstanceDiscoveryMetadataEntry
+            AadInstanceDiscovery.Instance.Cache.TryAdd(host, new InstanceDiscoveryMetadataEntry
             {
                 PreferredNetwork = host,
                 PreferredCache = host,

--- a/msal/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -64,7 +64,7 @@ namespace Test.MSAL.NET.Unit
             HttpMessageHandlerFactory.ClearMockHandlers();
             Telemetry.GetInstance().RegisterReceiver(_myReceiver.OnEvents);
         
-            AadInstanceDiscovery.Instance.InstanceCache.Clear();
+            AadInstanceDiscovery.Instance.Cache.Clear();
             AddMockResponseForInstanceDisovery();
         }
 

--- a/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -64,7 +64,7 @@ namespace Test.MSAL.NET.Unit
             HttpMessageHandlerFactory.ClearMockHandlers();
             Telemetry.GetInstance().RegisterReceiver(_myReceiver.OnEvents);
 
-            AadInstanceDiscovery.Instance.InstanceCache.Clear();
+            AadInstanceDiscovery.Instance.Cache.Clear();
             AddMockResponseForInstanceDisovery();
         }
 
@@ -963,7 +963,7 @@ namespace Test.MSAL.NET.Unit
             try
             {
                 Task<AuthenticationResult> task =
-                    app.AcquireTokenSilentAsync(TestConstants.ScopeForAnotherResource.ToArray(),
+                    app.AcquireTokenSilentAsync(TestConstants.CacheMissScope,
                         new Account()
                         {
                             Username = TestConstants.DisplayableId,

--- a/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -940,11 +940,8 @@ namespace Test.MSAL.NET.Unit
             {
                 Task<AuthenticationResult> task =
                     app.AcquireTokenSilentAsync(TestConstants.CacheMissScope,
-                        new Account()
-                        {
-                            Username = TestConstants.DisplayableId,
-                            HomeAccountId = TestConstants.UserIdentifier,
-                        }, app.Authority, false);
+                        new Account(TestConstants.UserIdentifier, TestConstants.DisplayableId, null),
+                        app.Authority, false);
                 AuthenticationResult result = task.Result;
                 Assert.Fail("MsalUiRequiredException was expected");
             }

--- a/msal/tests/Test.MSAL.NET.Unit/Test.MSAL.NET.Unit.csproj
+++ b/msal/tests/Test.MSAL.NET.Unit/Test.MSAL.NET.Unit.csproj
@@ -85,4 +85,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+	  <Target Name="ProjectReferenceSolution" BeforeTargets="ResolveAssemblyReferences" DependsOnTargets="ResolveProjectReferences">
+  </Target>
 </Project>

--- a/msal/tests/Test.MSAL.NET.Unit/TestConstants.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/TestConstants.cs
@@ -38,6 +38,7 @@ namespace Test.MSAL.NET.Unit
         public static readonly SortedSet<string> Scope = new SortedSet<string>(new[] { "r1/scope1", "r1/scope2" });
         public static readonly string ScopeStr = "r1/scope1 r1/scope2";
         public static readonly SortedSet<string> ScopeForAnotherResource = new SortedSet<string>(new[] { "r2/scope1", "r2/scope2" });
+        public static readonly SortedSet<string> CacheMissScope = new SortedSet<string>(new[] { "r3/scope1", "r3/scope2" });
         public static readonly string ScopeForAnotherResourceStr = "r2/scope1 r2/scope2";
         public static readonly string ProductionPrefNetworkEnvironment = "login.microsoftonline.com";
         public static readonly string ProductionPrefCacheEnvironment = "login.windows.net";

--- a/msal/tests/Test.MSAL.NET.Unit/UnifiedCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/UnifiedCacheTests.cs
@@ -61,7 +61,7 @@ namespace Test.MSAL.NET.Unit
             HttpMessageHandlerFactory.ClearMockHandlers();
             Telemetry.GetInstance().RegisterReceiver(_myReceiver.OnEvents);
 
-            AadInstanceDiscovery.Instance.InstanceCache.Clear();
+            AadInstanceDiscovery.Instance.Cache.Clear();
             AddMockResponseForInstanceDisovery();
     }
 


### PR DESCRIPTION
support of B2C:
- In case of absence of required claims in b2C idToken skip storing tokens in the cache
- cache look up based on environments aliases and tenant id instead of authority
- refactoring
- addressing some pr comments