### PR TITLE
Add U/P entry point to the public interface

### DIFF
--- a/msal/src/Microsoft.Identity.Client/IPublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/IPublicClientApplication.cs
@@ -320,5 +320,21 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes,
             string username);
 #endif
+
+#if DESKTOP
+        /// <summary>
+        /// Non-interactive request to acquire a security token from the authority, via Username/Password Authentication.
+        /// See https://aka.ms/msal-net-up.
+        /// </summary>
+        /// <param name="scopes">Scopes requested to access a protected API</param>
+        /// <param name="username">Identifier of the user application requests token on behalf.
+        /// Generally in UserPrincipalName (UPN) format, e.g. john.doe@contoso.com</param>
+        /// <param name="securePassword">User password.</param>
+        /// <returns>Authentication result containing a token for the requested scopes and account</returns>
+        Task<AuthenticationResult> AcquireTokenByUsernamePasswordAsync(
+            IEnumerable<string> scopes,
+            string username,
+            System.Security.SecureString securePassword);
+#endif
     }
 }


### PR DESCRIPTION
IPublicClientApplication is a convenience interface so that developers can easily mock MSAL in their unit tests. We have forgotten to add the U/P public API to the it. There is no functional impact because of this.