### PR TITLE
B2C cache fix

### DIFF
--- a/core/src/Cache/MsalAccountCacheItem.cs
+++ b/core/src/Cache/MsalAccountCacheItem.cs
@@ -43,6 +43,13 @@ namespace Microsoft.Identity.Core.Cache
             Init(environment, idToken?.ObjectId, response.ClientInfo, idToken.Name, idToken.PreferredUsername, idToken.TenantId);
         }
 
+        internal MsalAccountCacheItem(string environment, MsalTokenResponse response, string preferredUsername, string tenantID) : this()
+        {
+            IdToken idToken = IdToken.Parse(response.IdToken);
+
+            Init(environment, idToken?.ObjectId, response.ClientInfo, idToken.Name, preferredUsername, tenantID);
+        }
+
         internal MsalAccountCacheItem(string environment, string localAccountId, string rawClientInfo,
             string name, string preferredUsername, string tenantId) : this()
         {

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Identity.Client
     /// </summary>
     public sealed class TokenCache
     {
-        private const string notReturnedFromServer = "Not returned from server";
+        private const string preferred_usernameNotInIdtoken = "preferred_username not in idtoken";
 
         static TokenCache()
         {
@@ -128,7 +128,9 @@ namespace Microsoft.Identity.Client
 
             IdToken idToken = IdToken.Parse(response.IdToken);
 
-            var preferredUsername = !String.IsNullOrWhiteSpace(idToken?.PreferredUsername)? idToken.PreferredUsername : notReturnedFromServer;
+            //The preferred_username value cannot be null or empty in order to comply with the ADAL/MSAL Unified cache schema. 
+            //It will be set to "preferred_username not in idtoken" 
+            var preferredUsername = !String.IsNullOrWhiteSpace(idToken?.PreferredUsername)? idToken.PreferredUsername : preferred_usernameNotInIdtoken;
 
             var instanceDiscoveryMetadataEntry = GetCachedAuthorityMetaData(requestParams.TenantUpdatedCanonicalAuthority);
 

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -220,16 +220,24 @@ namespace Microsoft.Identity.Client
             }
         }
 
-        private void UseFallBackTenantIDForB2C(AuthenticationRequestParameters requestParams, IdToken idToken)
+        /// <summary>
+        /// This method ensures the tenant id is set on the id token
+        /// The B2C scenario does not return the tenant id within the id token at the moment.
+        /// As a fall back, the tenant id on the id Token is set to the tenant id that is in the B2C authority originally passed in by the user.
+        /// </summary>
+        /// <param name="requestParams">Request parameters set by the user</param>
+        /// <param name="idToken">iD token returned from STS</param>
+        private void EnsureTenantIDIsSpecifiedForB2CAuthority(AuthenticationRequestParameters requestParams, IdToken idToken)
         {
-            //The B2C scenario does not return the tenantID within the ID Token at the moment.
-            //As a fall back, the tenantID is set to the tenantID that is in the B2C authority originally passed in by the user.
-
-            if (requestParams.Authority.AuthorityType == Core.Instance.AuthorityType.B2C)
+            if (!string.IsNullOrEmpty(idToken.TenantId) || requestParams.Authority.AuthorityType != Core.Instance.AuthorityType.B2C)
+            {
+                return;
+            }
+            else
             {
                 var tenantID = requestParams.Authority.GetTenantId();
 
-                if (string.IsNullOrEmpty(idToken.TenantId) && !string.IsNullOrEmpty(tenantID))
+                if (!string.IsNullOrEmpty(tenantID))
                     idToken.TenantId = tenantID;
             }
         }

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -180,7 +180,7 @@ namespace Microsoft.Identity.Client
                     {
                         tokenCacheAccessor.SaveIdToken(msalIdTokenCacheItem, requestParams.RequestContext);
 
-                        var msalAccountCacheItem = new MsalAccountCacheItem(preferredEnvironmentHost, response);
+                        var msalAccountCacheItem = new MsalAccountCacheItem(preferredEnvironmentHost, response, preferredUsername, tenantId);
 
                         tokenCacheAccessor.SaveAccount(msalAccountCacheItem, requestParams.RequestContext);
                     }

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Identity.Client
             MsalRefreshTokenCacheItem msalRefreshTokenCacheItem = null;
 
             MsalIdTokenCacheItem msalIdTokenCacheItem = null;
-            if (!String.IsNullOrWhiteSpace(tenantId))
+            if (idToken != null)
             {
                 msalIdTokenCacheItem = new MsalIdTokenCacheItem
                     (preferredEnvironmentHost, requestParams.ClientId, response, tenantId);
@@ -176,7 +176,7 @@ namespace Microsoft.Identity.Client
 
                     tokenCacheAccessor.SaveAccessToken(msalAccessTokenCacheItem, requestParams.RequestContext);
 
-                    if (!String.IsNullOrWhiteSpace(tenantId))
+                    if (idToken != null)
                     {
                         tokenCacheAccessor.SaveIdToken(msalIdTokenCacheItem, requestParams.RequestContext);
 

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -233,13 +233,11 @@ namespace Microsoft.Identity.Client
             {
                 return;
             }
-            else
-            {
-                var tenantID = requestParams.Authority.GetTenantId();
 
-                if (!string.IsNullOrEmpty(tenantID))
-                    idToken.TenantId = tenantID;
-            }
+            var tenantID = requestParams.Authority.GetTenantId();
+
+            if (!string.IsNullOrEmpty(tenantID))
+                idToken.TenantId = tenantID;
         }
 
         private void DeleteAccessTokensWithIntersectingScopes(AuthenticationRequestParameters requestParams,

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Identity.Client
             IdToken idToken = IdToken.Parse(response.IdToken);
 
             //using fallback tenantID in the IDToken if it is null in B2C scenarios
-            UseFallBackTenantIDForB2C(requestParams, idToken);
+            EnsureTenantIDIsSpecifiedForB2CAuthority(requestParams, idToken);
 
             var msalAccessTokenCacheItem =
                 new MsalAccessTokenCacheItem(preferredEnvironmentHost, requestParams.ClientId, response, tenantId)

--- a/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
@@ -882,6 +882,40 @@ namespace Test.MSAL.NET.Unit.CacheTests
             Assert.IsTrue(item.ScopeSet.Contains(scopeInCache));
         }
 
+        [TestMethod]
+        [TestCategory("TokenCacheTests")]
+        public void CacheB2CTokenTestAsync()
+        {
+            TokenCache B2CCache = new TokenCache();
+            var tenantID = "someTenantID";
+            var authority = Authority.CreateAuthority(String.Format("https://login.microsoftonline.com/tfp/{0}/somePolicy/oauth2/v2.0/authorize", tenantID), false);
+
+            MsalTokenResponse response = new MsalTokenResponse();
+            //creating IDToken with empty tenantID and displayableID/PreferedUserName for B2C scenario
+            response.IdToken = MockHelpers.CreateIdToken(String.Empty, String.Empty, String.Empty);
+            response.ClientInfo = MockHelpers.CreateClientInfo();
+            response.AccessToken = "access-token";
+            response.ExpiresIn = 3599;
+            response.CorrelationId = "correlation-id";
+            response.RefreshToken = "refresh-token";
+            response.Scope = TestConstants.Scope.AsSingleString();
+            response.TokenType = "Bearer";
+
+            RequestContext requestContext = new RequestContext(new MsalLogger(Guid.NewGuid(), null));
+            AuthenticationRequestParameters requestParams = new AuthenticationRequestParameters()
+            {
+                RequestContext = requestContext,
+                Authority = authority,
+                ClientId = TestConstants.ClientId,
+                TenantUpdatedCanonicalAuthority = TestConstants.AuthorityTestTenant
+            };
+
+            B2CCache.SaveAccessAndRefreshToken(requestParams, response);
+
+            Assert.AreEqual(1, B2CCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
+            Assert.AreEqual(1, B2CCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
+        }
+
         /*
         [TestMethod]
         [TestCategory("TokenCacheTests")]

--- a/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
@@ -884,7 +884,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
 
         [TestMethod]
         [TestCategory("TokenCacheTests")]
-        public void CacheB2CTokenTestAsync()
+        public void CacheB2CTokenTest()
         {
             TokenCache B2CCache = new TokenCache();
             var tenantID = "someTenantID";


### PR DESCRIPTION
Injecting tenantID  into the returned B2C ID Token to enable caching for b2c scenarios.

Removed check for preferedUserName from MSAL caching on B2C scenarios.

VSTS bug 533786

This fix was tested E2E with the MSAL desktop App. Both interactive and silent B2C calls were tested