### PR TITLE
silent call authority null - use app authority

### DIFF
--- a/core/src/Instance/AadAuthority.cs
+++ b/core/src/Instance/AadAuthority.cs
@@ -51,6 +51,8 @@ namespace Microsoft.Identity.Core.Instance
 
         private const string AadInstanceDiscoveryEndpoint = "https://login.microsoftonline.com/common/discovery/instance";
 
+        public const string AADCanonicalAuthorityTemplate = "https://{0}/{1}/";
+
         internal AadAuthority(string authority, bool validateAuthority) : base(authority, validateAuthority)
         {
             AuthorityType = AuthorityType.Aad;
@@ -114,7 +116,7 @@ namespace Microsoft.Identity.Core.Instance
             Uri authorityUri = new Uri(CanonicalAuthority);
 
             CanonicalAuthority = 
-                string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/", authorityUri.Authority, tenantId);
+                string.Format(CultureInfo.InvariantCulture, AADCanonicalAuthorityTemplate, authorityUri.Authority, tenantId);
         }
     }
 }

--- a/core/src/Instance/AadAuthority.cs
+++ b/core/src/Instance/AadAuthority.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Identity.Core.OAuth2;
@@ -107,6 +108,13 @@ namespace Microsoft.Identity.Core.Instance
         {
             return GetFirstPathSegment(CanonicalAuthority);
         }
-        
+
+        internal override void UpdateTenantId(string tenantId)
+        {
+            Uri authorityUri = new Uri(CanonicalAuthority);
+
+            CanonicalAuthority = 
+                string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/", authorityUri.Authority, tenantId);
+        }
     }
 }

--- a/core/src/Instance/AdfsAuthority.cs
+++ b/core/src/Instance/AdfsAuthority.cs
@@ -175,5 +175,10 @@ namespace Microsoft.Identity.Core.Instance
         {
             throw new NotImplementedException();
         }
+
+        internal override void UpdateTenantId(string tenantId)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/core/src/Instance/Authority.cs
+++ b/core/src/Instance/Authority.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Core.Instance
 {
     internal abstract class Authority
     {
-        private static readonly HashSet<string> TenantlessTenantNames =
+        internal static readonly HashSet<string> TenantlessTenantNames =
             new HashSet<string>(new[] {"common", "organizations"});
         private bool _resolved;
 
@@ -242,6 +242,8 @@ namespace Microsoft.Identity.Core.Instance
         protected abstract string GetDefaultOpenIdConfigurationEndpoint();
 
         internal abstract string GetTenantId();
+
+        internal abstract void UpdateTenantId(string tenantId);
 
         private async Task<TenantDiscoveryResponse> DiscoverEndpointsAsync(string openIdConfigurationEndpoint,
             RequestContext requestContext)

--- a/core/src/Instance/B2CAuthority.cs
+++ b/core/src/Instance/B2CAuthority.cs
@@ -71,8 +71,11 @@ namespace Microsoft.Identity.Core.Instance
             Uri authorityUri = new Uri(CanonicalAuthority);
             var segments = authorityUri.Segments;
 
+            var b2cPrefix = segments[1].TrimEnd('/');
+            var b2cPolicy = segments[3].TrimEnd('/');
+
             CanonicalAuthority = string.Format(CultureInfo.InvariantCulture, B2CCanonicalAuthorityTemplate, 
-                authorityUri.Authority, segments[1].TrimEnd('/'), tenantId, segments[3].TrimEnd('/'));
+                authorityUri.Authority, b2cPrefix, tenantId, b2cPolicy);
         }
     }
 }

