### PR TITLE
Reverting the renaming of the LogLevel enum.

### DIFF
--- a/msal/src/Microsoft.Identity.Client/Internal/MsalLogger.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/MsalLogger.cs
@@ -49,42 +49,42 @@ namespace Microsoft.Identity.Client.Internal
 
         public override void InfoPii(string message)
         {
-            Log(MsalLogLevel.Info, message, true);
+            Log(LogLevel.Info, message, true);
         }
 
         public override void Verbose(string message)
         {
-            Log(MsalLogLevel.Verbose, message, false);
+            Log(LogLevel.Verbose, message, false);
         }
 
         public override void VerbosePii(string message)
         {
-            Log(MsalLogLevel.Verbose, message, true);
+            Log(LogLevel.Verbose, message, true);
         }
 
         public override void ErrorPii(string message)
         {
-            Log(MsalLogLevel.Error, message, true);
+            Log(LogLevel.Error, message, true);
         }
 
         public override void Warning(string message)
         {
-            Log(MsalLogLevel.Warning, message, false);
+            Log(LogLevel.Warning, message, false);
         }
 
         public override void WarningPii(string message)
         {
-            Log(MsalLogLevel.Warning, message, true);
+            Log(LogLevel.Warning, message, true);
         }
 
         public override void Info(string message)
         {
-            Log(MsalLogLevel.Info, message, false);
+            Log(LogLevel.Info, message, false);
         }
 
         public override void Error(Exception ex)
         {
-            Log(MsalLogLevel.Error,
+            Log(LogLevel.Error,
                 MsalExceptionFactory.GetPiiScrubbedExceptionDetails(ex),
                 false);
         }
@@ -96,11 +96,11 @@ namespace Microsoft.Identity.Client.Internal
 
         public override void Error(string message)
         {
-            Log(MsalLogLevel.Error, message, false);
+            Log(LogLevel.Error, message, false);
         }
 
 
-        private static void ExecuteCallback(MsalLogLevel level, string message, bool containsPii)
+        private static void ExecuteCallback(LogLevel level, string message, bool containsPii)
         {
             lock (Logger.LockObj)
             {
@@ -108,7 +108,7 @@ namespace Microsoft.Identity.Client.Internal
             }
         }
 
-        private void Log(MsalLogLevel msalLogLevel, string logMessage, bool containsPii)
+        private void Log(LogLevel msalLogLevel, string logMessage, bool containsPii)
         {
             if ((msalLogLevel > Logger.Level) || (!Logger.PiiLoggingEnabled && containsPii))
             {

--- a/msal/src/Microsoft.Identity.Client/Internal/PlatformPlugin.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/PlatformPlugin.cs
@@ -54,20 +54,20 @@ namespace Microsoft.Identity.Client.Internal
             PlatformInformation = new PlatformInformation();
         }
 
-        public static void LogMessage(MsalLogLevel logLevel, string formattedMessage)
+        public static void LogMessage(LogLevel logLevel, string formattedMessage)
         {
             switch (logLevel)
             {
-                case MsalLogLevel.Error:
+                case LogLevel.Error:
                     PlatformLogger.Error(formattedMessage);
                     break;
-                case MsalLogLevel.Warning:
+                case LogLevel.Warning:
                     PlatformLogger.Warning(formattedMessage);
                     break;
-                case MsalLogLevel.Info:
+                case LogLevel.Info:
                     PlatformLogger.Information(formattedMessage);
                     break;
-                case MsalLogLevel.Verbose:
+                case LogLevel.Verbose:
                     PlatformLogger.Verbose(formattedMessage);
                     break;
             }

--- a/msal/src/Microsoft.Identity.Client/Logger.cs
+++ b/msal/src/Microsoft.Identity.Client/Logger.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Identity.Client
     /// <param name="message">Pre-formatted log message</param>
     /// <param name="containsPii">Indicates if the log message contains PII. If Logger.PiiLoggingEnabled is set to 
     /// false then this value is always false.</param>
-    public delegate void LogCallback(MsalLogLevel level, string message, bool containsPii);
+    public delegate void LogCallback(LogLevel level, string message, bool containsPii);
 
     /// <summary>
     /// MSAL Log Levels
     /// </summary>
-    public enum MsalLogLevel
+    public enum LogLevel
     {
         /// <summary>
         /// Error Log level
@@ -101,7 +101,7 @@ namespace Microsoft.Identity.Client
         /// <summary>
         /// Configurable log level. Default value is Info.
         /// </summary>
-        public static MsalLogLevel Level { get; set; } = MsalLogLevel.Info;
+        public static LogLevel Level { get; set; } = LogLevel.Info;
 
         /// <summary>
         /// Flag to enable/disable logging of PII data. PII logs are never written to default outputs like Console, Logcat or NSLog.

--- a/msal/tests/AutomationApp/AppLogger.cs
+++ b/msal/tests/AutomationApp/AppLogger.cs
@@ -34,7 +34,7 @@ namespace AutomationApp
     {
         private readonly StringBuilder _logCollector = new StringBuilder();
 
-        public void Log(MsalLogLevel level, string message, bool containsPii)
+        public void Log(LogLevel level, string message, bool containsPii)
         {
             _logCollector.Append(message);
         }

--- a/msal/tests/Test.MSAL.NET.Unit/LoggerTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/LoggerTests.cs
@@ -62,21 +62,21 @@ namespace Test.MSAL.NET.Unit
         {
             MsalLogger logger = new MsalLogger(Guid.Empty, null);
             var counter = 0;
-            Logger.Level = MsalLogLevel.Error;
+            Logger.Level = LogLevel.Error;
 
-            _callback.When(x => x(MsalLogLevel.Error, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Error, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Error("test message");
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Warning, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Warning, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Warning("test message");
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Info, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Info, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Info("test message");
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Verbose, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Verbose, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Verbose("test message");
             Assert.AreEqual(1, counter);
         }
@@ -87,21 +87,21 @@ namespace Test.MSAL.NET.Unit
         {
             MsalLogger logger = new MsalLogger(Guid.Empty, null);
             var counter = 0;
-            Logger.Level = MsalLogLevel.Warning;
+            Logger.Level = LogLevel.Warning;
 
-            _callback.When(x => x(MsalLogLevel.Error, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Error, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Error(new Exception("test message"));
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Warning, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Warning, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Warning("test message");
             Assert.AreEqual(2, counter);
 
-            _callback.When(x => x(MsalLogLevel.Info, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Info, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Info("test message");
             Assert.AreEqual(2, counter);
 
-            _callback.When(x => x(MsalLogLevel.Verbose, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Verbose, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Verbose("test message");
             Assert.AreEqual(2, counter);
         }
@@ -113,21 +113,21 @@ namespace Test.MSAL.NET.Unit
             MsalLogger logger = new MsalLogger(Guid.Empty, null);
 
             var counter = 0;
-            Logger.Level = MsalLogLevel.Info;
+            Logger.Level = LogLevel.Info;
 
-            _callback.When(x => x(MsalLogLevel.Error, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Error, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Error(new Exception("test message"));
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Warning, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Warning, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Warning("test message");
             Assert.AreEqual(2, counter);
 
-            _callback.When(x => x(MsalLogLevel.Info, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Info, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Info("test message");
             Assert.AreEqual(3, counter);
 
-            _callback.When(x => x(MsalLogLevel.Verbose, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Verbose, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Verbose("test message");
             Assert.AreEqual(3, counter);
         }
@@ -139,21 +139,21 @@ namespace Test.MSAL.NET.Unit
             MsalLogger logger = new MsalLogger(Guid.Empty, null);
 
             var counter = 0;
-            Logger.Level = MsalLogLevel.Verbose;
+            Logger.Level = LogLevel.Verbose;
 
-            _callback.When(x => x(MsalLogLevel.Error, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Error, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Error(new Exception("test message"));
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Warning, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Warning, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Warning("test message");
             Assert.AreEqual(2, counter);
 
-            _callback.When(x => x(MsalLogLevel.Info, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Info, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Info("test message");
             Assert.AreEqual(3, counter);
 
-            _callback.When(x => x(MsalLogLevel.Verbose, Arg.Any<string>(), false)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Verbose, Arg.Any<string>(), false)).Do(x => counter++);
             logger.Verbose("test message");
             Assert.AreEqual(4, counter);
         }
@@ -165,22 +165,22 @@ namespace Test.MSAL.NET.Unit
             MsalLogger logger = new MsalLogger(Guid.Empty, null);
 
             var counter = 0;
-            Logger.Level = MsalLogLevel.Error;
+            Logger.Level = LogLevel.Error;
             Logger.PiiLoggingEnabled = true;
 
-            _callback.When(x => x(MsalLogLevel.Error, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Error, Arg.Any<string>(), true)).Do(x => counter++);
             logger.ErrorPii(new Exception("test message"));
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Warning, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Warning, Arg.Any<string>(), true)).Do(x => counter++);
             logger.WarningPii("test message");
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Info, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Info, Arg.Any<string>(), true)).Do(x => counter++);
             logger.InfoPii("test message");
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Verbose, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Verbose, Arg.Any<string>(), true)).Do(x => counter++);
             logger.VerbosePii("test message");
             Assert.AreEqual(1, counter);
         }
@@ -192,22 +192,22 @@ namespace Test.MSAL.NET.Unit
             MsalLogger logger = new MsalLogger(Guid.Empty, null);
 
             var counter = 0;
-            Logger.Level = MsalLogLevel.Warning;
+            Logger.Level = LogLevel.Warning;
             Logger.PiiLoggingEnabled = true;
 
-            _callback.When(x => x(MsalLogLevel.Error, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Error, Arg.Any<string>(), true)).Do(x => counter++);
             logger.ErrorPii(new Exception("test message"));
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Warning, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Warning, Arg.Any<string>(), true)).Do(x => counter++);
             logger.WarningPii("test message");
             Assert.AreEqual(2, counter);
 
-            _callback.When(x => x(MsalLogLevel.Info, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Info, Arg.Any<string>(), true)).Do(x => counter++);
             logger.InfoPii("test message");
             Assert.AreEqual(2, counter);
 
-            _callback.When(x => x(MsalLogLevel.Verbose, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Verbose, Arg.Any<string>(), true)).Do(x => counter++);
             logger.VerbosePii("test message");
             Assert.AreEqual(2, counter);
         }
@@ -219,22 +219,22 @@ namespace Test.MSAL.NET.Unit
             MsalLogger logger = new MsalLogger(Guid.Empty, null);
 
             var counter = 0;
-            Logger.Level = MsalLogLevel.Info;
+            Logger.Level = LogLevel.Info;
             Logger.PiiLoggingEnabled = true;
 
-            _callback.When(x => x(MsalLogLevel.Error, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Error, Arg.Any<string>(), true)).Do(x => counter++);
             logger.ErrorPii(new Exception("test message"));
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Warning, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Warning, Arg.Any<string>(), true)).Do(x => counter++);
             logger.WarningPii("test message");
             Assert.AreEqual(2, counter);
 
-            _callback.When(x => x(MsalLogLevel.Info, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Info, Arg.Any<string>(), true)).Do(x => counter++);
             logger.InfoPii("test message");
             Assert.AreEqual(3, counter);
 
-            _callback.When(x => x(MsalLogLevel.Verbose, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Verbose, Arg.Any<string>(), true)).Do(x => counter++);
             logger.VerbosePii("test message");
             Assert.AreEqual(3, counter);
         }
@@ -246,22 +246,22 @@ namespace Test.MSAL.NET.Unit
             MsalLogger logger = new MsalLogger(Guid.Empty, null);
 
             var counter = 0;
-            Logger.Level = MsalLogLevel.Verbose;
+            Logger.Level = LogLevel.Verbose;
             Logger.PiiLoggingEnabled = true;
 
-            _callback.When(x => x(MsalLogLevel.Error, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Error, Arg.Any<string>(), true)).Do(x => counter++);
             logger.ErrorPii(new Exception("test message"));
             Assert.AreEqual(1, counter);
 
-            _callback.When(x => x(MsalLogLevel.Warning, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Warning, Arg.Any<string>(), true)).Do(x => counter++);
             logger.WarningPii("test message");
             Assert.AreEqual(2, counter);
 
-            _callback.When(x => x(MsalLogLevel.Info, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Info, Arg.Any<string>(), true)).Do(x => counter++);
             logger.InfoPii("test message");
             Assert.AreEqual(3, counter);
 
-            _callback.When(x => x(MsalLogLevel.Verbose, Arg.Any<string>(), true)).Do(x => counter++);
+            _callback.When(x => x(LogLevel.Verbose, Arg.Any<string>(), true)).Do(x => counter++);
             logger.VerbosePii("test message");
             Assert.AreEqual(4, counter);
         }

--- a/msal/tests/dev apps/DesktopTestApp/MainForm.cs
+++ b/msal/tests/dev apps/DesktopTestApp/MainForm.cs
@@ -56,7 +56,7 @@ namespace DesktopTestApp
             Logger.LogCallback = LogDelegate;
         }
 
-        public void LogDelegate(MsalLogLevel level, string message, bool containsPii)
+        public void LogDelegate(LogLevel level, string message, bool containsPii)
         {
             Action action = null;
 
@@ -346,7 +346,7 @@ namespace DesktopTestApp
             _publicClientHandler.ExtraQueryParams = extraQueryParams.Text;
             Environment.SetEnvironmentVariable("MsalExtraQueryParameter", environmentQP.Text);
 
-            Logger.Level = (MsalLogLevel)Enum.Parse(typeof(MsalLogLevel), (string)logLevel.SelectedItem);
+            Logger.Level = (LogLevel)Enum.Parse(typeof(LogLevel), (string)logLevel.SelectedItem);
             Logger.PiiLoggingEnabled = PiiLoggingEnabled.Checked;
         }
 

--- a/msal/tests/dev apps/WebTestApp/WebApi/Controllers/UserProfileController.cs
+++ b/msal/tests/dev apps/WebTestApp/WebApi/Controllers/UserProfileController.cs
@@ -56,7 +56,7 @@ namespace WebApi.Controllers
 
         static UserProfileController()
         {
-            Logger.LogCallback = delegate(MsalLogLevel level, string message, bool containsPii)
+            Logger.LogCallback = delegate(LogLevel level, string message, bool containsPii)
             {
                 lock (LogStringBuilder)
                 {
@@ -64,7 +64,7 @@ namespace WebApi.Controllers
                                                 message);
                 }
             };
-            Logger.Level = MsalLogLevel.Verbose;
+            Logger.Level = LogLevel.Verbose;
             Logger.PiiLoggingEnabled = true;
         }
 

--- a/msal/tests/dev apps/WebTestApp/WebApp/Controllers/HomeController.cs
+++ b/msal/tests/dev apps/WebTestApp/WebApp/Controllers/HomeController.cs
@@ -56,7 +56,7 @@ namespace WebApp.Controllers
 
         static HomeController()
         {
-            Logger.LogCallback = delegate(MsalLogLevel level, string message, bool containsPii)
+            Logger.LogCallback = delegate(LogLevel level, string message, bool containsPii)
             {
                 lock (LogStringBuilder)
                 {
@@ -64,7 +64,7 @@ namespace WebApp.Controllers
                                                 message);
                 }
             };
-            Logger.Level = MsalLogLevel.Verbose;
+            Logger.Level = LogLevel.Verbose;
             Logger.PiiLoggingEnabled = true;
         }
 

--- a/msal/tests/dev apps/WebTestApp/WebApp/Startup.cs
+++ b/msal/tests/dev apps/WebTestApp/WebApp/Startup.cs
@@ -98,7 +98,7 @@ namespace WebApp
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             // Add the console logger.
-            loggerFactory.AddConsole(LogLevel.Debug);
+            loggerFactory.AddConsole(Microsoft.Extensions.Logging.LogLevel.Debug);
 
             // Configure error handling middleware.
             app.UseExceptionHandler("/Home/Error");

--- a/msal/tests/dev apps/XForms/XForms/App.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/App.xaml.cs
@@ -66,11 +66,11 @@ namespace XForms
 
             InitPublicClient();
 
-            Logger.LogCallback = delegate(MsalLogLevel level, string message, bool containsPii)
+            Logger.LogCallback = delegate(LogLevel level, string message, bool containsPii)
             {
                 Device.BeginInvokeOnMainThread(() => { LogPage.AddToLog("[" + level + "]" + " - " + message, containsPii); });
             };
-            Logger.Level = MsalLogLevel.Verbose;
+            Logger.Level = LogLevel.Verbose;
             Logger.PiiLoggingEnabled = true;
         }
 


### PR DESCRIPTION
by renaming MsalLogLevel back to LogLevel.

We keep the enum as a non-nested enum, though.