### PR TITLE
Jennyf/uwp

### DIFF
--- a/msal/tests/dev apps/DesktopTestApp/MainForm.cs
+++ b/msal/tests/dev apps/DesktopTestApp/MainForm.cs
@@ -224,6 +224,7 @@ namespace DesktopTestApp
             using (new UIProgressScope(this))
             {
                 ClearResultPageInfo();
+                userPasswordTextBox.PasswordChar = '*';
 
                 string username = loginHintTextBox.Text; //Can be blank for U/P 
                 SecureString securePassword = ConvertToSecureString(userPasswordTextBox);
@@ -236,6 +237,8 @@ namespace DesktopTestApp
         {
             try
             {
+                _publicClientHandler.PublicClientApplication = new PublicClientApplication(publicClientId, "https://login.microsoftonline.com/organizations");
+
                 AuthenticationResult authResult = await _publicClientHandler.PublicClientApplication.AcquireTokenByUsernamePasswordAsync(
                     scopes.Text.AsArray(),
                     username,

--- a/msal/tests/dev apps/XForms/XForms/AcquirePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/AcquirePage.xaml.cs
@@ -62,6 +62,7 @@ namespace XForms
                 Select(x => x.Username).ToList();
 
             userIds.Add(UserNotSelected);
+            usersPicker.ItemsSource = userIds;
             usersPicker.SelectedIndex = 0;
         }
 


### PR DESCRIPTION
The silent call in the Xamarin MSAL apps does not work because the below line was removed. Adding it back.