--- a/core/src/Instance/B2CAuthority.cs
+++ b/core/src/Instance/B2CAuthority.cs
@@ -34,6 +34,7 @@ namespace Microsoft.Identity.Core.Instance
     internal class B2CAuthority : AadAuthority
     {
         public const string Prefix = "tfp"; // The http path of B2C authority looks like "/tfp/<your_tenant_name>/..."
+        public const string B2CCanonicalAuthorityTemplate = "https://{0}/{1}/{2}/{3}/";
 
         internal B2CAuthority(string authority, bool validateAuthority) : base(authority, validateAuthority)
         {
@@ -44,8 +45,9 @@ namespace Microsoft.Identity.Core.Instance
                 throw new ArgumentException(CoreErrorMessages.B2cAuthorityUriInvalidPath);
             }
 
-            CanonicalAuthority = string.Format(CultureInfo.InvariantCulture, "https://{0}/{1}/{2}/{3}/", authorityUri.Authority,
+            CanonicalAuthority = string.Format(CultureInfo.InvariantCulture, B2CCanonicalAuthorityTemplate, authorityUri.Authority,
                 pathSegments[0], pathSegments[1], pathSegments[2]);
+
             AuthorityType = AuthorityType.B2C;
         }
 
@@ -62,6 +64,15 @@ namespace Microsoft.Identity.Core.Instance
         internal override string GetTenantId()
         {
             return new Uri(CanonicalAuthority).Segments[2].TrimEnd('/');
+        }
+
+        internal override void UpdateTenantId(string tenantId)
+        {
+            Uri authorityUri = new Uri(CanonicalAuthority);
+            var segments = authorityUri.Segments;
+
+            CanonicalAuthority = string.Format(CultureInfo.InvariantCulture, B2CCanonicalAuthorityTemplate, 
+                authorityUri.Authority, segments[1].TrimEnd('/'), tenantId, segments[3].TrimEnd('/'));
         }
     }
 }

