### PR TITLE
Fix XML comments warnings:

### DIFF
--- a/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -32,11 +32,15 @@ using Microsoft.Identity.Core.Helpers;
 
 namespace Microsoft.Identity.Client
 {
+#if !DESKTOP && !NET_CORE
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
+#endif
     /// <summary>
     /// Contains the results of one token acquisition operation in <see cref="PublicClientApplication"/>
-    /// or <see cref="Microsoft.Identity.Client.ConfidentialClientApplication"/>. For details see https://aka.ms/msal-net-authenticationresult
-    /// </summary>
+    /// or <see cref="T:ConfidentialClientApplication"/>. For details see https://aka.ms/msal-net-authenticationresult
+    /// </summary> 
     public partial class AuthenticationResult
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     {
         private const string Oauth2AuthorizationHeader = "Bearer ";
         private readonly MsalAccessTokenCacheItem _msalAccessTokenCacheItem;

--- a/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -39,11 +39,15 @@ using Microsoft.Identity.Core.Telemetry;
 
 namespace Microsoft.Identity.Client
 {
+#if !DESKTOP && !NET_CORE
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
+#endif
     /// <Summary>
     /// Abstract class containing common API methods and properties. Both <see cref="Microsoft.Identity.Client.PublicClientApplication"/> and <see cref="Microsoft.Identity.Client.ConfidentialClientApplication"/> 
     /// extend this class. For details see https://aka.ms/msal-net-client-applications
     /// </Summary>
     public abstract partial class ClientApplicationBase
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     {
         private TokenCache userTokenCache;
 
@@ -115,6 +119,7 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public string ClientId { get; }
 
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
         /// <summary>
         /// The redirect URI (also known as Reply URI or Reply URL), is the URI at which Azure AD will contact back the application with the tokens. 
         /// This redirect URI needs to be registered in the app registration (https://aka.ms/msal-net-register-app).
@@ -131,6 +136,7 @@ namespace Microsoft.Identity.Client
         /// <remarks>This is especially important when you deploy an application that you have initially tested locally; 
         /// you then need to add the reply URL of the deployed application in the application registration portal</remarks>
         public string RedirectUri { get; set; }
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
         /// <summary>
         /// Sets or Gets a custom query parameters that may be sent to the STS for dogfood testing or debugging. This is a string of segments

--- a/msal/src/Microsoft.Identity.Client/Exceptions/MsalClientException.cs
+++ b/msal/src/Microsoft.Identity.Client/Exceptions/MsalClientException.cs
@@ -60,6 +60,9 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string NetworkNotAvailableError = "network_not_available";
 
+#if !DESKTOP && !NET_CORE
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
+#endif
         /// <summary>
         /// Duplicate query parameter was found in extraQueryParameters.
         /// <para>What happens?</para> You have used <see cref="ClientApplicationBase.SliceParameters"/> or the <c>extraQueryParameter</c> of overrides
@@ -70,6 +73,7 @@ namespace Microsoft.Identity.Client
         /// <seealso cref="P:ClientApplicationBase.SliceParameters"/>
         /// <seealso cref="ConfidentialClientApplication.GetAuthorizationRequestUrlAsync(System.Collections.Generic.IEnumerable{string}, string, string, string, System.Collections.Generic.IEnumerable{string}, string)"/>
         public const string DuplicateQueryParameterError = "duplicate_query_parameter";
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
         /// <summary>
         /// The request could not be performed because of a failure in the UI flow.

--- a/msal/src/Microsoft.Identity.Client/Exceptions/MsalServiceException.cs
+++ b/msal/src/Microsoft.Identity.Client/Exceptions/MsalServiceException.cs
@@ -186,13 +186,16 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public int StatusCode { get; internal set; } = 0;
 
+#if !DESKTOP
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
+#endif
         /// <summary>
         /// Additional claims requested by the service. When this property is not null or empty, this means that the service requires the user to 
         /// provide additional claims, such as doing two factor authentication. The are two cases:
         /// <list type="bullent">
         /// <item><description>
-        /// If your application is a <see cref="PublicClientApplication"/>, you should just call and <see cref="PublicClientApplication.AcquireTokenAsync"/>
-        /// override of <see cref="PublicClientApplication"/> having an <c>extraQueryParameter</c> argument, and add the following string <c>$"claims={ex.Claims}"</c>
+        /// If your application is a <see cref="PublicClientApplication"/>, you should just call an override of <see cref="PublicClientApplication.AcquireTokenAsync(System.Collections.Generic.IEnumerable{string}, string, UIBehavior, string, System.Collections.Generic.IEnumerable{string}, string)"/>
+        /// in <see cref="PublicClientApplication"/> having an <c>extraQueryParameter</c> argument, and add the following string <c>$"claims={ex.Claims}"</c>
         /// to the extraQueryParameters, where ex is an instance of this exception.
         /// </description></item>
         /// <item>><description>If your application is a <see cref="ConfidentialClientApplication"/>, (therefore doing the On-Behalf-Of flow), you should throw an Http unauthorize 
@@ -201,6 +204,7 @@ namespace Microsoft.Identity.Client
         /// For more details see https://aka.ms/msal-net-claim-challenge
         /// </summary>
         public string Claims { get; internal set; }
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
         
         /// <summary>
         /// Raw response body received from the server.

--- a/msal/src/Microsoft.Identity.Client/Exceptions/MsalUiRequiredException.cs
+++ b/msal/src/Microsoft.Identity.Client/Exceptions/MsalUiRequiredException.cs
@@ -47,6 +47,9 @@ namespace Microsoft.Identity.Client
         /// </summary>
         public const string InvalidGrantError = "invalid_grant";
 
+#if !DESKTOP && !NET_CORE
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
+#endif
         /// <summary>
         /// <para>Mitigation:</para> If your application is a <see cref="PublicClientApplication"/> call one of the <c>AcquireTokenAsync</c> overrides so
         /// that the user of your application signs-in and accepts consent. If your application is a <see cref="T:ConfidentialClientApplication"/>. If it's a Web App
@@ -54,6 +57,7 @@ namespace Microsoft.Identity.Client
         /// as described in https://aka.ms/msal-net-authorization-code. This error should not happen in Web APIs.
         /// </summary>
         public const string NoTokensFoundError = "no_tokens_found";
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
         /// <summary>
         /// This error code comes back from <see cref="ClientApplicationBase.AcquireTokenSilentAsync(System.Collections.Generic.IEnumerable{string}, IAccount)"/> calls when a null user is 

--- a/msal/src/Microsoft.Identity.Client/IClientApplicationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/IClientApplicationBase.cs
@@ -56,6 +56,9 @@ namespace Microsoft.Identity.Client
         /// </summary>
         string ClientId { get; }
 
+#if !DESKTOP && !NET_CORE
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
+#endif
         /// <summary>
         /// The redirect URI (also known as Reply URI or Reply URL), is the URI at which Azure AD will contact back the application with the tokens. 
         /// This redirect URI needs to be registered in the app registration (https://aka.ms/msal-net-register-app)
@@ -73,6 +76,7 @@ namespace Microsoft.Identity.Client
         /// you then need to add the reply URL of the deployed application in the application registration portal.
         /// </remarks>
         string RedirectUri { get; set; }
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
 
         /// <summary>
         /// Gets a boolean value telling the application if the authority needs to be verified against a list of known authorities. The default

--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -37,6 +37,9 @@ using Microsoft.Identity.Core.Telemetry;
 
 namespace Microsoft.Identity.Client
 {
+#if !DESKTOP && !NET_CORE
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
+#endif
     /// <summary>
     /// Class to be used to acquire tokens in desktop or mobile applications (Desktop / UWP / Xamarin.iOS / Xamarin.Android).
     /// public client applications are not trusted to safely keep application secrets, and therefore they only access Web APIs in the name of the user only 
@@ -53,6 +56,7 @@ namespace Microsoft.Identity.Client
     /// </list>
     /// </remarks>
     public sealed partial class PublicClientApplication : ClientApplicationBase, IPublicClientApplication
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     {
         static PublicClientApplication()
         {

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -42,14 +42,18 @@ using Microsoft.Identity.Core.Telemetry;
 
 namespace Microsoft.Identity.Client
 {
+#if !DESKTOP && !NET_CORE
+#pragma warning disable CS1574 // XML comment has cref attribute that could not be resolved
+#endif
     /// <summary>
     /// Token cache storing access and refresh tokens for accounts 
-    /// This class is used in the constuctors of <see cref="PublicClientApplication"/> and <see cref="Microsoft.Identity.Client.ConfidentialClientApplication"/>.
+    /// This class is used in the constuctors of <see cref="PublicClientApplication"/> and <see cref="ConfidentialClientApplication"/>.
     /// In the case of ConfidentialClientApplication, two instances are used, one for the user token cache, and one for the application
     /// token cache (in the case of applications using the client credential flows).
-    /// See also <see cref="Microsoft.Identity.Client.TokenCacheExtensions"/> which contains extension methods used to customize the cache serialization
+    /// See also <see cref="TokenCacheExtensions"/> which contains extension methods used to customize the cache serialization
     /// </summary>
     public sealed class TokenCache
+#pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     {
         static TokenCache()
         {


### PR DESCRIPTION
See https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/607

**Note that**
I did not fix the XML comment warning in `UserAssertion.cs`, as I think that `UserAssertion` should only be in the platforms that define `ConfidentialClientApplication` OBO