### PR TITLE
Tweaking the MSAL 2.0.0-preview library to provide actionable migration help

### DIFF
--- a/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -35,7 +35,7 @@ namespace Microsoft.Identity.Client
     /// <summary>
     /// Contains the results of one token acquisition operation.
     /// </summary>
-    public class AuthenticationResult
+    public partial class AuthenticationResult
     {
         private const string Oauth2AuthorizationHeader = "Bearer ";
         private readonly MsalAccessTokenCacheItem _msalAccessTokenCacheItem;

--- a/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client
     /// <Summary>
     /// Abstract class containing common API methods and properties. Both PublicClientApplication and ConfidentialClientApplication extend this class.
     /// </Summary>
-    public abstract class ClientApplicationBase
+    public abstract partial class ClientApplicationBase
     {
         private TokenCache userTokenCache;
 

--- a/msal/src/Microsoft.Identity.Client/IClientApplicationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/IClientApplicationBase.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Identity.Client
     /// <summary>
     /// Component containing common validation methods
     /// </summary>
-    public interface IClientApplicationBase
+    public partial interface IClientApplicationBase
     {
         /// <summary>
         /// Identifier of the component consuming MSAL and it is intended for libraries/SDKs that consume MSAL. This will allow for 

--- a/msal/src/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
+++ b/msal/src/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
@@ -10,21 +10,21 @@ namespace Microsoft.Identity.Client
     /// In MSAL.NET 1.x, was representing a User. From MSAL 2.x use <see cref="IAccount"/> which represents an account
     /// (a user has several accounts). See https://aka.ms/msal-net-2-released for more details.
     /// </summary>
-    [Obsolete("Use IAccount instead")]
+    [Obsolete("Use IAccount instead (See https://aka.ms/msal-net-2-released)")]
     public interface IUser
     {
         /// <summary>
         /// In MSAL.NET 1.x was the displayable ID of a user. From MSAL 2.x use the <see cref="IAccount.Username"/> of an account.
         /// See https://aka.ms/msal-net-2-released for more details
         /// </summary>
-        [Obsolete("Use IAccount.Username instead", true)]
+        [Obsolete("Use IAccount.Username instead (See https://aka.ms/msal-net-2-released)", true)]
         string DisplayableId { get; }
 
         /// <summary>
         /// In MSAL.NET 1.x was the name of the user (which was not very useful as the concatenation of 
         /// some claims). From MSAL 2.x rather use <see cref="IAccount.Username"/>. See https://aka.ms/msal-net-2-released for more details.
         /// </summary>
-        [Obsolete("Use IAccount.Username instead", true)]
+        [Obsolete("Use IAccount.Username instead (See https://aka.ms/msal-net-2-released)", true)]
         string Name { get; }
 
         /// <summary>
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Client
         /// From MSAL.NET 2.x use <see cref="IAccount.Environment"/> which retrieves the host only (e.g. login.microsoftonline.com).
         /// See https://aka.ms/msal-net-2-released for more details.
         /// </summary>
-        [Obsolete("Use IAccount.Environment instead to get the Identity Provider host", true)]
+        [Obsolete("Use IAccount.Environment instead to get the Identity Provider host (See https://aka.ms/msal-net-2-released)", true)]
         string IdentityProvider { get; }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace Microsoft.Identity.Client
         /// From MSAL.NET 2.x, use <see cref="IAccount.HomeAccountId"/><see cref="AccountId.Identifier"/> to get
         /// the user identifier (globally unique accross tenants). See https://aka.ms/msal-net-2-released for more details.
         /// </summary>
-        [Obsolete("Use IAccount.HomeAccountId.Identifier instead to get the user identifier", true)]
+        [Obsolete("Use IAccount.HomeAccountId.Identifier instead to get the user identifier (See https://aka.ms/msal-net-2-released)", true)]
         string Identifier { get; }
     }
 
@@ -50,7 +50,7 @@ namespace Microsoft.Identity.Client
         /// In MSAL 1.x returned an enumeration of <see cref="IUser"/>. From MSAL 2.x, use <see cref="GetAccountsAsync"/> instead.
         /// See https://aka.ms/msal-net-2-released for more details.
         /// </summary>
-        [Obsolete("Use GetAccountsAsync instead", true)]
+        [Obsolete("Use GetAccountsAsync instead (See https://aka.ms/msal-net-2-released)", true)]
         IEnumerable<IUser> Users { get; }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="identifier">Identifier of the user to retrieve</param>
         /// <returns>the user in the cache with the identifier passed as an argument</returns>
-        [Obsolete("Use GetAccountAsync instead and pass IAccount.HomeAccountId.Identifier", true)]
+        [Obsolete("Use GetAccountAsync instead and pass IAccount.HomeAccountId.Identifier (See https://aka.ms/msal-net-2-released)", true)]
         IUser GetUser(string identifier);
 
         /// <summary>
@@ -67,7 +67,7 @@ namespace Microsoft.Identity.Client
         /// See https://aka.ms/msal-net-2-released for more details.
         /// </summary>
         /// <param name="user">User to remove from the cache</param>
-        [Obsolete("Use RemoveAccountAsync instead", true)]
+        [Obsolete("Use RemoveAccountAsync instead (See https://aka.ms/msal-net-2-released)", true)]
         void Remove(IUser user);
     }
 
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Client
         /// In MSAL 1.x returned an enumeration of <see cref="IUser"/>. From MSAL 2.x, use <see cref="GetAccountsAsync"/> instead.
         /// See https://aka.ms/msal-net-2-released for more details.
         /// </summary>
-        [Obsolete("Use GetAccountsAsync instead", true)]
+        [Obsolete("Use GetAccountsAsync instead (See https://aka.ms/msal-net-2-released)", true)]
         public IEnumerable<IUser> Users { get { throw new NotImplementedException(); } }
 
         /// <summary>
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         /// <param name="identifier">Identifier of the user to retrieve</param>
         /// <returns>the user in the cache with the identifier passed as an argument</returns>
-        [Obsolete("Use GetAccountAsync instead and pass IAccount.HomeAccountId.Identifier", true)]
+        [Obsolete("Use GetAccountAsync instead and pass IAccount.HomeAccountId.Identifier (See https://aka.ms/msal-net-2-released)", true)]
         public IUser GetUser(string identifier) { throw new NotImplementedException(); }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Client
         /// See https://aka.ms/msal-net-2-released for more details.
         /// </summary>
         /// <param name="user">User to remove from the cache</param>
-        [Obsolete("Use RemoveAccountAsync instead", true)]
+        [Obsolete("Use RemoveAccountAsync instead (See https://aka.ms/msal-net-2-released)", true)]
         public void Remove(IUser user) { throw new NotImplementedException(); }
     }
 
@@ -104,7 +104,7 @@ namespace Microsoft.Identity.Client
         /// In MSAL.NET 1.x, returned the user who signed in to get the authentication result. From MSAL 2.x
         /// rather use <see cref="Account"/> instead. See https://aka.ms/msal-net-2-released for more details.
         /// </summary>
-        [Obsolete("Use Account instead", true)]
+        [Obsolete("Use Account instead (See https://aka.ms/msal-net-2-released)", true)]
         public IUser User { get { throw new NotImplementedException(); } }
     }
 