--- a/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -277,6 +277,17 @@ namespace Microsoft.Identity.Client
         internal async Task<AuthenticationResult> AcquireTokenSilentCommonAsync(Authority authority,
             IEnumerable<string> scopes, IAccount account, bool forceRefresh, ApiEvent.ApiIds apiId)
         {
+            if (authority == null)
+            {
+                authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+                var tenantId = authority.GetTenantId();
+
+                if (Core.Instance.Authority.TenantlessTenantNames.Contains(tenantId))
+                {
+                    authority.UpdateTenantId(account.HomeAccountId.TenantId);
+                }
+            }
+
             var handler = new SilentRequest(
                 CreateRequestParameters(authority, scopes, account, UserTokenCache),
                 forceRefresh)

--- a/msal/src/Microsoft.Identity.Client/Exceptions/MsalErrorMessage.cs
+++ b/msal/src/Microsoft.Identity.Client/Exceptions/MsalErrorMessage.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Core
         public const string MissingAuthenticateHeader = "WWW-Authenticate header was expected in the response";
 
         public const string MultipleTokensMatched =
-            "The cache contains multiple tokens satisfying the requirements. Call AcquireToken again providing more requirements like authority";
+            "The cache contains multiple tokens satisfying the requirements. Try to clear token cache and report the issue";
 
         public const string NetworkNotAvailable = "The network is down so authentication cannot proceed";
         public const string NoDataFromSTS = "No data received from security token service";

--- a/msal/src/Microsoft.Identity.Client/Exceptions/MsalErrorMessage.cs
+++ b/msal/src/Microsoft.Identity.Client/Exceptions/MsalErrorMessage.cs
@@ -70,7 +70,7 @@ namespace Microsoft.Identity.Core
         public const string MissingAuthenticateHeader = "WWW-Authenticate header was expected in the response";
 
         public const string MultipleTokensMatched =
-            "The cache contains multiple tokens satisfying the requirements. Try to clear token cache and report the issue";
+            "The cache contains multiple tokens satisfying the requirements. Try to clear token cache";
 
         public const string NetworkNotAvailable = "The network is down so authentication cannot proceed";
         public const string NoDataFromSTS = "No data received from security token service";

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -325,9 +325,21 @@ namespace Microsoft.Identity.Client
         private MsalAccessTokenCacheItem FindAccessTokenCommon
             (AuthenticationRequestParameters requestParams, string preferredEnvironmentAlias, ISet<string> environmentAliases)
         {
+            string msg;
+
+            //no authority passed
+            if (environmentAliases.Count == 0)
+            {
+                msg = "No authority provided. Skipping cache lookup ";
+                requestParams.RequestContext.Logger.Warning(msg);
+                requestParams.RequestContext.Logger.WarningPii(msg);
+
+                return null;
+            }
+
             lock (LockObject)
             {
-                string msg = "Looking up access token in the cache..";
+                msg = "Looking up access token in the cache..";
                 requestParams.RequestContext.Logger.Info(msg);
                 requestParams.RequestContext.Logger.InfoPii(msg);
                 MsalAccessTokenCacheItem msalAccessTokenCacheItem = null;
@@ -394,107 +406,46 @@ namespace Microsoft.Identity.Client
                 msg = "Matching entry count after filtering by scopes - " + filteredItems.Count();
                 requestParams.RequestContext.Logger.Info(msg);
                 requestParams.RequestContext.Logger.InfoPii(msg);
-                //no authority passed
-                if (environmentAliases.Count == 0)
+
+                //filter by authority
+                IEnumerable<MsalAccessTokenCacheItem> filteredByPrefferedAlias =
+                    filteredItems.Where
+                    (item => item.Environment.Equals(preferredEnvironmentAlias, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+
+                if (filteredByPrefferedAlias.Any())
                 {
-                    msg = "No authority provided..";
-                    requestParams.RequestContext.Logger.Info(msg);
-                    requestParams.RequestContext.Logger.InfoPii(msg);
-                    
-                    //if only one cached token found
-                    if (filteredItems.Count() == 1)
-                    {
-                        msalAccessTokenCacheItem = filteredItems.First();
-                        requestParams.Authority =
-                            Authority.CreateAuthority(msalAccessTokenCacheItem.Authority, requestParams.ValidateAuthority);
-
-                        msg = "1 matching entry found.Authority may be used for refreshing access token.";
-                        requestParams.RequestContext.Logger.Info(msg);
-                        requestParams.RequestContext.Logger.InfoPii(msg);
-                    }
-                    else if (filteredItems.Count() > 1)
-                    {
-                        msg = "Multiple authorities found for same client_id, user and scopes";
-                        requestParams.RequestContext.Logger.Error(msg);
-                        requestParams.RequestContext.Logger.ErrorPii(msg + " :- " + filteredItems
-                                .Select(tci => tci.Authority)
-                                .AsSingleString());
-                        throw new MsalClientException(MsalClientException.MultipleTokensMatchedError,
-                            MsalErrorMessage.MultipleTokensMatched);
-                    }
-                    else
-                    {
-                        msg = "No tokens found for matching client_id, user and scopes.";
-                        requestParams.RequestContext.Logger.Info(msg);
-                        requestParams.RequestContext.Logger.InfoPii(msg);
-
-                        msg = "Check if the tokens are for the same authority for given client_id and user.";
-                        requestParams.RequestContext.Logger.Info(msg);
-                        requestParams.RequestContext.Logger.InfoPii(msg);
-                        //no match found. check if there was a single authority used
-                        IEnumerable<string> authorityList = tokenCacheItems.Select(tci => tci.Authority).Distinct();
-                        if (authorityList.Count() > 1)
-                        {
-                            msg = "Multiple authorities found for same client_id and user.";
-                            requestParams.RequestContext.Logger.Error(msg);
-                            requestParams.RequestContext.Logger.ErrorPii(msg + " :- " + authorityList.AsSingleString());
-
-                            throw new MsalClientException(MsalClientException.MultipleTokensMatchedError,
-                                "Multiple authorities found in the cache. Pass in authority in the API overload.");
-                        }
-
-                        msg = "Distinct Authority found. Use it for refresh token grant call";
-                        requestParams.RequestContext.Logger.Info(msg);
-                        requestParams.RequestContext.Logger.InfoPii(msg);
-                        requestParams.Authority = Authority.CreateAuthority(authorityList.First(), requestParams.ValidateAuthority);
-                    }
+                    filteredItems = filteredByPrefferedAlias;
                 }
                 else
                 {
-                    msg = "Authority provided..";
+                    filteredItems = filteredItems.Where(
+                        item => environmentAliases.Contains(item.Environment) &&
+                        item.TenantId.Equals(requestParams.Authority.GetTenantId(), StringComparison.OrdinalIgnoreCase)).ToList();
+                }
+
+                //no match
+                if (!filteredItems.Any())
+                {
+                    msg = "No tokens found for matching authority, client_id, user and scopes.";
                     requestParams.RequestContext.Logger.Info(msg);
                     requestParams.RequestContext.Logger.InfoPii(msg);
+                    return null;
+                }
 
-                    //authority was passed in the API
-                    IEnumerable<MsalAccessTokenCacheItem> filteredByPrefferedAlias = 
-                        filteredItems.Where
-                        (item => item.Environment.Equals(preferredEnvironmentAlias, StringComparison.OrdinalIgnoreCase))
-                        .ToList();
+                //if only one cached token found
+                if (filteredItems.Count() == 1)
+                {
+                    msalAccessTokenCacheItem = filteredItems.First();
+                }
+                else
+                {
+                    msg = "Multiple tokens found for matching authority, client_id, user and scopes.";
+                    requestParams.RequestContext.Logger.Error(msg);
+                    requestParams.RequestContext.Logger.ErrorPii(msg);
 
-                    if (filteredByPrefferedAlias.Any())
-                    {
-                        filteredItems = filteredByPrefferedAlias;
-                    }
-                    else
-                    {
-                        filteredItems = filteredItems.Where(
-                            item => environmentAliases.Contains(item.Environment) && 
-                            item.TenantId.Equals(requestParams.Authority.GetTenantId(), StringComparison.OrdinalIgnoreCase)).ToList();
-                    }
-
-                    //no match
-                    if (!filteredItems.Any())
-                    {
-                        msg = "No tokens found for matching authority, client_id, user and scopes.";
-                        requestParams.RequestContext.Logger.Info(msg);
-                        requestParams.RequestContext.Logger.InfoPii(msg);
-                        return null;
-                    }
-
-                    //if only one cached token found
-                    if (filteredItems.Count() == 1)
-                    {
-                        msalAccessTokenCacheItem = filteredItems.First();
-                    }
-                    else
-                    {
-                        msg = "Multiple tokens found for matching authority, client_id, user and scopes.";
-                        requestParams.RequestContext.Logger.Error(msg);
-                        requestParams.RequestContext.Logger.ErrorPii(msg);
-                        
-                        throw new MsalClientException(MsalClientException.MultipleTokensMatchedError,
-                            MsalErrorMessage.MultipleTokensMatched);
-                    }
+                    throw new MsalClientException(MsalClientException.MultipleTokensMatchedError,
+                        MsalErrorMessage.MultipleTokensMatched);
                 }
 
                 if (msalAccessTokenCacheItem != null && msalAccessTokenCacheItem.ExpiresOn >

--- a/msal/src/Microsoft.Identity.Client/TokenCache.cs
+++ b/msal/src/Microsoft.Identity.Client/TokenCache.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Identity.Client
 
             lock (LockObject)
             {
-                msg = "Looking up access token in the cache..";
+                msg = "Looking up access token in the cache.";
                 requestParams.RequestContext.Logger.Info(msg);
                 requestParams.RequestContext.Logger.InfoPii(msg);
                 MsalAccessTokenCacheItem msalAccessTokenCacheItem = null;
@@ -400,8 +400,7 @@ namespace Microsoft.Identity.Client
                 IEnumerable<MsalAccessTokenCacheItem> filteredItems =
                     tokenCacheItems.Where(
                             item =>
-                                item.ScopeSet.ScopeContains(requestParams.Scope))
-                        .ToList();
+                                item.ScopeSet.ScopeContains(requestParams.Scope));
 
                 msg = "Matching entry count after filtering by scopes - " + filteredItems.Count();
                 requestParams.RequestContext.Logger.Info(msg);
@@ -410,8 +409,7 @@ namespace Microsoft.Identity.Client
                 //filter by authority
                 IEnumerable<MsalAccessTokenCacheItem> filteredByPrefferedAlias =
                     filteredItems.Where
-                    (item => item.Environment.Equals(preferredEnvironmentAlias, StringComparison.OrdinalIgnoreCase))
-                    .ToList();
+                    (item => item.Environment.Equals(preferredEnvironmentAlias, StringComparison.OrdinalIgnoreCase));
 
                 if (filteredByPrefferedAlias.Any())
                 {
@@ -421,7 +419,7 @@ namespace Microsoft.Identity.Client
                 {
                     filteredItems = filteredItems.Where(
                         item => environmentAliases.Contains(item.Environment) &&
-                        item.TenantId.Equals(requestParams.Authority.GetTenantId(), StringComparison.OrdinalIgnoreCase)).ToList();
+                        item.TenantId.Equals(requestParams.Authority.GetTenantId(), StringComparison.OrdinalIgnoreCase));
                 }
 
                 //no match

--- a/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/PublicClientApplicationTests.cs
@@ -870,7 +870,7 @@ namespace Test.MSAL.NET.Unit
 
             HttpMessageHandlerFactory.AddMockHandler(
                 MockHelpers.CreateInstanceDiscoveryMockHandler(
-                    TestConstants.GetDiscoveryEndpoint(TestConstants.PrefCacheAuthorityCommonTenant)));
+                    TestConstants.GetDiscoveryEndpoint(TestConstants.AuthorityCommonTenant)));
 
             //add mock response for tenant endpoint discovery
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler


### PR DESCRIPTION
[VSTS - 530576](https://identitydivision.visualstudio.com/DevEx/_workitems/edit/530576)
AcquireTokenSilent without passing authority does not work as expected when migrating from ADAL V4 to MSAL V2.