### PR TITLE
ading setKeyChainSecGroup api to adal cache accessor

### DIFF
--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -160,10 +160,21 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// For more details, please see https://aka.ms/adal-net-sharing-cache-on-ios
         /// </summary>
         /// <remarks>This API may change in future release.</remarks>
+        
+        private string keychainSecurityGroup;
+
         public string KeychainSecurityGroup
         {
-            get { return this.KeychainSecurityGroup; }
-            set => TokenCache.tokenCacheAccessor.SetKeychainSecurityGroup(value);
+            get 
+            { 
+                return keychainSecurityGroup; 
+            }
+            set 
+            { 
+                keychainSecurityGroup = value;
+                StorageDelegates.legacyCachePersistance.SetKeychainSecurityGroup(value);
+                TokenCache.tokenCacheAccessor.SetKeychainSecurityGroup(value); 
+            }
         }
 #endif
 

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/StorageDelegates.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/StorageDelegates.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using Microsoft.Identity.Core.Cache;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -48,15 +49,15 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
 #endif
     internal static class StorageDelegates
     {
+        internal static readonly ILegacyCachePersistance legacyCachePersistance = new LegacyCachePersistance();
+
         public static void BeforeAccess(TokenCacheNotificationArgs args)
         {
 #if ANDROID || iOS || WINDOWS_APP
             if (args != null && args.TokenCache != null)
             {
-                ILegacyCachePersistance legacyCachePersistance = new LegacyCachePersistance();
                 args.TokenCache.Deserialize(legacyCachePersistance.LoadCache());
             }
-
 #endif
         }
 
@@ -65,7 +66,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
 #if ANDROID || iOS || WINDOWS_APP
             if (args != null && args.TokenCache != null && args.TokenCache.HasStateChanged)
             {
-                ILegacyCachePersistance legacyCachePersistance = new LegacyCachePersistance();
                 legacyCachePersistance.WriteCache(args.TokenCache.Serialize());
                 args.TokenCache.HasStateChanged = false;
             }

--- a/core/src/Cache/ILegacyCachePersistance.cs
+++ b/core/src/Cache/ILegacyCachePersistance.cs
@@ -38,5 +38,9 @@ namespace Microsoft.Identity.Core.Cache
         byte[] LoadCache();
 
         void WriteCache(byte[] serializedCache);
+
+#if iOS
+        void SetKeychainSecurityGroup(string keychainSecurityGroup);
+#endif
     }
 }

--- a/core/src/Cache/ITokenCacheAccessor.cs
+++ b/core/src/Cache/ITokenCacheAccessor.cs
@@ -63,15 +63,6 @@ namespace Microsoft.Identity.Core.Cache
 
         ICollection<string> GetAllAccountsAsString();
 
-        /*
-        ICollection<string> GetAllAccessTokenKeys();
-
-        ICollection<string> GetAllRefreshTokenKeys();
-
-        ICollection<string> GetAllIdTokenKeys();
-
-        ICollection<string> GetAllAccountKeys();
-        */
 #if iOS
         void SetKeychainSecurityGroup(string keychainSecurityGroup);
 #endif

--- a/core/src/Platforms/iOS/LegacyCachePersistance.cs
+++ b/core/src/Platforms/iOS/LegacyCachePersistance.cs
@@ -36,6 +36,25 @@ namespace Microsoft.Identity.Core.Cache
         const string NAME = "ADAL.PCL.iOS";
         private const string LocalSettingsContainerName = "ActiveDirectoryAuthenticationLibrary";
 
+        private string keychainGroup;
+
+        private string GetBundleId()
+        {
+            return NSBundle.MainBundle.BundleIdentifier;
+        }
+
+        public void SetKeychainSecurityGroup(string keychainSecurityGroup)
+        {
+            if (keychainSecurityGroup == null)
+            {
+                keychainGroup = GetBundleId();
+            }
+            else
+            {
+                keychainGroup = keychainSecurityGroup;
+            }
+        }
+
         byte[] ILegacyCachePersistance.LoadCache()
         {
             try
@@ -51,6 +70,11 @@ namespace Microsoft.Identity.Core.Cache
                     Comment = NAME + " Cache",
                     Description = "Storage for cache"
                 };
+
+                if (keychainGroup != null)
+                {
+                    rec.AccessGroup = keychainGroup;
+                }
 
                 var match = SecKeyChain.QueryAsRecord(rec, out res);
                 if (res == SecStatusCode.Success && match != null && match.ValueData != null)
@@ -84,6 +108,11 @@ namespace Microsoft.Identity.Core.Cache
                     Comment = NAME + " Cache",
                     Description = "Storage for cache"
                 };
+
+                if (keychainGroup != null)
+                {
+                    s.AccessGroup = keychainGroup;
+                }
 
                 var err = SecKeyChain.Remove(s);
                 if (err != SecStatusCode.Success)

--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -78,10 +78,21 @@ namespace Microsoft.Identity.Client
         /// For more details, please see https://aka.ms/msal-net-sharing-cache-on-ios
         /// </summary>
         /// <remarks>This API may change in future release.</remarks>
+        
+        private string keychainSecurityGroup;
+
         public string KeychainSecurityGroup
         {
-            get { return this.KeychainSecurityGroup; }
-            set => UserTokenCache.tokenCacheAccessor.SetKeychainSecurityGroup(value);
+            get 
+            { 
+                return keychainSecurityGroup; 
+            }
+            set 
+            { 
+                keychainSecurityGroup = value;
+                UserTokenCache.tokenCacheAccessor.SetKeychainSecurityGroup(value);
+                UserTokenCache.legacyCachePersistance.SetKeychainSecurityGroup(value);
+            }
         }
 #endif
 


### PR DESCRIPTION
Setting keychain security group on adal cache accessor + fixing KeychainSecurityGroup getters and setters on AuthenticationContext and PublicClientApplication.