@@ -114,7 +114,7 @@ namespace Microsoft.Identity.Client
         /// In MSAL.NET 1.x, returned the user who signed in to get the authentication result. From MSAL 2.x
         /// rather use <see cref="Account"/> instead. See https://aka.ms/msal-net-2-released for more details.
         /// </summary>
-        [Obsolete("Use Account instead", true)]
+        [Obsolete("Use Account instead (See https://aka.ms/msal-net-2-released)", true)]
         public IUser User { get { throw new NotImplementedException(); } }
     }
 }

--- a/msal/src/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
+++ b/msal/src/Microsoft.Identity.Client/MigrationAid/MigrationAid.cs
@@ -1,0 +1,120 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Client
+{
+    /// <summary>
+    /// In MSAL.NET 1.x, was representing a User. From MSAL 2.x use <see cref="IAccount"/> which represents an account
+    /// (a user has several accounts). See https://aka.ms/msal-net-2-released for more details.
+    /// </summary>
+    [Obsolete("Use IAccount instead")]
+    public interface IUser
+    {
+        /// <summary>
+        /// In MSAL.NET 1.x was the displayable ID of a user. From MSAL 2.x use the <see cref="IAccount.Username"/> of an account.
+        /// See https://aka.ms/msal-net-2-released for more details
+        /// </summary>
+        [Obsolete("Use IAccount.Username instead", true)]
+        string DisplayableId { get; }
+
+        /// <summary>
+        /// In MSAL.NET 1.x was the name of the user (which was not very useful as the concatenation of 
+        /// some claims). From MSAL 2.x rather use <see cref="IAccount.Username"/>. See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        [Obsolete("Use IAccount.Username instead", true)]
+        string Name { get; }
+
+        /// <summary>
+        /// In MSAL.NET 1.x was the URL of the identity provider (e.g. https://login.microsoftonline.com/tenantId)
+        /// From MSAL.NET 2.x use <see cref="IAccount.Environment"/> which retrieves the host only (e.g. login.microsoftonline.com).
+        /// See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        [Obsolete("Use IAccount.Environment instead to get the Identity Provider host", true)]
+        string IdentityProvider { get; }
+
+        /// <summary>
+        /// In MSAL.NET 1.x was an identifier for the user in the guest tenant
+        /// From MSAL.NET 2.x, use <see cref="IAccount.HomeAccountId"/><see cref="AccountId.Identifier"/> to get
+        /// the user identifier (globally unique accross tenants). See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        [Obsolete("Use IAccount.HomeAccountId.Identifier instead to get the user identifier", true)]
+        string Identifier { get; }
+    }
+
+    public partial interface IClientApplicationBase
+    {
+        /// <summary>
+        /// In MSAL 1.x returned an enumeration of <see cref="IUser"/>. From MSAL 2.x, use <see cref="GetAccountsAsync"/> instead.
+        /// See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        [Obsolete("Use GetAccountsAsync instead", true)]
+        IEnumerable<IUser> Users { get; }
+
+        /// <summary>
+        /// In MSAL 1.x, return a user from its identifier. From MSAL 2.x, use <see cref="GetAccountsAsync"/> instead.
+        /// See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        /// <param name="identifier">Identifier of the user to retrieve</param>
+        /// <returns>the user in the cache with the identifier passed as an argument</returns>
+        [Obsolete("Use GetAccountAsync instead and pass IAccount.HomeAccountId.Identifier", true)]
+        IUser GetUser(string identifier);
+
+        /// <summary>
+        /// In MSAL 1.x removed a user from the cache. From MSAL 2.x, use <see cref="RemoveAsync(IAccount)"/> instead.
+        /// See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        /// <param name="user">User to remove from the cache</param>
+        [Obsolete("Use RemoveAccountAsync instead", true)]
+        void Remove(IUser user);
+    }
+
+    public partial class ClientApplicationBase
+    {
+        /// <summary>
+        /// In MSAL 1.x returned an enumeration of <see cref="IUser"/>. From MSAL 2.x, use <see cref="GetAccountsAsync"/> instead.
+        /// See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        [Obsolete("Use GetAccountsAsync instead", true)]
+        public IEnumerable<IUser> Users { get { throw new NotImplementedException(); } }
+
+        /// <summary>
+        /// In MSAL 1.x, return a user from its identifier. From MSAL 2.x, use <see cref="GetAccountsAsync"/> instead.
+        /// See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        /// <param name="identifier">Identifier of the user to retrieve</param>
+        /// <returns>the user in the cache with the identifier passed as an argument</returns>
+        [Obsolete("Use GetAccountAsync instead and pass IAccount.HomeAccountId.Identifier", true)]
+        public IUser GetUser(string identifier) { throw new NotImplementedException(); }
+
+        /// <summary>
+        /// In MSAL 1.x removed a user from the cache. From MSAL 2.x, use <see cref="RemoveAsync(IAccount)"/> instead.
+        /// See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        /// <param name="user">User to remove from the cache</param>
+        [Obsolete("Use RemoveAccountAsync instead", true)]
+        public void Remove(IUser user) { throw new NotImplementedException(); }
+    }
+
+    public partial class AuthenticationResult
+    {
+        /// <summary>
+        /// In MSAL.NET 1.x, returned the user who signed in to get the authentication result. From MSAL 2.x
+        /// rather use <see cref="Account"/> instead. See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        [Obsolete("Use Account instead", true)]
+        public IUser User { get { throw new NotImplementedException(); } }
+    }
+
+    public partial class TokenCacheNotificationArgs
+    {
+        /// <summary>
+        /// In MSAL.NET 1.x, returned the user who signed in to get the authentication result. From MSAL 2.x
+        /// rather use <see cref="Account"/> instead. See https://aka.ms/msal-net-2-released for more details.
+        /// </summary>
+        [Obsolete("Use Account instead", true)]
+        public IUser User { get { throw new NotImplementedException(); } }
+    }
+}

