### PR TITLE
In .NET FW (4.6.2) or .NET Core (2, 2.1), the PlatformInformationBase…

### DIFF
--- a/msal/src/Microsoft.Identity.Client/Internal/ModuleInitializer.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/ModuleInitializer.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client.Internal
                     CoreExceptionFactory.Instance = new MsalExceptionFactory();
                     CoreTelemetryService.InitializeCoreTelemetryService(Telemetry.GetInstance() as ITelemetry);
                     CoreLoggerBase.Default = new MsalLogger(Guid.Empty, null);
-                    isInitialized = true;
+                    isInitialized = PlatformInformation.Initialized;
                 }
             }
         }

--- a/msal/src/Microsoft.Identity.Client/Internal/PlatformInformationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/PlatformInformationBase.cs
@@ -34,10 +34,11 @@ namespace Microsoft.Identity.Client.Internal
 {
     internal abstract class PlatformInformationBase : CorePlatformInformationBase
     {
-           
+        public static bool Initialized {get;} = false;
         static PlatformInformationBase()
         {
             Instance = new PlatformInformation();
+            Initialized = true;
         }
 
         public override string GetAssemblyFileVersionAttribute()


### PR DESCRIPTION
In .NET FW (4.6.2) or .NET Core (2, 2.1), the `PlatformInformationBase`  static constructor is not called in a program like the following:

````CSharp
       static void Main(string[] args)
        {
            TokenCache tokenCache = new TokenCache();
            tokenCache.Deserialize(null);
       }
````
hence an ArgumentNullException when any code wants to access `CorePlatformInformationBase.Instance`.

This branch is an attempt to initialize it (and this solves the issue. Not sure this is the right fix)