### PR TITLE
First round at removing static httprequest layer, moving to HttpManager

### DIFF
--- a/core/src/Exceptions/CoreExceptionFactory.cs
+++ b/core/src/Exceptions/CoreExceptionFactory.cs
@@ -29,11 +29,42 @@ using System;
 
 namespace Microsoft.Identity.Core
 {
+    internal interface ICoreExceptionFactory
+    {
+        Exception GetClientException(
+            string errorCode,
+            string errorMessage,
+            Exception innerException = null);
+
+        Exception GetServiceException(
+            string errorCode,
+            string errorMessage);
+
+        Exception GetServiceException(
+           string errorCode,
+           string errorMessage,
+           ExceptionDetail exceptionDetail = null);
+
+        Exception GetServiceException(
+           string errorCode,
+           string errorMessage,
+           Exception innerException = null,
+           ExceptionDetail exceptionDetail = null);
+
+        Exception GetUiRequiredException(
+           string errorCode,
+           string errorMessage,
+           Exception innerException = null,
+           ExceptionDetail exceptionDetail = null);
+
+        string GetPiiScrubbedDetails(Exception exception);
+    }
+
     /// <summary>
     /// Abstract factory for spewing exceptions for Adal and Msal. Use the <see cref="Instance"/>
     /// singleton to access an actual implementation which will have been injected.
     /// </summary>
-    internal abstract class CoreExceptionFactory
+    internal abstract class CoreExceptionFactory : ICoreExceptionFactory
     {
         public static CoreExceptionFactory Instance { get; set; }
 

--- a/core/src/Exceptions/ICoreExceptionFactory.cs
+++ b/core/src/Exceptions/ICoreExceptionFactory.cs
@@ -29,40 +29,34 @@ using System;
 
 namespace Microsoft.Identity.Core
 {
-    /// <summary>
-    /// Abstract factory for spewing exceptions for Adal and Msal. Use the <see cref="Instance"/>
-    /// singleton to access an actual implementation which will have been injected.
-    /// </summary>
-    internal abstract class CoreExceptionFactory : ICoreExceptionFactory
+    internal interface ICoreExceptionFactory
     {
-        public static CoreExceptionFactory Instance { get; set; }
-
-        public abstract Exception GetClientException(
+        Exception GetClientException(
             string errorCode,
             string errorMessage,
             Exception innerException = null);
 
-        public abstract Exception GetServiceException(
+        Exception GetServiceException(
             string errorCode,
             string errorMessage);
 
-        public abstract Exception GetServiceException(
+        Exception GetServiceException(
            string errorCode,
            string errorMessage,
            ExceptionDetail exceptionDetail = null);
 
-        public abstract Exception GetServiceException(
-           string errorCode,
-           string errorMessage,
-           Exception innerException = null,
-           ExceptionDetail exceptionDetail = null);
-
-        public abstract Exception GetUiRequiredException(
+        Exception GetServiceException(
            string errorCode,
            string errorMessage,
            Exception innerException = null,
            ExceptionDetail exceptionDetail = null);
 
-        public abstract string GetPiiScrubbedDetails(Exception exception);
+        Exception GetUiRequiredException(
+           string errorCode,
+           string errorMessage,
+           Exception innerException = null,
+           ExceptionDetail exceptionDetail = null);
+
+        string GetPiiScrubbedDetails(Exception exception);
     }
 }

--- a/core/src/Http/HttpClientFactory.cs
+++ b/core/src/Http/HttpClientFactory.cs
@@ -30,7 +30,13 @@ using System.Net.Http.Headers;
 
 namespace Microsoft.Identity.Core.Http
 {
-    internal class HttpClientFactory
+    internal interface IHttpClientFactory
+    {
+        // TODO: rename this to GetHttpClient once we make the underlying class not fully static.
+        HttpClient GetTheHttpClient();
+    }
+
+    internal class HttpClientFactory : IHttpClientFactory
     {
         // as per guidelines HttpClient should be a singeton instance in an application.
         private static HttpClient _client;
@@ -49,6 +55,11 @@ namespace Microsoft.Identity.Core.Http
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             return httpClient;
+        }
+
+        public HttpClient GetTheHttpClient()
+        {
+            return HttpClientFactory.GetHttpClient();
         }
 
         public static HttpClient GetHttpClient()

--- a/core/src/Http/HttpManager.cs
+++ b/core/src/Http/HttpManager.cs
@@ -1,0 +1,272 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Core.Http
+{
+    internal class HttpManager : IHttpManager
+    {
+        private readonly ICoreExceptionFactory _coreExceptionFactory;
+        private readonly IHttpClientFactory _httpClientFactory;
+
+        public HttpManager(ICoreExceptionFactory coreExceptionFactory = null, IHttpClientFactory httpClientFactory = null)
+        {
+            _coreExceptionFactory = coreExceptionFactory ?? CoreExceptionFactory.Instance;
+            _httpClientFactory = httpClientFactory ?? new HttpClientFactory();
+        }
+
+        public async Task<HttpResponse> SendPostAsync(
+            Uri endpoint,
+            IDictionary<string, string> headers,
+            IDictionary<string, string> bodyParameters,
+            RequestContext requestContext)
+        {
+            HttpContent body = bodyParameters == null ? null : new FormUrlEncodedContent(bodyParameters);
+            return await SendPostAsync(endpoint, headers, body, requestContext).ConfigureAwait(false);
+        }
+
+        public async Task<HttpResponse> SendPostAsync(Uri endpoint, IDictionary<string, string> headers,
+            HttpContent body, RequestContext requestContext)
+        {
+            return await ExecuteWithRetryAsync(endpoint, headers, body, HttpMethod.Post, requestContext).ConfigureAwait(false);
+        }
+
+        public async Task<HttpResponse> SendGetAsync(
+            Uri endpoint,
+            Dictionary<string, string> headers,
+            RequestContext requestContext)
+        {
+            return await ExecuteWithRetryAsync(endpoint, headers, null, HttpMethod.Get, requestContext).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Performs the POST request just like <see cref="SendPostAsync(Uri, IDictionary{string, string}, HttpContent, RequestContext)"/>
+        /// but does not throw a ServiceUnavailable service exception. Instead, it returns the <see cref="IHttpWebResponse"/> associated
+        /// with the request.
+        /// </summary>
+        public async Task<IHttpWebResponse> SendPostForceResponseAsync(
+            Uri uri,
+            Dictionary<string, string> headers,
+            StringContent body,
+            RequestContext requestContext)
+        {
+            return await ExecuteWithRetryAsync(uri, headers, body, HttpMethod.Post, requestContext, doNotThrow: true).ConfigureAwait(false);
+        }
+
+        private HttpRequestMessage CreateRequestMessage(Uri endpoint, IDictionary<string, string> headers)
+        {
+            HttpRequestMessage requestMessage = new HttpRequestMessage { RequestUri = endpoint };
+            requestMessage.Headers.Accept.Clear();
+            if (headers != null)
+            {
+                foreach (KeyValuePair<string, string> kvp in headers)
+                {
+                    requestMessage.Headers.Add(kvp.Key, kvp.Value);
+                }
+            }
+
+            return requestMessage;
+        }
+
+        private async Task<HttpResponse> ExecuteWithRetryAsync(
+            Uri endpoint,
+            IDictionary<string, string> headers,
+            HttpContent body,
+            HttpMethod method,
+            RequestContext requestContext,
+            bool doNotThrow = false,
+            bool retry = true)
+        {
+            Exception toThrow = null;
+            bool isRetryable = false;
+            HttpResponse response = null;
+            try
+            {
+                HttpContent clonedBody = body;
+                if (body != null)
+                {
+                    // Since HttpContent would be disposed by underlying client.SendAsync(),
+                    // we duplicate it so that we will have a copy in case we would need to retry
+                    clonedBody = await CloneHttpContentAsync(body).ConfigureAwait(false);
+                }
+
+                response = await ExecuteAsync(endpoint, headers, clonedBody, method).ConfigureAwait(false);
+
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    return response;
+                }
+
+                var msg = string.Format(CultureInfo.InvariantCulture,
+                    CoreErrorMessages.HttpRequestUnsuccessful,
+                    (int)response.StatusCode, response.StatusCode);
+                requestContext.Logger.Info(msg);
+                requestContext.Logger.InfoPii(msg);
+
+                if ((int)response.StatusCode >= 500 && (int)response.StatusCode < 600)
+                {
+                    isRetryable = true;
+                }
+            }
+            catch (TaskCanceledException exception)
+            {
+                string noPiiMsg = _coreExceptionFactory.GetPiiScrubbedDetails(exception);
+                requestContext.Logger.Error(noPiiMsg);
+                requestContext.Logger.ErrorPii(exception);
+                isRetryable = true;
+                toThrow = exception;
+            }
+
+            if (isRetryable)
+            {
+                if (retry)
+                {
+                    const string msg = "Retrying one more time..";
+                    requestContext.Logger.Info(msg);
+                    requestContext.Logger.InfoPii(msg);
+                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+                    return await ExecuteWithRetryAsync(
+                        endpoint,
+                        headers,
+                        body,
+                        method,
+                        requestContext,
+                        doNotThrow,
+                        retry: false).ConfigureAwait(false);
+                }
+
+                const string message = "Request retry failed.";
+                requestContext.Logger.Info(message);
+                requestContext.Logger.InfoPii(message);
+                if (toThrow != null)
+                {
+                    throw _coreExceptionFactory.GetServiceException(
+                        CoreErrorCodes.RequestTimeout,
+                        "Request to the endpoint timed out.",
+                        toThrow);
+                }
+
+                if (doNotThrow)
+                {
+                    return response;
+                }
+
+                throw _coreExceptionFactory.GetServiceException(
+                        CoreErrorCodes.ServiceNotAvailable,
+                        "Service is unavailable to process the request",
+                        null,
+                        new ExceptionDetail
+                        {
+                            StatusCode = (int)response.StatusCode,
+                            ResponseBody = response.Body,
+                            HttpHeaders = response.HeadersAsDictionary
+                        });
+            }
+
+            return response;
+        }
+
+        private async Task<HttpResponse> ExecuteAsync(
+            Uri endpoint,
+            IDictionary<string, string> headers,
+            HttpContent body,
+            HttpMethod method)
+        {
+            HttpClient client = _httpClientFactory.GetTheHttpClient();
+
+            using (HttpRequestMessage requestMessage = CreateRequestMessage(endpoint, headers))
+            {
+                requestMessage.Method = method;
+                requestMessage.Content = body;
+
+                using (HttpResponseMessage responseMessage =
+                    await client.SendAsync(requestMessage).ConfigureAwait(false))
+                {
+                    HttpResponse returnValue = await CreateResponseAsync(responseMessage).ConfigureAwait(false);
+                    returnValue.UserAgent = client.DefaultRequestHeaders.UserAgent.ToString();
+                    return returnValue;
+                }
+            }
+        }
+
+        private async Task<HttpResponse> CreateResponseAsync(HttpResponseMessage response)
+        {
+            var headers = new Dictionary<string, string>();
+            if (response.Headers != null)
+            {
+                foreach (var kvp in response.Headers)
+                {
+                    headers[kvp.Key] = kvp.Value.First();
+                }
+            }
+
+            return new HttpResponse
+            {
+                Headers = response.Headers,
+                Body = await response.Content.ReadAsStringAsync().ConfigureAwait(false),
+                StatusCode = response.StatusCode
+            };
+        }
+
+        private async Task<HttpContent> CloneHttpContentAsync(HttpContent httpContent)
+        {
+            var temp = new MemoryStream();
+            await httpContent.CopyToAsync(temp).ConfigureAwait(false);
+            temp.Position = 0;
+
+            var clone = new StreamContent(temp);
+            if (httpContent.Headers != null)
+            {
+                foreach (var h in httpContent.Headers)
+                {
+                    clone.Headers.Add(h.Key, h.Value);
+                }
+            }
+
+#if WINDOWS_APP
+            // WORKAROUND 
+            // On UWP there is a bug in the Http stack that causes an exception to be thrown when moving around a stream.
+            // https://stackoverflow.com/questions/31774058/postasync-throwing-irandomaccessstream-error-when-targeting-windows-10-uwp
+            // LoadIntoBufferAsync is necessary to buffer content for multiple reads - see https://stackoverflow.com/questions/26942514/multiple-calls-to-httpcontent-readasasync
+            // Documentation is sparse, but it looks like loading the buffer into memory avoids the bug, without 
+            // replacing the System.Net.HttpClient with Windows.Web.Http.HttpClient, which is not exactly a drop in replacement
+            await clone.LoadIntoBufferAsync().ConfigureAwait(false);
+#endif
+
+            return clone;
+        }
+    }
+}

--- a/core/src/Http/HttpRequest.cs
+++ b/core/src/Http/HttpRequest.cs
@@ -42,24 +42,24 @@ namespace Microsoft.Identity.Core.Http
         {
         }
 
-        public static async Task<HttpResponse> SendPostAsync(Uri endpoint, IDictionary<string, string> headers,
-            IDictionary<string, string> bodyParameters, RequestContext requestContext)
+        public static async Task<HttpResponse> SendPostAsync(
+            Uri endpoint, 
+            IDictionary<string, string> headers,
+            IDictionary<string, string> bodyParameters, 
+            RequestContext requestContext)
         {
-            HttpContent body = null;
-            if (bodyParameters != null)
-            {
-                body = new FormUrlEncodedContent(bodyParameters);
-            }
-            return await SendPostAsync(endpoint, headers, body, requestContext).ConfigureAwait(false);
+            IHttpManager mgr = new HttpManager();
+            return await mgr.SendPostAsync(endpoint, headers, bodyParameters, requestContext).ConfigureAwait(false);
         }
 
-        public static async Task<HttpResponse> SendPostAsync(Uri endpoint, IDictionary<string, string> headers,
-            HttpContent body, RequestContext requestContext)
+        public static async Task<HttpResponse> SendPostAsync(
+            Uri endpoint, 
+            IDictionary<string, string> headers,
+            HttpContent body, 
+            RequestContext requestContext)
         {
-            return
-                await
-                    ExecuteWithRetryAsync(endpoint, headers, body, HttpMethod.Post, requestContext)
-                        .ConfigureAwait(false);
+            IHttpManager mgr = new HttpManager();
+            return await mgr.SendPostAsync(endpoint, headers, body, requestContext).ConfigureAwait(false);
         }
 
         public static async Task<HttpResponse> SendGetAsync(
@@ -67,7 +67,8 @@ namespace Microsoft.Identity.Core.Http
             Dictionary<string, string> headers,
             RequestContext requestContext)
         {
-            return await ExecuteWithRetryAsync(endpoint, headers, null, HttpMethod.Get, requestContext).ConfigureAwait(false);
+            IHttpManager mgr = new HttpManager();
+            return await mgr.SendGetAsync(endpoint, headers, requestContext).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -81,191 +82,8 @@ namespace Microsoft.Identity.Core.Http
             StringContent body, 
             RequestContext requestContext)
         {
-            return await
-                     ExecuteWithRetryAsync(uri, headers, body, HttpMethod.Post, requestContext, doNotThrow: true)
-                         .ConfigureAwait(false);
-        }
-
-        private static HttpRequestMessage CreateRequestMessage(Uri endpoint, IDictionary<string, string> headers)
-        {
-            HttpRequestMessage requestMessage = new HttpRequestMessage { RequestUri = endpoint };
-            requestMessage.Headers.Accept.Clear();
-            if (headers != null)
-            {
-                foreach (KeyValuePair<string, string> kvp in headers)
-                {
-                    requestMessage.Headers.Add(kvp.Key, kvp.Value);
-                }
-            }
-
-            return requestMessage;
-        }
-
-        private static async Task<HttpResponse> ExecuteWithRetryAsync(
-            Uri endpoint, 
-            IDictionary<string, string> headers,
-            HttpContent body, 
-            HttpMethod method,
-            RequestContext requestContext, 
-            bool doNotThrow = false,
-            bool retry = true)
-        {
-            Exception toThrow = null;
-            bool isRetryable = false;
-            HttpResponse response = null;
-            try
-            {
-                HttpContent clonedBody = body;
-                if (body != null)
-                {
-                    // Since HttpContent would be disposed by underlying client.SendAsync(),
-                    // we duplicate it so that we will have a copy in case we would need to retry
-                    clonedBody = await CloneHttpContentAsync(body).ConfigureAwait(false);
-                }
-
-                response = await ExecuteAsync(endpoint, headers, clonedBody, method).ConfigureAwait(false);
-
-                if (response.StatusCode == HttpStatusCode.OK)
-                {
-                    return response;
-                }
-
-                var msg = string.Format(CultureInfo.InvariantCulture,
-                    CoreErrorMessages.HttpRequestUnsuccessful,
-                    (int)response.StatusCode, response.StatusCode);
-                requestContext.Logger.Info(msg);
-                requestContext.Logger.InfoPii(msg);
-
-                if ((int)response.StatusCode >= 500 && (int)response.StatusCode < 600)
-                {
-                    isRetryable = true;
-                }
-            }
-            catch (TaskCanceledException exception)
-            {
-                string noPiiMsg = CoreExceptionFactory.Instance.GetPiiScrubbedDetails(exception);
-                requestContext.Logger.Error(noPiiMsg);
-                requestContext.Logger.ErrorPii(exception);
-                isRetryable = true;
-                toThrow = exception;
-            }
-
-            if (isRetryable)
-            {
-                if (retry)
-                {
-                    const string msg = "Retrying one more time..";
-                    requestContext.Logger.Info(msg);
-                    requestContext.Logger.InfoPii(msg);
-                    await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
-                    return await ExecuteWithRetryAsync(
-                        endpoint, 
-                        headers, 
-                        body, 
-                        method, 
-                        requestContext, 
-                        doNotThrow, 
-                        retry: false).ConfigureAwait(false);
-                }
-
-                const string message = "Request retry failed.";
-                requestContext.Logger.Info(message);
-                requestContext.Logger.InfoPii(message);
-                if (toThrow != null)
-                {
-                    throw CoreExceptionFactory.Instance.GetServiceException(
-                        CoreErrorCodes.RequestTimeout,
-                        "Request to the endpoint timed out.",
-                        toThrow);
-                }
-
-                if (doNotThrow)
-                {
-                    return response;
-                }
-
-                throw CoreExceptionFactory.Instance.GetServiceException(
-                        CoreErrorCodes.ServiceNotAvailable,
-                        "Service is unavailable to process the request",
-                        null,
-                        new ExceptionDetail
-                        {
-                            StatusCode = (int)response.StatusCode,
-                            ResponseBody = response.Body,
-                            HttpHeaders = response.HeadersAsDictionary
-                        });
-            }
-
-            return response;
-        }
-
-        private static async Task<HttpResponse> ExecuteAsync(Uri endpoint, IDictionary<string, string> headers,
-            HttpContent body, HttpMethod method)
-        {
-            HttpClient client = HttpClientFactory.GetHttpClient();
-
-            using (HttpRequestMessage requestMessage = CreateRequestMessage(endpoint, headers))
-            {
-                requestMessage.Method = method;
-                requestMessage.Content = body;
-
-                using (HttpResponseMessage responseMessage =
-                    await client.SendAsync(requestMessage).ConfigureAwait(false))
-                {
-                    HttpResponse returnValue = await CreateResponseAsync(responseMessage).ConfigureAwait(false);
-                    returnValue.UserAgent = client.DefaultRequestHeaders.UserAgent.ToString();
-                    return returnValue;
-                }
-
-            }
-        }
-
-        private static async Task<HttpResponse> CreateResponseAsync(HttpResponseMessage response)
-        {
-            var headers = new Dictionary<string, string>();
-            if (response.Headers != null)
-            {
-                foreach (var kvp in response.Headers)
-                {
-                    headers[kvp.Key] = kvp.Value.First();
-                }
-            }
-
-            return new HttpResponse
-            {
-                Headers = response.Headers,
-                Body = await response.Content.ReadAsStringAsync().ConfigureAwait(false),
-                StatusCode = response.StatusCode
-            };
-        }
-
-
-        private static async Task<HttpContent> CloneHttpContentAsync(HttpContent httpContent)
-        {
-            var temp = new MemoryStream();
-            await httpContent.CopyToAsync(temp).ConfigureAwait(false);
-            temp.Position = 0;
-            
-            var clone = new StreamContent(temp);
-            if (httpContent.Headers != null)
-            {
-                foreach (var h in httpContent.Headers)
-                {
-                    clone.Headers.Add(h.Key, h.Value);
-                }
-            }
-
-#if WINDOWS_APP
-            // WORKAROUND 
-            // On UWP there is a bug in the Http stack that causes an exception to be thrown when moving around a stream.
-            // https://stackoverflow.com/questions/31774058/postasync-throwing-irandomaccessstream-error-when-targeting-windows-10-uwp
-            // LoadIntoBufferAsync is necessary to buffer content for multiple reads - see https://stackoverflow.com/questions/26942514/multiple-calls-to-httpcontent-readasasync
-            // Documentation is sparse, but it looks like loading the buffer into memory avoids the bug, without 
-            // replacing the System.Net.HttpClient with Windows.Web.Http.HttpClient, which is not exactly a drop in replacement
-            await clone.LoadIntoBufferAsync().ConfigureAwait(false);
-#endif
-            
-            return clone;
+            IHttpManager mgr = new HttpManager();
+            return await mgr.SendPostForceResponseAsync(uri, headers, body, requestContext).ConfigureAwait(false);
         }
     }
 }

--- a/core/src/Http/IHttpManager.cs
+++ b/core/src/Http/IHttpManager.cs
@@ -1,0 +1,60 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Core.Http
+{
+    internal interface IHttpManager
+    {
+        Task<HttpResponse> SendPostAsync(
+            Uri endpoint,
+            IDictionary<string, string> headers,
+            IDictionary<string, string> bodyParameters,
+            RequestContext requestContext);
+
+        Task<HttpResponse> SendPostAsync(
+            Uri endpoint,
+            IDictionary<string, string> headers,
+            HttpContent body,
+            RequestContext requestContext);
+
+        Task<HttpResponse> SendGetAsync(
+            Uri endpoint,
+            Dictionary<string, string> headers,
+            RequestContext requestContext);
+
+        Task<IHttpWebResponse> SendPostForceResponseAsync(
+            Uri uri,
+            Dictionary<string, string> headers,
+            StringContent body,
+            RequestContext requestContext);
+    }
+}


### PR DESCRIPTION
Create a new class, HttpManager and its corresponding interface, IHttpManager.  The intent is to replace the static HttpRequest class with this object and bound usage of this to IHttpManager so we can simplify our http layer mocking.  This currently gets us a non-static version of HttpManager and places its implementation under HttpRequest's static calls as the first step.