--- a/msal/src/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCacheNotificationArgs.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Identity.Client
     /// <summary>
     /// Contains parameters used by the MSAL call accessing the cache.
     /// </summary>
-    public sealed class TokenCacheNotificationArgs
+    public sealed partial class TokenCacheNotificationArgs
     {
         /// <summary>
         /// Gets the TokenCache


### PR DESCRIPTION
This PR proposes to tweak the MSAL 2.0.0-preview library to **provide actionable migration help** for developers who want to migrate from MSAL 1.x to MSAL 2.0.0-preview. 

## Why? the migration experience if we don't do anything
Updating the MSAL NuGet package to MSAL.NET 2.0.0-preview, developers will get only a few build errors that IUser cannot be found. If they have read the blog post, they'll probably realize that they need to use IAccount instead, but otherwise, they might not understand what happens ; they might think that I’m missing an assembly. Note the tooltips are not actionable (are you missing an assembly). developers can see that other members have red squiggles, but there are no errors for that. this is confusing
![image](https://user-images.githubusercontent.com/13203188/44091785-e699b9fe-9fce-11e8-85c6-aa82342a5ec5.png)

Then, after some research, they might find that they need to use IAccount and rebuild, and this time have 12 errors. this becomes a trial/error process with no idea of the time it will take to upgrade.

## The experience proposed by this PR
This PR proposes to help the user migrate by providing **more actionable error messages, and links to the blog post**, the developer experience becoming:
-	All the location to change would be presented immediately. This might be a bit overwhelming, but at least this enables the developer to predict the amount of work to do.
-	The obsolete types / members are explicated with actionable error messages: advice on what to use instead
-	Finally the tooltips on the error messages in Visual Studio are even more actionable, explaining what happens (that’s in the XML comments), and leading the developer to the blog post, which therefore cannot be missed.

![image](https://user-images.githubusercontent.com/13203188/44091905-42c48ab0-9fcf-11e8-8cae-dad9d47b855a.png)

![image](https://user-images.githubusercontent.com/13203188/44091931-5327ad24-9fcf-11e8-8d6b-9f67f37f4242.png)

## How this is done?
This is done by:
- providing the missing types, or members, with an [Obsolete] attribute and some meaningful and actionable message.
- providing an aka.ms link to the blog post.

The only change to the product code is to set 4 interfaces and classes as partial, and provide partial implementations with obsolete attributes in the MigrationAid.cs file (which of course could be split into several files, but why bother).