### PR TITLE
Improving the XML comments around device code flow

### DIFF
--- a/msal/src/Microsoft.Identity.Client/Features/DeviceCode/DeviceCodeResult.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/DeviceCode/DeviceCodeResult.cs
@@ -39,8 +39,9 @@ namespace Microsoft.Identity.Client
     /// to be entered on that device.
     /// See https://aka.ms/msal-device-code-flow.
     /// </summary>
-    /// <seealso cref="PublicClientApplication.AcquireTokenWithDeviceCodeAsync(IEnumerable{string}, Func{DeviceCodeResult, System.Threading.Tasks.Task})" and
-    /// the other overrides/>
+    /// <seealso cref="PublicClientApplication.AcquireTokenWithDeviceCodeAsync(IEnumerable{string}, Func{DeviceCodeResult, System.Threading.Tasks.Task})"> and
+    /// the other overrides
+    /// </seealso>
     public class DeviceCodeResult
     {
         internal DeviceCodeResult(

--- a/msal/src/Microsoft.Identity.Client/Features/DeviceCode/DeviceCodeResult.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/DeviceCode/DeviceCodeResult.cs
@@ -35,9 +35,12 @@ namespace Microsoft.Identity.Client
     /// <summary>
     /// This object is returned as part of the device code flow
     /// and has information intended to be shown to the user about
-    /// where to navigate to login and what the device code is that needs
-    /// to be entered.
+    /// where to navigate to login and what the device code needs
+    /// to be entered on that device.
+    /// See https://aka.ms/msal-device-code-flow.
     /// </summary>
+    /// <seealso cref="PublicClientApplication.AcquireTokenWithDeviceCodeAsync(IEnumerable{string}, Func{DeviceCodeResult, System.Threading.Tasks.Task})" and
+    /// the other overrides/>
     public class DeviceCodeResult
     {
         internal DeviceCodeResult(
@@ -96,7 +99,7 @@ namespace Microsoft.Identity.Client
         public string ClientId { get; }
 
         /// <summary>
-        /// List of the scopes that would be the recipient of the token.
+        /// List of the scopes that would be held by token.
         /// </summary>
         public IReadOnlyCollection<string> Scopes { get; }
     }

--- a/msal/src/Microsoft.Identity.Client/Features/DeviceCode/IPublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/DeviceCode/IPublicClientApplication.cs
@@ -40,59 +40,89 @@ namespace Microsoft.Identity.Client
     public partial interface IPublicClientApplication : IClientApplicationBase
     {
         /// <summary>
-        /// Acquires device code from the authority and returns it to the caller via
-        /// the deviceCodeResultCallback. The function then proceeds to poll for the security
-        /// token which is granted upon successful login based on the device code information.
+        /// Acquires a security token on a device without a Web browser, by letting the user authenticate on 
+        /// another device. This is done in two steps:
+        /// <list type="bullet">
+        /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
+        /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
+        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// <item><description>The method then proceeds to poll for the security
+        /// token which is granted upon successful login by the user based on the device code information</description></item>
+        /// </list>
         /// See https://aka.ms/msal-device-code-flow.
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
-        /// <param name="deviceCodeResultCallback">The callback containing information to show the user about how to authenticate and enter the device code.</param>
-        /// <returns>Authentication result containing a token for the requested scopes and account</returns>
+        /// <param name="deviceCodeResultCallback">Callback containing information to show the user about how to authenticate and enter the device code.</param>
+        /// <returns>Authentication result containing a token for the requested scopes and for the user who has authenticated on another device with the code</returns>
+
         Task<AuthenticationResult> AcquireTokenWithDeviceCodeAsync(
             IEnumerable<string> scopes,
             Func<DeviceCodeResult, Task> deviceCodeResultCallback);
 
         /// <summary>
-        /// Acquires device code from the authority and returns it to the caller via
-        /// the deviceCodeResultCallback. The function then proceeds to poll for the security
-        /// token which is granted upon successful login based on the device code information.
+        /// Acquires a security token on a device without a Web browser, by letting the user authenticate on 
+        /// another device, with possiblity of passing extra parameters. This is done in two steps:
+        /// <list type="bullet">
+        /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
+        /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
+        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// <item><description>The method then proceeds to poll for the security
+        /// token which is granted upon successful login by the user based on the device code information</description></item>
+        /// </list>
         /// See https://aka.ms/msal-device-code-flow.
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
-        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
-        /// <param name="deviceCodeResultCallback">The callback containing information to show the user about how to authenticate and enter the device code.</param>
-        /// <returns>Authentication result containing a token for the requested scopes and account</returns>
+        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. 
+        /// This is expected to be a string of segments of the form <c>key=value</c> separated by an ampersand character.
+        /// The parameter can be null.</param>
+        /// <param name="deviceCodeResultCallback">Callback containing information to show the user about how to authenticate and enter the device code.</param>
+        /// <returns>Authentication result containing a token for the requested scopes and for the user who has authenticated on another device with the code</returns>
+
         Task<AuthenticationResult> AcquireTokenWithDeviceCodeAsync(
             IEnumerable<string> scopes,
             string extraQueryParameters,
             Func<DeviceCodeResult, Task> deviceCodeResultCallback);
 
         /// <summary>
-        /// Acquires device code from the authority and returns it to the caller via
-        /// the deviceCodeResultCallback. The function then proceeds to poll for the security
-        /// token which is granted upon successful login based on the device code information.
+        /// Acquires a security token on a device without a Web browser, by letting the user authenticate on 
+        /// another device, with possiblity of cancelling the token acquisition before it times out. This is done in two steps:
+        /// <list type="bullet">
+        /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
+        /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
+        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// <item><description>The method then proceeds to poll for the security
+        /// token which is granted upon successful login by the user based on the device code information. This step is cancelable</description></item>
+        /// </list>
         /// See https://aka.ms/msal-device-code-flow.
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
         /// <param name="deviceCodeResultCallback">The callback containing information to show the user about how to authenticate and enter the device code.</param>
         /// <param name="cancellationToken">A CancellationToken which can be triggered to cancel the operation in progress.</param>
-        /// <returns>Authentication result containing a token for the requested scopes and account</returns>
+        /// <returns>Authentication result containing a token for the requested scopes and for the user who has authenticated on another device with the code</returns>
         Task<AuthenticationResult> AcquireTokenWithDeviceCodeAsync(
             IEnumerable<string> scopes,
             Func<DeviceCodeResult, Task> deviceCodeResultCallback,
             CancellationToken cancellationToken);
 
         /// <summary>
-        /// Acquires device code from the authority and returns it to the caller via
-        /// the deviceCodeResultCallback. The function then proceeds to poll for the security
-        /// token which is granted upon successful login based on the device code information.
+        /// Acquires a security token on a device without a Web browser, by letting the user authenticate on 
+        /// another device, with possiblity of passing extra query parameters and cancelling the token acquisition before it times out. This is done in two steps:
+        /// <list type="bullet">
+        /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
+        /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
+        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// <item><description>The method then proceeds to poll for the security
+        /// token which is granted upon successful login by the user based on the device code information. This step is cancelable</description></item>
+        /// </list>
         /// See https://aka.ms/msal-device-code-flow.
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
-        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
+        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. 
+        /// This is expected to be a string of segments of the form <c>key=value</c> separated by an ampersand character.
+        /// The parameter can be null.</param>
         /// <param name="deviceCodeResultCallback">The callback containing information to show the user about how to authenticate and enter the device code.</param>
         /// <param name="cancellationToken">A CancellationToken which can be triggered to cancel the operation in progress.</param>
-        /// <returns>Authentication result containing a token for the requested scopes and account</returns>
+        /// <returns>Authentication result containing a token for the requested scopes and for the user who has authenticated on another device with the code</returns>
         Task<AuthenticationResult> AcquireTokenWithDeviceCodeAsync(
             IEnumerable<string> scopes,
             string extraQueryParameters,

--- a/msal/src/Microsoft.Identity.Client/Features/DeviceCode/IPublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/DeviceCode/IPublicClientApplication.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Identity.Client
         /// <list type="bullet">
         /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
         /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
-        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// to direct them to authenticate (to a specific URL, with a code)</description></item>
         /// <item><description>The method then proceeds to poll for the security
         /// token which is granted upon successful login by the user based on the device code information</description></item>
         /// </list>
@@ -65,7 +65,7 @@ namespace Microsoft.Identity.Client
         /// <list type="bullet">
         /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
         /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
-        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// to direct them to authenticate (to a specific URL, with a code)</description></item>
         /// <item><description>The method then proceeds to poll for the security
         /// token which is granted upon successful login by the user based on the device code information</description></item>
         /// </list>
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Client
         /// <list type="bullet">
         /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
         /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
-        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// to direct them to authenticate (to a specific URL, with a code)</description></item>
         /// <item><description>The method then proceeds to poll for the security
         /// token which is granted upon successful login by the user based on the device code information. This step is cancelable</description></item>
         /// </list>
@@ -110,7 +110,7 @@ namespace Microsoft.Identity.Client
         /// <list type="bullet">
         /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
         /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
-        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// to direct them to authenticate (to a specific URL, with a code)</description></item>
         /// <item><description>The method then proceeds to poll for the security
         /// token which is granted upon successful login by the user based on the device code information. This step is cancelable</description></item>
         /// </list>

--- a/msal/src/Microsoft.Identity.Client/Features/DeviceCode/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/DeviceCode/PublicClientApplication.cs
@@ -37,14 +37,20 @@ namespace Microsoft.Identity.Client
     public sealed partial class PublicClientApplication : ClientApplicationBase
     {
         /// <summary>
-        /// Acquires device code from the authority and returns it to the caller via
-        /// the deviceCodeResultCallback. The function then proceeds to poll for the security
-        /// token which is granted upon successful login based on the device code information.
+        /// Acquires a security token on a device without a Web browser, by letting the user authenticate on 
+        /// another device. This is done in two steps:
+        /// <list type="bullet">
+        /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
+        /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
+        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// <item><description>The method then proceeds to poll for the security
+        /// token which is granted upon successful login by the user based on the device code information</description></item>
+        /// </list>
         /// See https://aka.ms/msal-device-code-flow.
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
-        /// <param name="deviceCodeResultCallback">The callback containing information to show the user about how to authenticate and enter the device code.</param>
-        /// <returns></returns>
+        /// <param name="deviceCodeResultCallback">Callback containing information to show the user about how to authenticate and enter the device code.</param>
+        /// <returns>Authentication result containing a token for the requested scopes and for the user who has authenticated on another device with the code</returns>
         public Task<AuthenticationResult> AcquireTokenWithDeviceCodeAsync(
             IEnumerable<string> scopes,
             Func<DeviceCodeResult, Task> deviceCodeResultCallback)
@@ -53,15 +59,23 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Acquires device code from the authority and returns it to the caller via
-        /// the deviceCodeResultCallback. The function then proceeds to poll for the security
-        /// token which is granted upon successful login based on the device code information.
+        /// Acquires a security token on a device without a Web browser, by letting the user authenticate on 
+        /// another device, with possiblity of passing extra parameters. This is done in two steps:
+        /// <list type="bullet">
+        /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
+        /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
+        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// <item><description>The method then proceeds to poll for the security
+        /// token which is granted upon successful login by the user based on the device code information</description></item>
+        /// </list>
         /// See https://aka.ms/msal-device-code-flow.
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
-        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
-        /// <param name="deviceCodeResultCallback">The callback containing information to show the user about how to authenticate and enter the device code.</param>
-        /// <returns></returns>
+        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. 
+        /// This is expected to be a string of segments of the form <c>key=value</c> separated by an ampersand character.
+        /// The parameter can be null.</param>
+        /// <param name="deviceCodeResultCallback">Callback containing information to show the user about how to authenticate and enter the device code.</param>
+        /// <returns>Authentication result containing a token for the requested scopes and for the user who has authenticated on another device with the code</returns>
         public async Task<AuthenticationResult> AcquireTokenWithDeviceCodeAsync(
             IEnumerable<string> scopes,
             string extraQueryParameters,
@@ -80,15 +94,21 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Acquires device code from the authority and returns it to the caller via
-        /// the deviceCodeResultCallback. The function then proceeds to poll for the security
-        /// token which is granted upon successful login based on the device code information.
+        /// Acquires a security token on a device without a Web browser, by letting the user authenticate on 
+        /// another device, with possiblity of cancelling the token acquisition before it times out. This is done in two steps:
+        /// <list type="bullet">
+        /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
+        /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
+        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// <item><description>The method then proceeds to poll for the security
+        /// token which is granted upon successful login by the user based on the device code information. This step is cancelable</description></item>
+        /// </list>
         /// See https://aka.ms/msal-device-code-flow.
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
         /// <param name="deviceCodeResultCallback">The callback containing information to show the user about how to authenticate and enter the device code.</param>
         /// <param name="cancellationToken">A CancellationToken which can be triggered to cancel the operation in progress.</param>
-        /// <returns></returns>
+        /// <returns>Authentication result containing a token for the requested scopes and for the user who has authenticated on another device with the code</returns>
         public Task<AuthenticationResult> AcquireTokenWithDeviceCodeAsync(
             IEnumerable<string> scopes,
             Func<DeviceCodeResult, Task> deviceCodeResultCallback,
@@ -98,16 +118,24 @@ namespace Microsoft.Identity.Client
         }
 
         /// <summary>
-        /// Acquires device code from the authority and returns it to the caller via
-        /// the deviceCodeResultCallback. The function then proceeds to poll for the security
-        /// token which is granted upon successful login based on the device code information.
+        /// Acquires a security token on a device without a Web browser, by letting the user authenticate on 
+        /// another device, with possiblity of passing extra query parameters and cancelling the token acquisition before it times out. This is done in two steps:
+        /// <list type="bullet">
+        /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
+        /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
+        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// <item><description>The method then proceeds to poll for the security
+        /// token which is granted upon successful login by the user based on the device code information. This step is cancelable</description></item>
+        /// </list>
         /// See https://aka.ms/msal-device-code-flow.
         /// </summary>
         /// <param name="scopes">Scopes requested to access a protected API</param>
-        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. The parameter can be null.</param>
+        /// <param name="extraQueryParameters">This parameter will be appended as is to the query string in the HTTP authentication request to the authority. 
+        /// This is expected to be a string of segments of the form <c>key=value</c> separated by an ampersand character.
+        /// The parameter can be null.</param>
         /// <param name="deviceCodeResultCallback">The callback containing information to show the user about how to authenticate and enter the device code.</param>
         /// <param name="cancellationToken">A CancellationToken which can be triggered to cancel the operation in progress.</param>
-        /// <returns></returns>
+        /// <returns>Authentication result containing a token for the requested scopes and for the user who has authenticated on another device with the code</returns>
         public async Task<AuthenticationResult> AcquireTokenWithDeviceCodeAsync(
             IEnumerable<string> scopes,
             string extraQueryParameters,

--- a/msal/src/Microsoft.Identity.Client/Features/DeviceCode/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/DeviceCode/PublicClientApplication.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Client
         /// <list type="bullet">
         /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
         /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
-        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// to direct them to authenticate (to a specific URL, with a code)</description></item>
         /// <item><description>The method then proceeds to poll for the security
         /// token which is granted upon successful login by the user based on the device code information</description></item>
         /// </list>
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Client
         /// <list type="bullet">
         /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
         /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
-        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// to direct them to authenticate (to a specific URL, with a code)</description></item>
         /// <item><description>The method then proceeds to poll for the security
         /// token which is granted upon successful login by the user based on the device code information</description></item>
         /// </list>
@@ -99,7 +99,7 @@ namespace Microsoft.Identity.Client
         /// <list type="bullet">
         /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
         /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
-        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// to direct them to authenticate (to a specific URL, with a code)</description></item>
         /// <item><description>The method then proceeds to poll for the security
         /// token which is granted upon successful login by the user based on the device code information. This step is cancelable</description></item>
         /// </list>
@@ -123,7 +123,7 @@ namespace Microsoft.Identity.Client
         /// <list type="bullet">
         /// <item><description>the method first acquires a device code from the authority and returns it to the caller via
         /// the <paramref name="deviceCodeResultCallback"/>. This callback takes care of interacting with the user
-        /// to direct him to authenticate (to a specific URL, with a code)</description></item>
+        /// to direct them to authenticate (to a specific URL, with a code)</description></item>
         /// <item><description>The method then proceeds to poll for the security
         /// token which is granted upon successful login by the user based on the device code information. This step is cancelable</description></item>
         /// </list>

--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -51,9 +51,7 @@ namespace Microsoft.Identity.Client
     /// <item><description>Contrary to <see cref="Microsoft.Identity.Client.ConfidentialClientApplication"/>, public clients are unable to hold configuration time secrets, 
     /// and as a result have no client secret</description></item>
     /// <item><description>the redirect URL is pre-proposed by the library. It does not need to be passed in the constructor</description></item>
-    /// <item><description>.NET Core does not support UI, and therefore this platform does not provide the interactive token acquisition methods. Actually
-    /// until MSAL.NET supports Windows integrated authentication, Username/Password, and Device Code Flow, the .NET Core platform does not
-    /// provide any public client application flows</description></item>
+    /// <item><description>.NET Core does not support UI, and therefore this platform does not provide the interactive token acquisition methods</description></item>
     /// </list>
     /// </remarks>
     public sealed partial class PublicClientApplication : ClientApplicationBase, IPublicClientApplication
@@ -126,7 +124,7 @@ namespace Microsoft.Identity.Client
 
 #if WINDOWS_APP
         /// <summary>
-        /// Flag to enable authentication with the user currently logeed-in in Windows.
+        /// Flag to enable authentication with the user currently logged-in in Windows.
         /// When set to true, the application will try to connect to the corporate network using windows integrated authentication.
         /// </summary>
         public bool UseCorporateNetwork { get; set; }


### PR DESCRIPTION
Improving the XML comments around device code flow
Also removing the explanation for the empty PublicClientApplication on .NET core as we now have all the flows