### PR TITLE
Jmprieur/fix msal deserialize regression

### DIFF
--- a/msal/src/Microsoft.Identity.Client/Features/TokenCache/TokenCacheExtensions.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/TokenCache/TokenCacheExtensions.cs
@@ -91,11 +91,15 @@ namespace Microsoft.Identity.Client
         /// </remarks>
         public static void Deserialize(this TokenCache tokenCache, byte[] unifiedState)
         {
-            lock (tokenCache.LockObject)
+            // Only deserialize if there is something to deserialize (like in MSAL 1.x)
+            if (unifiedState != null)
             {
-                RequestContext requestContext = new RequestContext(new MsalLogger(Guid.Empty, null));
+                lock (tokenCache.LockObject)
+                {
+                    RequestContext requestContext = new RequestContext(new MsalLogger(Guid.Empty, null));
 
-                TokenCacheSerializeHelper.DeserializeUnifiedCache(tokenCache.tokenCacheAccessor, unifiedState, requestContext);
+                    TokenCacheSerializeHelper.DeserializeUnifiedCache(tokenCache.tokenCacheAccessor, unifiedState, requestContext);
+                }
             }
         }
 

--- a/msal/src/Microsoft.Identity.Client/Features/TokenCache/TokenCacheExtensions.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/TokenCache/TokenCacheExtensions.cs
@@ -87,7 +87,8 @@ namespace Microsoft.Identity.Client
         /// <param name="tokenCache">Token cache to deserialize (to fill-in from the state)</param>
         /// <param name="unifiedState">Array of bytes containing serialized Msal cache data</param>
         /// <remarks>
-        /// <paramref name="unifiedState"/>Is a Json blob containing access tokens, refresh tokens, id tokens and accounts information
+        /// <paramref name="unifiedState"/>Is a Json blob containing access tokens, refresh tokens, id tokens and accounts information.
+        /// If it's <c>null</c>, then this method won't do anything (this is the same behavior as MSAL 1.x)
         /// </remarks>
         public static void Deserialize(this TokenCache tokenCache, byte[] unifiedState)
         {

--- a/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
@@ -780,6 +780,9 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 ClientId = TestConstants.ClientId
             };
 
+            // Backward compatibility with MSAL 1.x, this should not throw
+            cache.Deserialize(null);
+
             MsalTokenResponse response = new MsalTokenResponse();
             response.IdToken = MockHelpers.CreateIdToken(TestConstants.UniqueId, TestConstants.DisplayableId);
             response.ClientInfo = MockHelpers.CreateClientInfo();


### PR DESCRIPTION
proposing a fix for MSAL.NET GitHub issue: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/603,
this is affecting a number of Web App samples (which arguably were not testing that the bytes returned from a session cache were null)
