### PR TITLE
Remove static initializer race condition

### DIFF
--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/ModuleInitializer.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/ModuleInitializer.cs
@@ -84,7 +84,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
             CoreLoggerBase.Default = new AdalLogger(Guid.Empty);
             CoreExceptionFactory.Instance = new AdalExceptionFactory();
             CoreTelemetryService.InitializeCoreTelemetryService(Telemetry.GetInstance() as ITelemetry);
-            CorePlatformInformationBase.Instance = new PlatformInformation();
             isInitialized = true;
         }
     }

--- a/core/src/CorePlatformInformationBase.cs
+++ b/core/src/CorePlatformInformationBase.cs
@@ -26,14 +26,11 @@
 //------------------------------------------------------------------------------
 
 using System;
-using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Core
 {
     internal abstract class CorePlatformInformationBase
     {
-        public static CorePlatformInformationBase Instance { get; set; }
-
         public const string DefaultRedirectUri = "urn:ietf:wg:oauth:2.0:oob";
         public abstract string GetProductName();
 

--- a/core/src/Instance/AadAuthority.cs
+++ b/core/src/Instance/AadAuthority.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Core.Instance
 
         public const string AADCanonicalAuthorityTemplate = "https://{0}/{1}/";
 
-        internal AadAuthority(string authority, bool validateAuthority) : base(authority, validateAuthority)
+        internal AadAuthority(CorePlatformInformationBase platformInformation, string authority, bool validateAuthority) : base(platformInformation, authority, validateAuthority)
         {
             AuthorityType = AuthorityType.Aad;
         }
@@ -61,7 +61,7 @@ namespace Microsoft.Identity.Core.Instance
         internal override async Task UpdateCanonicalAuthorityAsync(RequestContext requestContext)
         {
             var metadata = await AadInstanceDiscovery.Instance.
-                GetMetadataEntryAsync(new Uri(CanonicalAuthority), this.ValidateAuthority, requestContext).ConfigureAwait(false);
+                GetMetadataEntryAsync(PlatformInformation, new Uri(CanonicalAuthority), this.ValidateAuthority, requestContext).ConfigureAwait(false);
 
             CanonicalAuthority = UpdateHost(CanonicalAuthority, metadata.PreferredNetwork);
         }
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Core.Instance
             {
                 InstanceDiscoveryResponse discoveryResponse =
                     await AadInstanceDiscovery.Instance.
-                    DoInstanceDiscoveryAndCacheAsync(authorityUri, true, requestContext).ConfigureAwait(false);
+                    DoInstanceDiscoveryAndCacheAsync(PlatformInformation, authorityUri, true, requestContext).ConfigureAwait(false);
 
                 return discoveryResponse.TenantDiscoveryEndpoint;
             }

--- a/core/src/Instance/AdfsAuthority.cs
+++ b/core/src/Instance/AdfsAuthority.cs
@@ -41,9 +41,9 @@ namespace Microsoft.Identity.Core.Instance
     {
         private const string DefaultRealm = "http://schemas.microsoft.com/rel/trusted-realm";
         
-
         private readonly HashSet<string> _validForDomainsList = new HashSet<string>();
-        public AdfsAuthority(string authority, bool validateAuthority) : base(authority, validateAuthority)
+        public AdfsAuthority(CorePlatformInformationBase platformInformation, string authority, bool validateAuthority) 
+            : base(platformInformation, authority, validateAuthority)
         {
             AuthorityType = AuthorityType.Adfs;
         }
@@ -157,7 +157,7 @@ namespace Microsoft.Identity.Core.Instance
 
         private async Task<DrsMetadataResponse> QueryEnrollmentServerEndpointAsync(string endpoint, RequestContext requestContext)
         {
-            OAuth2Client client = new OAuth2Client();
+            OAuth2Client client = new OAuth2Client(PlatformInformation);
             client.AddQueryParameter("api-version", "1.0");
             return await client.ExecuteRequestAsync<DrsMetadataResponse>(new Uri(endpoint), HttpMethod.Get, requestContext).ConfigureAwait(false);
         }

--- a/core/src/Instance/B2CAuthority.cs
+++ b/core/src/Instance/B2CAuthority.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Identity.Core.Instance
         public const string Prefix = "tfp"; // The http path of B2C authority looks like "/tfp/<your_tenant_name>/..."
         public const string B2CCanonicalAuthorityTemplate = "https://{0}/{1}/{2}/{3}/";
 
-        internal B2CAuthority(string authority, bool validateAuthority) : base(authority, validateAuthority)
+        internal B2CAuthority(CorePlatformInformationBase platformInformation, string authority, bool validateAuthority) : base(platformInformation, authority, validateAuthority)
         {
             Uri authorityUri = new Uri(authority);
             string[] pathSegments = authorityUri.AbsolutePath.Substring(1).Split(new [] { '/'}, StringSplitOptions.RemoveEmptyEntries);

--- a/core/src/MsalIdHelper.cs
+++ b/core/src/MsalIdHelper.cs
@@ -66,22 +66,15 @@ namespace Microsoft.Identity.Core
     /// </summary>
     internal static class MsalIdHelper
     {
-        private static CorePlatformInformationBase corePlatformInformationBaseInstance;
-
-        static MsalIdHelper()
+        public static IDictionary<string, string> GetMsalIdParameters(CorePlatformInformationBase platformInformation)
         {
-            corePlatformInformationBaseInstance = CorePlatformInformationBase.Instance;
-        }
-
-        public static IDictionary<string, string> GetMsalIdParameters()
-        {
-            if (corePlatformInformationBaseInstance == null)
+            if (platformInformation == null)
             {
                 throw CoreExceptionFactory.Instance.GetClientException(CoreErrorCodes.PlatformNotSupported, CoreErrorMessages.PlatformNotSupported);
             }
             var parameters = new Dictionary<string, string>
             {
-                [MsalIdParameter.Product] = corePlatformInformationBaseInstance.GetProductName(),
+                [MsalIdParameter.Product] = platformInformation.GetProductName(),
                 [MsalIdParameter.Version] = GetMsalVersion()
             };
 
@@ -120,18 +113,6 @@ namespace Microsoft.Identity.Core
             }
 
             return null;
-        }
-
-        public static string GetAssemblyFileVersion()
-        {
-            return corePlatformInformationBaseInstance.GetAssemblyFileVersionAttribute();
-        }
-
-        public static string GetAssemblyInformationalVersion()
-        {
-            AssemblyInformationalVersionAttribute attribute =
-                typeof (MsalIdHelper).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-            return (attribute != null) ? attribute.InformationalVersion : string.Empty;
         }
     }
 }

--- a/core/src/OAuth2/OAuth2Client.cs
+++ b/core/src/OAuth2/OAuth2Client.cs
@@ -42,11 +42,13 @@ namespace Microsoft.Identity.Core.OAuth2
     internal class OAuth2Client
     {
         private readonly Dictionary<string, string> _bodyParameters = new Dictionary<string, string>();
-
-        private readonly Dictionary<string, string> _headers =
-            new Dictionary<string, string>(MsalIdHelper.GetMsalIdParameters());
-
+        private readonly Dictionary<string, string> _headers;
         private readonly Dictionary<string, string> _queryParameters = new Dictionary<string, string>();
+
+        public OAuth2Client(CorePlatformInformationBase platformInformation)
+        {
+            _headers = new Dictionary<string, string>(MsalIdHelper.GetMsalIdParameters(platformInformation));
+        }
 
         public void AddQueryParameter(string key, string value)
         {

--- a/core/src/Telemetry/DefaultEvent.cs
+++ b/core/src/Telemetry/DefaultEvent.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Identity.Core.Telemetry
 {
     internal class DefaultEvent : EventBase
     {
-        public DefaultEvent(string clientId) : base((string) (EventBase.EventNamePrefix + "default_event"))
+        public DefaultEvent(CorePlatformInformationBase platformInformation, string clientId) : base((string) (EventBase.EventNamePrefix + "default_event"))
         {
             this[EventNamePrefix + "client_id"] = clientId;
-            this[EventNamePrefix + "sdk_platform"] = CorePlatformInformationBase.Instance.GetProductName()?.ToLowerInvariant();
+            this[EventNamePrefix + "sdk_platform"] = platformInformation.GetProductName()?.ToLowerInvariant();
             this[EventNamePrefix + "sdk_version"] = MsalIdHelper.GetMsalVersion();
         }
     }

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/InstanceTests/AadAuthorityTests.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/InstanceTests/AadAuthorityTests.cs
@@ -89,7 +89,7 @@ namespace Test.Microsoft.Identity.Unit.InstanceTests
                 ResponseMessage = MockHelpers.CreateSuccessResponseMessage(File.ReadAllText("OpenidConfiguration.json"))
             });
 
-            Authority instance = Authority.CreateAuthority("https://login.microsoftonline.in/mytenant.com", true);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), "https://login.microsoftonline.in/mytenant.com", true);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Aad);
             Task.Run(async () =>
@@ -121,7 +121,7 @@ namespace Test.Microsoft.Identity.Unit.InstanceTests
                 ResponseMessage = MockHelpers.CreateSuccessResponseMessage(File.ReadAllText("OpenidConfiguration.json"))
             });
 
-            Authority instance = Authority.CreateAuthority("https://login.microsoftonline.in/mytenant.com", false);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), "https://login.microsoftonline.in/mytenant.com", false);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Aad);
             Task.Run(async () =>
@@ -168,7 +168,7 @@ namespace Test.Microsoft.Identity.Unit.InstanceTests
                                                                                 "4fa2-4f35-a59b-54b6f91a9c94\"}")
             });
 
-            Authority instance = Authority.CreateAuthority("https://login.microsoft0nline.com/mytenant.com", true);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), "https://login.microsoft0nline.com/mytenant.com", true);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Aad);
             try
@@ -207,7 +207,7 @@ namespace Test.Microsoft.Identity.Unit.InstanceTests
                 ResponseMessage = MockHelpers.CreateSuccessResponseMessage("{}")
             });
 
-            Authority instance = Authority.CreateAuthority("https://login.microsoft0nline.com/mytenant.com", true);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), "https://login.microsoft0nline.com/mytenant.com", true);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Aad);
             try
@@ -241,7 +241,7 @@ namespace Test.Microsoft.Identity.Unit.InstanceTests
                     MockHelpers.CreateSuccessResponseMessage(File.ReadAllText("OpenidConfiguration-MissingFields.json"))
             });
 
-            Authority instance = Authority.CreateAuthority("https://login.microsoftonline.in/mytenant.com", false);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), "https://login.microsoftonline.in/mytenant.com", false);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Aad);
             try
@@ -274,13 +274,13 @@ namespace Test.Microsoft.Identity.Unit.InstanceTests
             const string uriCustomPort = "https://login.microsoftonline.in:444/mytenant.com";
             const string uriCustomPortTailSlash = "https://login.microsoftonline.in:444/mytenant.com/";
 
-            var authority = Authority.CreateAuthority(uriNoPort, false);
+            var authority = Authority.CreateAuthority(new TestPlatformInformation(), uriNoPort, false);
             Assert.AreEqual(uriNoPortTailSlash, authority.CanonicalAuthority);
 
-            authority = Authority.CreateAuthority(uriDefaultPort, false);
+            authority = Authority.CreateAuthority(new TestPlatformInformation(), uriDefaultPort, false);
             Assert.AreEqual(uriNoPortTailSlash, authority.CanonicalAuthority);
 
-            authority = Authority.CreateAuthority(uriCustomPort, false);
+            authority = Authority.CreateAuthority(new TestPlatformInformation(), uriCustomPort, false);
             Assert.AreEqual(uriCustomPortTailSlash, authority.CanonicalAuthority);
         }
 

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/InstanceTests/AdfsAuthorityTests.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/InstanceTests/AdfsAuthorityTests.cs
@@ -102,7 +102,7 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
                 ResponseMessage = MockHelpers.CreateSuccessResponseMessage(File.ReadAllText("OpenidConfiguration-OnPremise.json"))
             });
 
-            Authority instance = Authority.CreateAuthority(TestConstants.OnPremiseAuthority, true);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.OnPremiseAuthority, true);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Adfs);
             Task.Run(async () =>
@@ -120,7 +120,7 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
             Assert.AreEqual(1, Authority.ValidatedAuthorities.Count);
 
             //attempt to do authority validation again. NO network call should be made
-            instance = Authority.CreateAuthority(TestConstants.OnPremiseAuthority, true);
+            instance = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.OnPremiseAuthority, true);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Adfs);
             Task.Run(async () =>
@@ -186,7 +186,7 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
                 ResponseMessage = MockHelpers.CreateSuccessResponseMessage(File.ReadAllText("OpenidConfiguration-OnPremise.json"))
             });
 
-            Authority instance = Authority.CreateAuthority(TestConstants.OnPremiseAuthority, true);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.OnPremiseAuthority, true);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Adfs);
             Task.Run(async () =>
@@ -215,7 +215,7 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
                 ResponseMessage = MockHelpers.CreateSuccessResponseMessage(File.ReadAllText("OpenidConfiguration-OnPremise.json"))
             });
 
-            Authority instance = Authority.CreateAuthority(TestConstants.OnPremiseAuthority, false);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.OnPremiseAuthority, false);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Adfs);
             Task.Run(async () =>
@@ -262,7 +262,7 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
                 ResponseMessage = MockHelpers.CreateFailureMessage(HttpStatusCode.NotFound, "not-found")
             });
 
-            Authority instance = Authority.CreateAuthority(TestConstants.OnPremiseAuthority, true);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.OnPremiseAuthority, true);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Adfs);
             try
@@ -311,7 +311,7 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
                 ResponseMessage = MockHelpers.CreateSuccessWebFingerResponseMessage("https://fs.some-other-sts.com")
             });
 
-            Authority instance = Authority.CreateAuthority(TestConstants.OnPremiseAuthority, true);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.OnPremiseAuthority, true);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Adfs);
             try
@@ -346,7 +346,7 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
                 ResponseMessage = MockHelpers.CreateSuccessResponseMessage(File.ReadAllText("drs-response-missing-field.json"))
             });
 
-            Authority instance = Authority.CreateAuthority(TestConstants.OnPremiseAuthority, true);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.OnPremiseAuthority, true);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Adfs);
             try
@@ -377,7 +377,7 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
                 ResponseMessage = MockHelpers.CreateSuccessResponseMessage(File.ReadAllText("OpenidConfiguration-MissingFields-OnPremise.json"))
             });
 
-            Authority instance = Authority.CreateAuthority(TestConstants.OnPremiseAuthority, false);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.OnPremiseAuthority, false);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.Adfs);
             try

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/InstanceTests/B2cAuthorityTests.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/InstanceTests/B2cAuthorityTests.cs
@@ -60,7 +60,7 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
         {
             try
             {
-                Authority instance = Authority.CreateAuthority("https://login.microsoftonline.in/tfp/", false);
+                Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), "https://login.microsoftonline.in/tfp/", false);
                 Assert.IsNotNull(instance);
                 Assert.AreEqual(instance.AuthorityType, AuthorityType.B2C);
                 Task
@@ -81,7 +81,7 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
         [TestCategory("B2CAuthorityTests")]
         public void ValidationEnabledNotSupportedTest()
         {
-            Authority instance = Authority.CreateAuthority(TestConstants.B2CAuthority, true);
+            Authority instance = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.B2CAuthority, true);
             Assert.IsNotNull(instance);
             Assert.AreEqual(instance.AuthorityType, AuthorityType.B2C);
             try
@@ -112,13 +112,13 @@ namespace Test.Microsoft.Identity.Core.Unit.InstanceTests
             const string uriCustomPort = "https://login.microsoftonline.in:444/tfp/tenant/policy";
             const string uriCustomPortTailSlash = "https://login.microsoftonline.in:444/tfp/tenant/policy/";
 
-            var authority = new B2CAuthority(uriNoPort, false);
+            var authority = new B2CAuthority(new TestPlatformInformation(), uriNoPort, false);
             Assert.AreEqual(uriNoPortTailSlash, authority.CanonicalAuthority);
 
-            authority = new B2CAuthority(uriDefaultPort, false);
+            authority = new B2CAuthority(new TestPlatformInformation(), uriDefaultPort, false);
             Assert.AreEqual(uriNoPortTailSlash, authority.CanonicalAuthority);
 
-            authority = new B2CAuthority(uriCustomPort, false);
+            authority = new B2CAuthority(new TestPlatformInformation(), uriCustomPort, false);
             Assert.AreEqual(uriCustomPortTailSlash, authority.CanonicalAuthority);
         }
     }

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/OAuth2Tests/TokenResponseTests.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/OAuth2Tests/TokenResponseTests.cs
@@ -77,7 +77,7 @@ namespace Test.Microsoft.Identity.Unit.OAuth2Tests
                 ResponseMessage =
                     MockHelpers.CreateSuccessTokenResponseMessage()
             });
-            OAuth2Client client = new OAuth2Client();
+            OAuth2Client client = new OAuth2Client(new TestPlatformInformation());
             Task<MsalTokenResponse> task = client.GetTokenAsync(new Uri(TestConstants.AuthorityCommonTenant), new RequestContext(new TestLogger(Guid.NewGuid(), null)));
             MsalTokenResponse response = task.Result;
             Assert.IsNotNull(response);

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/TestPlatformInformation.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/TestPlatformInformation.cs
@@ -25,22 +25,12 @@
 //
 //------------------------------------------------------------------------------
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Microsoft.Identity.Core;
 
 namespace Test.Microsoft.Identity.Core.Unit
 {
     class TestPlatformInformation : CorePlatformInformationBase
     {
-        static TestPlatformInformation()
-        {
-            Instance = new TestPlatformInformation();
-        }
-
         public override string GetProductName()
         {
             return null;

--- a/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -102,12 +102,10 @@ namespace Microsoft.Identity.Client
 
             RequestContext requestContext = new RequestContext(new MsalLogger(Guid.Empty, null));
 
-            var platformInformation = new PlatformInformation();
-
             requestContext.Logger.Info(string.Format(CultureInfo.InvariantCulture,
                 "MSAL {0} with assembly version '{1}', file version '{2}' and informational version '{3}' is running...",
-                new PlatformInformation().GetProductName(), MsalIdHelper.GetMsalVersion(),
-                platformInformation.GetAssemblyFileVersionAttribute(), GetAssemblyInformationalVersion()));
+                PlatformInformation.GetProductName(), MsalIdHelper.GetMsalVersion(),
+                PlatformInformation.GetAssemblyFileVersionAttribute(), GetAssemblyInformationalVersion()));
         }
 
         private static string GetAssemblyInformationalVersion()

--- a/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/ClientApplicationBase.cs
@@ -32,6 +32,7 @@ using System.Threading.Tasks;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Requests;
 using System.Linq;
+using System.Reflection;
 using Microsoft.Identity.Core;
 using Microsoft.Identity.Core.Instance;
 using Microsoft.Identity.Core.Helpers;
@@ -50,7 +51,13 @@ namespace Microsoft.Identity.Client
     public abstract partial class ClientApplicationBase
 #pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     {
+        static ClientApplicationBase()
+        {
+            ModuleInitializer.EnsureModuleInitialized();
+        }
+
         private TokenCache userTokenCache;
+        internal CorePlatformInformationBase PlatformInformation { get; }
 
         /// <Summary>
         /// Default Authority used for interactive calls.
@@ -81,8 +88,10 @@ namespace Microsoft.Identity.Client
         protected ClientApplicationBase(string clientId, string authority, string redirectUri,
             bool validateAuthority)
         {
+            PlatformInformation = new PlatformInformation();
+
             ClientId = clientId;
-            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, validateAuthority);
+            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(PlatformInformation, authority, validateAuthority);
             Authority = authorityInstance.CanonicalAuthority;
             RedirectUri = redirectUri;
             ValidateAuthority = validateAuthority;
@@ -93,10 +102,19 @@ namespace Microsoft.Identity.Client
 
             RequestContext requestContext = new RequestContext(new MsalLogger(Guid.Empty, null));
 
+            var platformInformation = new PlatformInformation();
+
             requestContext.Logger.Info(string.Format(CultureInfo.InvariantCulture,
                 "MSAL {0} with assembly version '{1}', file version '{2}' and informational version '{3}' is running...",
                 new PlatformInformation().GetProductName(), MsalIdHelper.GetMsalVersion(),
-                MsalIdHelper.GetAssemblyFileVersion(), MsalIdHelper.GetAssemblyInformationalVersion()));
+                platformInformation.GetAssemblyFileVersionAttribute(), GetAssemblyInformationalVersion()));
+        }
+
+        private static string GetAssemblyInformationalVersion()
+        {
+            AssemblyInformationalVersionAttribute attribute =
+                typeof(ClientApplicationBase).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+            return (attribute != null) ? attribute.InformationalVersion : string.Empty;
         }
 
         /// <summary>
@@ -180,7 +198,7 @@ namespace Microsoft.Identity.Client
                 requestContext.Logger.Info("Token cache is null or empty. Returning empty list of accounts.");
                 return Enumerable.Empty<Account>();
             }
-            return await UserTokenCache.GetAccountsAsync(Authority, ValidateAuthority, requestContext).ConfigureAwait(false);
+            return await UserTokenCache.GetAccountsAsync(PlatformInformation, Authority, ValidateAuthority, requestContext).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -247,7 +265,7 @@ namespace Microsoft.Identity.Client
             Authority authorityInstance = null;
             if (!string.IsNullOrEmpty(authority))
             {
-                authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
+                authorityInstance = Core.Instance.Authority.CreateAuthority(PlatformInformation, authority, ValidateAuthority);
             }
 
             return
@@ -268,12 +286,12 @@ namespace Microsoft.Identity.Client
                 return;
             }
 
-            await UserTokenCache.RemoveAsync(Authority, ValidateAuthority, account, requestContext).ConfigureAwait(false);
+            await UserTokenCache.RemoveAsync(PlatformInformation, Authority, ValidateAuthority, account, requestContext).ConfigureAwait(false);
         }
 
         internal Authority GetAuthority(IAccount account)
         {
-            var authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            var authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             var tenantId = authority.GetTenantId();
 
             if (Core.Instance.Authority.TenantlessTenantNames.Contains(tenantId)

--- a/msal/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/ConfidentialClient/ConfidentialClientApplication.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Identity.Client
         /// <seealso cref="AcquireTokenOnBehalfOfAsync(IEnumerable{string}, UserAssertion, string)"/> for the on-behalf-of flow when specifying the authority
         public async Task<AuthenticationResult> AcquireTokenOnBehalfOfAsync(IEnumerable<string> scopes, UserAssertion userAssertion)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenOnBehalfCommonAsync(authority, scopes, userAssertion, ApiEvent.ApiIds.AcquireTokenOnBehalfOfWithScopeUser, false)
@@ -162,7 +162,7 @@ namespace Microsoft.Identity.Client
         public async Task<AuthenticationResult> AcquireTokenOnBehalfOfAsync(IEnumerable<string> scopes, UserAssertion userAssertion,
             string authority)
         {
-            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
+            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(PlatformInformation, authority, ValidateAuthority);
             return
                 await
                     AcquireTokenOnBehalfCommonAsync(authorityInstance, scopes, userAssertion, ApiEvent.ApiIds.AcquireTokenOnBehalfOfWithScopeUserAuthority, false)
@@ -182,7 +182,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing a token for the requested scopes and account</returns>
         async Task<AuthenticationResult> IConfidentialClientApplicationWithCertificate.AcquireTokenOnBehalfOfWithCertificateAsync(IEnumerable<string> scopes, UserAssertion userAssertion)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenOnBehalfCommonAsync(authority, scopes, userAssertion, ApiEvent.ApiIds.AcquireTokenOnBehalfOfWithScopeUser, true)
@@ -204,7 +204,7 @@ namespace Microsoft.Identity.Client
         async Task<AuthenticationResult> IConfidentialClientApplicationWithCertificate.AcquireTokenOnBehalfOfWithCertificateAsync(IEnumerable<string> scopes, UserAssertion userAssertion,
             string authority)
         {
-            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
+            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(PlatformInformation, authority, ValidateAuthority);
             return
                 await
                     AcquireTokenOnBehalfCommonAsync(authorityInstance, scopes, userAssertion, ApiEvent.ApiIds.AcquireTokenOnBehalfOfWithScopeUserAuthority, true)
@@ -313,7 +313,7 @@ namespace Microsoft.Identity.Client
         public async Task<Uri> GetAuthorizationRequestUrlAsync(IEnumerable<string> scopes, string loginHint,
             string extraQueryParameters)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             var requestParameters =
                 CreateRequestParameters(authority, scopes, null, UserTokenCache);
             requestParameters.ClientId = ClientId;
@@ -343,7 +343,7 @@ namespace Microsoft.Identity.Client
         public async Task<Uri> GetAuthorizationRequestUrlAsync(IEnumerable<string> scopes, string redirectUri, string loginHint,
             string extraQueryParameters, IEnumerable<string> extraScopesToConsent, string authority)
         {
-            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
+            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(PlatformInformation, authority, ValidateAuthority);
             var requestParameters = CreateRequestParameters(authorityInstance, scopes, null,
                 UserTokenCache);
             requestParameters.RedirectUri = new Uri(redirectUri);
@@ -361,7 +361,7 @@ namespace Microsoft.Identity.Client
 
         private async Task<AuthenticationResult> AcquireTokenForClientCommonAsync(IEnumerable<string> scopes, bool forceRefresh, ApiEvent.ApiIds apiId, bool sendCertificate)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             AuthenticationRequestParameters parameters = CreateRequestParameters(authority, scopes, null,
                 AppTokenCache);
             parameters.IsClientCredentialRequest = true;
@@ -383,7 +383,7 @@ namespace Microsoft.Identity.Client
         private async Task<AuthenticationResult> AcquireTokenByAuthorizationCodeCommonAsync(string authorizationCode,
             IEnumerable<string> scopes, Uri redirectUri, ApiEvent.ApiIds apiId, bool sendCertificate)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             var requestParams = CreateRequestParameters(authority, scopes, null, UserTokenCache);
             requestParams.AuthorizationCode = authorizationCode;
             requestParams.RedirectUri = redirectUri;

--- a/msal/src/Microsoft.Identity.Client/Features/DeviceCode/DeviceCodeRequest.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/DeviceCode/DeviceCodeRequest.cs
@@ -32,6 +32,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Client.Internal.Requests;
 using Microsoft.Identity.Core.Helpers;
 using Microsoft.Identity.Core.OAuth2;
@@ -59,7 +60,7 @@ namespace Microsoft.Identity.Client.Features.DeviceCode
         {
             await base.PreTokenRequestAsync(cancellationToken).ConfigureAwait(false);
 
-            OAuth2Client client = new OAuth2Client();
+            OAuth2Client client = new OAuth2Client(PlatformInformation);
 
             var deviceCodeScopes = new HashSet<string>();
             deviceCodeScopes.UnionWith(AuthenticationRequestParameters.Scope);

--- a/msal/src/Microsoft.Identity.Client/Features/DeviceCode/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/DeviceCode/PublicClientApplication.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Identity.Client
             Func<DeviceCodeResult, Task> deviceCodeResultCallback,
             CancellationToken cancellationToken)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
 
             var requestParams = CreateRequestParameters(authority, scopes, null, UserTokenCache);
             requestParams.ExtraQueryParameters = extraQueryParameters;

--- a/msal/src/Microsoft.Identity.Client/Features/IntegratedWindowsAuth/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/IntegratedWindowsAuth/PublicClientApplication.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Identity.Client
 
         private async Task<AuthenticationResult> AcquireTokenByIWAAsync(IEnumerable<string> scopes, IntegratedWindowsAuthInput iwaInput)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             var requestParams = CreateRequestParameters(authority, scopes, null, UserTokenCache);
             var handler = new IntegratedWindowsAuthRequest(requestParams, iwaInput)
             {

--- a/msal/src/Microsoft.Identity.Client/Features/PublicClientWithTokenCache/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/PublicClientWithTokenCache/PublicClientApplication.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Identity.Client
         /// <param name="authority">Default authority to be used for the application</param>
         /// <param name="userTokenCache">Instance of TokenCache.</param>
         public PublicClientApplication(string clientId, string authority, TokenCache userTokenCache) : base(clientId,
-            authority, PlatformPlugin.PlatformInformation.GetDefaultRedirectUri(clientId), true)
+            authority, new PlatformInformation().GetDefaultRedirectUri(clientId), true)
         {
             UserTokenCache = userTokenCache;
         }

--- a/msal/src/Microsoft.Identity.Client/Features/UsernamePassword/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/UsernamePassword/PublicClientApplication.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Identity.Client
 
         private async Task<AuthenticationResult> AcquireTokenByUsernamePasswordAsync(IEnumerable<string> scopes, UsernamePasswordInput usernamePasswordInput)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             var requestParams = CreateRequestParameters(authority, scopes, null, UserTokenCache);
             var handler = new UsernamePasswordRequest(requestParams, usernamePasswordInput)
             {

--- a/msal/src/Microsoft.Identity.Client/Internal/ModuleInitializer.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/ModuleInitializer.cs
@@ -81,7 +81,6 @@ namespace Microsoft.Identity.Client.Internal
             CoreExceptionFactory.Instance = new MsalExceptionFactory();
             CoreTelemetryService.InitializeCoreTelemetryService(Telemetry.GetInstance() as ITelemetry);
             CoreLoggerBase.Default = new MsalLogger(Guid.Empty, null);
-            CorePlatformInformationBase.Instance = new PlatformInformation();
             isInitialized = true;
         }
     }

--- a/msal/src/Microsoft.Identity.Client/Internal/MsalLogger.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/MsalLogger.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Identity.Client.Internal
                 ? string.Empty
                 : " - " + CorrelationId;
 
-            var msalIdParameters = MsalIdHelper.GetMsalIdParameters();
+            var msalIdParameters = MsalIdHelper.GetMsalIdParameters(new PlatformInformation());
             string os = "N/A";
             if (msalIdParameters.ContainsKey(MsalIdParameter.OS))
             {
@@ -157,7 +157,21 @@ namespace Microsoft.Identity.Client.Internal
 
             if (Logger.DefaultLoggingEnabled)
             {
-                PlatformPlugin.LogMessage(Logger.Level, log);
+                switch (Logger.Level)
+                {
+                    case LogLevel.Error:
+                        PlatformLogger.Error(log);
+                        break;
+                    case LogLevel.Warning:
+                        PlatformLogger.Warning(log);
+                        break;
+                    case LogLevel.Info:
+                        PlatformLogger.Information(log);
+                        break;
+                    case LogLevel.Verbose:
+                        PlatformLogger.Verbose(log);
+                        break;
+                }
             }
 
             ExecuteCallback(msalLogLevel, log, isLoggingPii);

--- a/msal/src/Microsoft.Identity.Client/Internal/PlatformInformationBase.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/PlatformInformationBase.cs
@@ -25,25 +25,17 @@
 //
 //------------------------------------------------------------------------------
 
-using System;
 using System.Reflection;
-using System.Threading.Tasks;
 using Microsoft.Identity.Core;
 
 namespace Microsoft.Identity.Client.Internal
 {
     internal abstract class PlatformInformationBase : CorePlatformInformationBase
     {
-           
-        static PlatformInformationBase()
-        {
-            Instance = new PlatformInformation();
-        }
-
         public override string GetAssemblyFileVersionAttribute()
         {
             return
-                typeof (MsalIdHelper).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
+                typeof(MsalIdHelper).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyFileVersionAttribute>().Version;
         }
     }
 }

--- a/msal/src/Microsoft.Identity.Client/Internal/PlatformPlugin.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/PlatformPlugin.cs
@@ -31,46 +31,25 @@ namespace Microsoft.Identity.Client.Internal
 {
     internal static class PlatformPlugin
     {
-        static PlatformPlugin()
+        public static IWebUIFactory GetWebUiFactory()
         {
-            ModuleInitializer.EnsureModuleInitialized();
-            InitializeWebFactoryAndPlatform();
-        }
-
-        public static IWebUIFactory WebUIFactory { get; set; }
-        
-        public static PlatformInformationBase PlatformInformation { get; set; }
-
-        private static void InitializeWebFactoryAndPlatform()
-        {
-            IWebUIFactory webUIFactory = null;
+            if (_overloadWebUiFactory != null)
+            {
+                return _overloadWebUiFactory;
+            }
 
 #if ANDROID || iOS
-            webUIFactory = new Microsoft.Identity.Core.UI.WebUIFactory();
+            return new Microsoft.Identity.Core.UI.WebUIFactory();
 #else
-            webUIFactory = new UI.WebUIFactory();
+            return new UI.WebUIFactory();
 #endif
-            WebUIFactory = webUIFactory;
-            PlatformInformation = new PlatformInformation();
         }
 
-        public static void LogMessage(LogLevel logLevel, string formattedMessage)
+        private static IWebUIFactory _overloadWebUiFactory = null;
+        
+        public static void SetWebUiFactory(IWebUIFactory webUiFactory)
         {
-            switch (logLevel)
-            {
-                case LogLevel.Error:
-                    PlatformLogger.Error(formattedMessage);
-                    break;
-                case LogLevel.Warning:
-                    PlatformLogger.Warning(formattedMessage);
-                    break;
-                case LogLevel.Info:
-                    PlatformLogger.Information(formattedMessage);
-                    break;
-                case LogLevel.Verbose:
-                    PlatformLogger.Verbose(formattedMessage);
-                    break;
-            }
+            _overloadWebUiFactory = webUiFactory;
         }
     }
 }

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/AuthorizationCodeRequest.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/AuthorizationCodeRequest.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 throw new ArgumentNullException(nameof(authenticationRequestParameters.AuthorizationCode));
             }
 
-            PlatformPlugin.PlatformInformation.ValidateRedirectUri(authenticationRequestParameters.RedirectUri,
+            PlatformInformation.ValidateRedirectUri(authenticationRequestParameters.RedirectUri,
                 AuthenticationRequestParameters.RequestContext);
             if (!string.IsNullOrWhiteSpace(authenticationRequestParameters.RedirectUri.Fragment))
             {

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/ClientCredentialRequest.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (!ForceRefresh && LoadFromCache)
             {
                 MsalAccessTokenItem
-                    = await TokenCache.FindAccessTokenAsync(AuthenticationRequestParameters).ConfigureAwait(false);
+                    = await TokenCache.FindAccessTokenAsync(PlatformInformation, AuthenticationRequestParameters).ConfigureAwait(false);
             }
         }
         protected override async Task SendTokenRequestAsync(CancellationToken cancellationToken)

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/InteractiveRequest.cs
@@ -234,7 +234,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
                 authorizationRequestParameters[OAuth2Parameter.CorrelationId] = AuthenticationRequestParameters.RequestContext.Logger.CorrelationId.ToString();
             }
 
-            foreach (var kvp in MsalIdHelper.GetMsalIdParameters())
+            foreach (var kvp in MsalIdHelper.GetMsalIdParameters(PlatformInformation))
             {
                 authorizationRequestParameters[kvp.Key] = kvp.Value;
             }

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/OnBehalfOfRequest.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (LoadFromCache)
             {
                 MsalAccessTokenItem = 
-                    await TokenCache.FindAccessTokenAsync(AuthenticationRequestParameters).ConfigureAwait(false);
+                    await TokenCache.FindAccessTokenAsync(PlatformInformation, AuthenticationRequestParameters).ConfigureAwait(false);
             }
         }
 

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -42,10 +42,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 {
     internal abstract class RequestBase
     {
-        static RequestBase()
-        {
-            PlatformPlugin.PlatformInformation = new PlatformInformation();
-        }
+        internal CorePlatformInformationBase PlatformInformation => new PlatformInformation();
 
         protected static readonly Task CompletedTask = Task.FromResult(false);
         internal AuthenticationRequestParameters AuthenticationRequestParameters { get; }
@@ -231,7 +228,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             {
                 AuthenticationRequestParameters.RequestContext.Logger.Info("Saving Token Response to cache..");
 
-                var tuple = TokenCache.SaveAccessAndRefreshToken(AuthenticationRequestParameters, Response);
+                var tuple = TokenCache.SaveAccessAndRefreshToken(PlatformInformation, AuthenticationRequestParameters, Response);
                 MsalAccessTokenItem = tuple.Item1;
                 MsalIdTokenItem = tuple.Item2;
             }
@@ -284,7 +281,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
         protected virtual async Task SendTokenRequestAsync(CancellationToken cancellationToken)
         {
-            OAuth2Client client = new OAuth2Client();
+            OAuth2Client client = new OAuth2Client(PlatformInformation);
             client.AddBodyParameter(OAuth2Parameter.ClientId, AuthenticationRequestParameters.ClientId);
             client.AddBodyParameter(OAuth2Parameter.ClientInfo, "1");
             foreach (var entry in AuthenticationRequestParameters.ToParameters())

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/SilentRequest.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
 
             //look for access token.
             MsalAccessTokenItem
-                = await TokenCache.FindAccessTokenAsync(AuthenticationRequestParameters).ConfigureAwait(false);
+                = await TokenCache.FindAccessTokenAsync(PlatformInformation, AuthenticationRequestParameters).ConfigureAwait(false);
             if (MsalAccessTokenItem != null)
             {
                 MsalIdTokenItem = TokenCache.GetIdTokenCacheItem(MsalAccessTokenItem.GetIdTokenItemKey(), AuthenticationRequestParameters.RequestContext);
@@ -78,7 +78,7 @@ namespace Microsoft.Identity.Client.Internal.Requests
             if (MsalAccessTokenItem == null)
             {
                 _msalRefreshTokenItem =
-                    await TokenCache.FindRefreshTokenAsync(AuthenticationRequestParameters).ConfigureAwait(false);
+                    await TokenCache.FindRefreshTokenAsync(PlatformInformation, AuthenticationRequestParameters).ConfigureAwait(false);
 
                 if (_msalRefreshTokenItem == null)
                 {

--- a/msal/src/Microsoft.Identity.Client/Platforms/Android/PlatformInformation.cs
+++ b/msal/src/Microsoft.Identity.Client/Platforms/Android/PlatformInformation.cs
@@ -50,8 +50,10 @@ namespace Microsoft.Identity.Client
             base.ValidateRedirectUri(redirectUri, requestContext);
 
             if (DefaultRedirectUri.Equals(redirectUri.AbsoluteUri, StringComparison.OrdinalIgnoreCase))
+            {
                 throw new MsalException(MsalError.RedirectUriValidationFailed, "Default redirect URI - " + PlatformInformationBase.DefaultRedirectUri +
-                                        " can not be used on Android platform");
+                                                                               " can not be used on Android platform");
+            }
         }
 
         public override string GetDefaultRedirectUri(string clientId)

--- a/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/PublicClientApplication.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Identity.Client
         /// Note that this setting needs to be consistent with what is declared in the application registration portal 
         /// </param>
         public PublicClientApplication(string clientId, string authority)
-            : base(clientId, authority, PlatformPlugin.PlatformInformation.GetDefaultRedirectUri(clientId), true)
+            : base(clientId, authority, new PlatformInformation().GetDefaultRedirectUri(clientId), true)
         {
             UserTokenCache = new TokenCache()
             {
@@ -140,7 +140,7 @@ namespace Microsoft.Identity.Client
         /// and will consent to scopes and do multi-factor authentication if such a policy was enabled in the Azure AD tenant.</remarks>
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForLoginHintCommonAsync(authority, scopes, null, null,
@@ -156,7 +156,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing a token for the requested scopes and account</returns>
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, string loginHint)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForLoginHintCommonAsync(authority, scopes, null, loginHint,
@@ -174,7 +174,7 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes,
             IAccount account)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForUserCommonAsync(authority, scopes, null, account,
@@ -194,7 +194,7 @@ namespace Microsoft.Identity.Client
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, string loginHint,
             UIBehavior behavior, string extraQueryParameters)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForLoginHintCommonAsync(authority, scopes, null, loginHint,
@@ -214,7 +214,7 @@ namespace Microsoft.Identity.Client
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IAccount account,
             UIBehavior behavior, string extraQueryParameters)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForUserCommonAsync(authority, scopes, null, account, behavior,
@@ -238,7 +238,7 @@ namespace Microsoft.Identity.Client
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, string loginHint,
             UIBehavior behavior, string extraQueryParameters, IEnumerable<string> extraScopesToConsent, string authority)
         {
-            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
+            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(PlatformInformation, authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForLoginHintCommonAsync(authorityInstance, scopes, extraScopesToConsent,
@@ -262,7 +262,7 @@ namespace Microsoft.Identity.Client
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IAccount account,
             UIBehavior behavior, string extraQueryParameters, IEnumerable<string> extraScopesToConsent, string authority)
         {
-            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
+            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(PlatformInformation, authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForUserCommonAsync(authorityInstance, scopes, extraScopesToConsent, account,
@@ -281,7 +281,7 @@ namespace Microsoft.Identity.Client
         /// and will consent to scopes and do multi-factor authentication if such a policy was enabled in the Azure AD tenant.</remarks>
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, UIParent parent)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForLoginHintCommonAsync(authority, scopes, null, null,
@@ -299,7 +299,7 @@ namespace Microsoft.Identity.Client
         /// <returns>Authentication result containing a token for the requested scopes and login</returns>
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, string loginHint, UIParent parent)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForLoginHintCommonAsync(authority, scopes, null, loginHint,
@@ -318,7 +318,7 @@ namespace Microsoft.Identity.Client
             IEnumerable<string> scopes,
             IAccount account, UIParent parent)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForUserCommonAsync(authority, scopes, null, account,
@@ -339,7 +339,7 @@ namespace Microsoft.Identity.Client
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, string loginHint,
             UIBehavior behavior, string extraQueryParameters, UIParent parent)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForLoginHintCommonAsync(authority, scopes, null, loginHint,
@@ -360,7 +360,7 @@ namespace Microsoft.Identity.Client
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IAccount account,
             UIBehavior behavior, string extraQueryParameters, UIParent parent)
         {
-            Authority authority = Core.Instance.Authority.CreateAuthority(Authority, ValidateAuthority);
+            Authority authority = Core.Instance.Authority.CreateAuthority(PlatformInformation, Authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForUserCommonAsync(authority, scopes, null, account, behavior,
@@ -385,7 +385,7 @@ namespace Microsoft.Identity.Client
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, string loginHint,
             UIBehavior behavior, string extraQueryParameters, IEnumerable<string> extraScopesToConsent, string authority, UIParent parent)
         {
-            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
+            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(PlatformInformation, authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForLoginHintCommonAsync(authorityInstance, scopes, extraScopesToConsent,
@@ -410,7 +410,7 @@ namespace Microsoft.Identity.Client
         public async Task<AuthenticationResult> AcquireTokenAsync(IEnumerable<string> scopes, IAccount account,
         UIBehavior behavior, string extraQueryParameters, IEnumerable<string> extraScopesToConsent, string authority, UIParent parent)
         {
-            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(authority, ValidateAuthority);
+            Authority authorityInstance = Core.Instance.Authority.CreateAuthority(PlatformInformation, authority, ValidateAuthority);
             return
                 await
                     AcquireTokenForUserCommonAsync(authorityInstance, scopes, extraScopesToConsent, account,
@@ -435,7 +435,7 @@ namespace Microsoft.Identity.Client
 #endif
 #endif
 
-            return PlatformPlugin.WebUIFactory.CreateAuthenticationDialog(parent.CoreUIParent, requestContext);
+            return PlatformPlugin.GetWebUiFactory().CreateAuthenticationDialog(parent.CoreUIParent, requestContext);
         }
 
         private async Task<AuthenticationResult> AcquireTokenForLoginHintCommonAsync(Authority authority, IEnumerable<string> scopes,
@@ -448,7 +448,7 @@ namespace Microsoft.Identity.Client
 #if iOS || ANDROID
             if (!parent.CoreUIParent.UseEmbeddedWebview)
             {
-                PlatformPlugin.PlatformInformation.ValidateRedirectUri(requestParams.RedirectUri, requestParams.RequestContext);
+                PlatformInformation.ValidateRedirectUri(requestParams.RedirectUri, requestParams.RequestContext);
             }
 #endif
 
@@ -468,7 +468,7 @@ namespace Microsoft.Identity.Client
 #if iOS || ANDROID
             if (!parent.CoreUIParent.UseEmbeddedWebview)
             {
-                PlatformPlugin.PlatformInformation.ValidateRedirectUri(requestParams.RedirectUri, requestParams.RequestContext);
+                PlatformInformation.ValidateRedirectUri(requestParams.RedirectUri, requestParams.RequestContext);
             }
 #endif
 

--- a/msal/src/Microsoft.Identity.Client/Telemetry.cs
+++ b/msal/src/Microsoft.Identity.Client/Telemetry.cs
@@ -187,7 +187,7 @@ namespace Microsoft.Identity.Client
 
             if (eventsToFlush.Count > 0)
             {
-                eventsToFlush.Insert(0, new DefaultEvent(ClientId));
+                eventsToFlush.Insert(0, new DefaultEvent(new PlatformInformation(), ClientId));
                 _receiver(eventsToFlush.Cast<Dictionary<string, string>>().ToList());
             }
         }

--- a/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/CacheTests/TokenCacheTests.cs
@@ -126,11 +126,11 @@ namespace Test.MSAL.NET.Unit.CacheTests
             atItem.Secret = atKey;
 
             cache.tokenCacheAccessor.AccessTokenCacheDictionary[atKey] = JsonHelper.SerializeToJson(atItem);
-            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(new AuthenticationRequestParameters()
+            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(new TestPlatformInformation(), new AuthenticationRequestParameters()
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityTestTenant, false),
                 Scope = TestConstants.Scope,
                 Account = TestConstants.User
             }).Result;
@@ -168,13 +168,13 @@ namespace Test.MSAL.NET.Unit.CacheTests
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityTestTenant, false),
                 Scope = new SortedSet<string>(),
                 Account = TestConstants.User
             };
 
             param.Scope.Add("r1/scope1");
-            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(param).Result;
+            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(new TestPlatformInformation(), param).Result;
 
             Assert.IsNotNull(item);
             Assert.AreEqual(atKey.ToString(), item.Secret);
@@ -210,14 +210,14 @@ namespace Test.MSAL.NET.Unit.CacheTests
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 Scope = new SortedSet<string>(),
                 Account = new Account(TestConstants.UserIdentifier, TestConstants.DisplayableId, null)
             };
 
             param.Scope.Add(TestConstants.Scope.First());
             param.Scope.Add("non-existant-scopes");
-            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(param).Result;
+            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(new TestPlatformInformation(), param).Result;
 
             //intersected scopes are not returned.
             Assert.IsNull(item);
@@ -246,11 +246,11 @@ namespace Test.MSAL.NET.Unit.CacheTests
             cache.tokenCacheAccessor.AccessTokenCacheDictionary[atItem.GetKey().ToString()] =
                 JsonHelper.SerializeToJson(atItem);
 
-        Assert.IsNull(cache.FindAccessTokenAsync(new AuthenticationRequestParameters()
+        Assert.IsNull(cache.FindAccessTokenAsync(new TestPlatformInformation(), new AuthenticationRequestParameters()
         {
             RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
             ClientId = TestConstants.ClientId,
-            Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
+            Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityTestTenant, false),
             Scope = TestConstants.Scope,
             Account = new Account(TestConstants.UserIdentifier, TestConstants.DisplayableId, null)
             }).Result);
@@ -279,11 +279,11 @@ namespace Test.MSAL.NET.Unit.CacheTests
             cache.tokenCacheAccessor.AccessTokenCacheDictionary[atItem.GetKey().ToString()] =
                 JsonHelper.SerializeToJson(atItem);
 
-            Assert.IsNull(cache.FindAccessTokenAsync(new AuthenticationRequestParameters()
+            Assert.IsNull(cache.FindAccessTokenAsync(new TestPlatformInformation(), new AuthenticationRequestParameters()
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityTestTenant, false),
                 Scope = TestConstants.Scope,
                 Account = new Account(TestConstants.UserIdentifier, TestConstants.DisplayableId, null)
             }).Result);
@@ -307,20 +307,20 @@ namespace Test.MSAL.NET.Unit.CacheTests
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 Scope = TestConstants.Scope,
                 Account = TestConstants.User
             };
-            Assert.IsNotNull(cache.FindRefreshTokenAsync(authParams));
+            Assert.IsNotNull(cache.FindRefreshTokenAsync(new TestPlatformInformation(), authParams));
 
             // RT is stored by environment, client id and userIdentifier as index.
             // any change to authority (within same environment), uniqueid and displyableid will not 
             // change the outcome of cache look up.
-            Assert.IsNotNull(cache.FindRefreshTokenAsync(new AuthenticationRequestParameters()
+            Assert.IsNotNull(cache.FindRefreshTokenAsync(new TestPlatformInformation(), new AuthenticationRequestParameters()
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant + "more", false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant + "more", false),
                 Scope = TestConstants.Scope,
                 Account = TestConstants.User
             }));
@@ -343,11 +343,11 @@ namespace Test.MSAL.NET.Unit.CacheTests
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 Scope = TestConstants.Scope,
                 Account = TestConstants.User
             };
-            var rt = cache.FindRefreshTokenAsync(authParams).Result;
+            var rt = cache.FindRefreshTokenAsync(new TestPlatformInformation(), authParams).Result;
             Assert.IsNull(rt);
         }
 
@@ -376,11 +376,11 @@ namespace Test.MSAL.NET.Unit.CacheTests
             cache.tokenCacheAccessor.AccessTokenCacheDictionary[atItem.GetKey().ToString()] =
                 JsonHelper.SerializeToJson(atItem);
 
-            MsalAccessTokenCacheItem cacheItem = cache.FindAccessTokenAsync(new AuthenticationRequestParameters()
+            MsalAccessTokenCacheItem cacheItem = cache.FindAccessTokenAsync(new TestPlatformInformation(), new AuthenticationRequestParameters()
             {
                 IsClientCredentialRequest = true,
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityTestTenant, false),
                 ClientId = TestConstants.ClientId,
                 ClientCredential = TestConstants.CredentialWithSecret,
                 Scope = TestConstants.Scope
@@ -411,14 +411,14 @@ namespace Test.MSAL.NET.Unit.CacheTests
             AuthenticationRequestParameters requestParams = new AuthenticationRequestParameters()
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
-                Authority = Authority.CreateAuthority(TestConstants.B2CAuthority, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.B2CAuthority, false),
                 ClientId = TestConstants.ClientId,
                 TenantUpdatedCanonicalAuthority = TestConstants.AuthorityTestTenant
             };
 
             AddHostToInstanceCache(TestConstants.ProductionPrefNetworkEnvironment);
 
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
 
             Assert.AreEqual(1, cache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
             Assert.AreEqual(1, cache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -459,12 +459,12 @@ namespace Test.MSAL.NET.Unit.CacheTests
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 Scope = TestConstants.Scope,
                 UserAssertion = new UserAssertion(CoreCryptographyHelpers.CreateBase64UrlEncodedSha256Hash(atKey.ToString()))
             };
 
-            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(param).Result;
+            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(new TestPlatformInformation(), param).Result;
 
             //cache lookup should fail because there was no userassertion hash in the matched
             //token cache item.
@@ -503,12 +503,12 @@ namespace Test.MSAL.NET.Unit.CacheTests
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 Scope = TestConstants.Scope,
                 UserAssertion = new UserAssertion(atItem.UserAssertionHash + "-random")
             };
 
-            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(param).Result;
+            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(new TestPlatformInformation(), param).Result;
 
             // cache lookup should fail because there was userassertion hash did not match the one
             // stored in token cache item.
@@ -545,13 +545,13 @@ namespace Test.MSAL.NET.Unit.CacheTests
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityTestTenant, false),
                 Scope = TestConstants.Scope,
                 UserAssertion = new UserAssertion(atKey.ToString())
             };
 
             cache.AfterAccess = AfterAccessNoChangeNotification;
-            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(param).Result;
+            MsalAccessTokenCacheItem item = cache.FindAccessTokenAsync(new TestPlatformInformation(), param).Result;
 
             Assert.IsNotNull(item);
             Assert.AreEqual(atKey.ToString(), item.Secret);
@@ -578,14 +578,14 @@ namespace Test.MSAL.NET.Unit.CacheTests
             AuthenticationRequestParameters requestParams = new AuthenticationRequestParameters()
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 ClientId = TestConstants.ClientId,
                 TenantUpdatedCanonicalAuthority = TestConstants.AuthorityTestTenant
             };
 
             AddHostToInstanceCache(TestConstants.ProductionPrefNetworkEnvironment);
 
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
 
             Assert.AreEqual(1, cache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
             Assert.AreEqual(1, cache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -615,14 +615,14 @@ namespace Test.MSAL.NET.Unit.CacheTests
             AuthenticationRequestParameters requestParams = new AuthenticationRequestParameters()
             {
                 RequestContext = requestContext,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 ClientId = TestConstants.ClientId,
                 TenantUpdatedCanonicalAuthority = TestConstants.AuthorityTestTenant
             };
 
             AddHostToInstanceCache(TestConstants.ProductionPrefNetworkEnvironment);
 
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
 
             Assert.AreEqual(1, cache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
             Assert.AreEqual(1, cache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -637,7 +637,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
             response.Scope = TestConstants.Scope.AsSingleString() + " another-scope";
             response.TokenType = "Bearer";
 
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
 
             Assert.AreEqual(1, cache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
             Assert.AreEqual(1, cache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -669,14 +669,14 @@ namespace Test.MSAL.NET.Unit.CacheTests
             AuthenticationRequestParameters requestParams = new AuthenticationRequestParameters()
             {
                 RequestContext = requestContext,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 ClientId = TestConstants.ClientId,
                 TenantUpdatedCanonicalAuthority = TestConstants.AuthorityTestTenant
             };
 
             AddHostToInstanceCache(TestConstants.ProductionPrefNetworkEnvironment);
 
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
 
             response = new MsalTokenResponse();
             response.IdToken = MockHelpers.CreateIdToken(TestConstants.UniqueId, TestConstants.DisplayableId);
@@ -688,7 +688,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
             response.Scope = TestConstants.Scope.First();
             response.TokenType = "Bearer";
 
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
 
             Assert.AreEqual(1, cache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
             Assert.AreEqual(1, cache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -721,14 +721,14 @@ namespace Test.MSAL.NET.Unit.CacheTests
             AuthenticationRequestParameters requestParams = new AuthenticationRequestParameters()
             {
                 RequestContext = requestContext,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 ClientId = TestConstants.ClientId,
                 TenantUpdatedCanonicalAuthority = TestConstants.AuthorityTestTenant
             };
 
             AddHostToInstanceCache(TestConstants.ProductionPrefNetworkEnvironment);
 
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
 
             response = new MsalTokenResponse
             {
@@ -742,7 +742,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 TokenType = "Bearer"
             };
 
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
 
             Assert.AreEqual(1, cache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
             Assert.AreEqual(1, cache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);
@@ -774,14 +774,14 @@ namespace Test.MSAL.NET.Unit.CacheTests
             AuthenticationRequestParameters requestParams = new AuthenticationRequestParameters()
             {
                 RequestContext = requestContext,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 ClientId = TestConstants.ClientId,
                 TenantUpdatedCanonicalAuthority = TestConstants.AuthorityHomeTenant
             };
 
             AddHostToInstanceCache(TestConstants.ProductionPrefNetworkEnvironment);
 
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
 
             response = new MsalTokenResponse();
             response.IdToken = MockHelpers.CreateIdToken(TestConstants.UniqueId, TestConstants.DisplayableId);
@@ -798,13 +798,13 @@ namespace Test.MSAL.NET.Unit.CacheTests
             requestParams = new AuthenticationRequestParameters()
             {
                 RequestContext = requestContext,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityGuestTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityGuestTenant, false),
                 ClientId = TestConstants.ClientId,
                 TenantUpdatedCanonicalAuthority = TestConstants.AuthorityGuestTenant
             };
 
             cache.SetAfterAccess(AfterAccessChangedNotification);
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
             Assert.IsFalse(cache.HasStateChanged);
 
             Assert.AreEqual(1, cache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
@@ -846,14 +846,14 @@ namespace Test.MSAL.NET.Unit.CacheTests
             AuthenticationRequestParameters requestParams = new AuthenticationRequestParameters()
             {
                 RequestContext = requestContext,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false),
                 ClientId = TestConstants.ClientId,
                 TenantUpdatedCanonicalAuthority = TestConstants.AuthorityTestTenant
             };
 
             AddHostToInstanceCache(TestConstants.ProductionPrefNetworkEnvironment);
 
-            cache.SaveAccessAndRefreshToken(requestParams, response);
+            cache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
             byte[] serializedCache = cache.Serialize();
             cache.tokenCacheAccessor.AccessTokenCacheDictionary.Clear();
             cache.tokenCacheAccessor.RefreshTokenCacheDictionary.Clear();
@@ -906,7 +906,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
             {
                 RequestContext = new RequestContext(new MsalLogger(Guid.Empty, null)),
                 ClientId = TestConstants.ClientId,
-                Authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false),
+                Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityTestTenant, false),
                 Scope = new SortedSet<string>(),
                 Account = TestConstants.User
             };
@@ -916,7 +916,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
             var upperCaseScope = scopeInCache.ToUpper();
             param.Scope.Add(upperCaseScope);
 
-            var item = tokenCache.FindAccessTokenAsync(param).Result;
+            var item = tokenCache.FindAccessTokenAsync(new TestPlatformInformation(), param).Result;
 
             Assert.IsNotNull(item);
             Assert.IsTrue(item.ScopeSet.Contains(scopeInCache));
@@ -928,7 +928,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
         {
             TokenCache B2CCache = new TokenCache();
             var tenantID = "someTenantID";
-            var authority = Authority.CreateAuthority(String.Format("https://login.microsoftonline.com/tfp/{0}/somePolicy/oauth2/v2.0/authorize", tenantID), false);
+            var authority = Authority.CreateAuthority(new TestPlatformInformation(), String.Format("https://login.microsoftonline.com/tfp/{0}/somePolicy/oauth2/v2.0/authorize", tenantID), false);
 
             MsalTokenResponse response = new MsalTokenResponse();
             //creating IDToken with empty tenantID and displayableID/PreferedUserName for B2C scenario
@@ -950,7 +950,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 TenantUpdatedCanonicalAuthority = TestConstants.AuthorityTestTenant
             };
 
-            B2CCache.SaveAccessAndRefreshToken(requestParams, response);
+            B2CCache.SaveAccessAndRefreshToken(new TestPlatformInformation(), requestParams, response);
 
             Assert.AreEqual(1, B2CCache.tokenCacheAccessor.RefreshTokenCacheDictionary.Count);
             Assert.AreEqual(1, B2CCache.tokenCacheAccessor.AccessTokenCacheDictionary.Count);

--- a/msal/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/ConfidentialClientApplicationTests.cs
@@ -42,6 +42,7 @@ using Microsoft.Identity.Core.Helpers;
 using Microsoft.Identity.Core.Http;
 using Microsoft.Identity.Core.Instance;
 using NSubstitute;
+using Test.Microsoft.Identity.Core.Unit;
 using Test.Microsoft.Identity.Core.Unit.Mocks;
 
 namespace Test.MSAL.NET.Unit
@@ -549,7 +550,7 @@ namespace Test.MSAL.NET.Unit
             var cache = new TokenCache();
             TokenCacheHelper.PopulateCacheForClientCredential(cache.tokenCacheAccessor);
 
-            var authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false).CanonicalAuthority;
+            var authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityTestTenant, false).CanonicalAuthority;
             var app = new ConfidentialClientApplication(TestConstants.ClientId, authority,
                 TestConstants.RedirectUri, new ClientCredential(TestConstants.ClientSecret),
                 null, cache)
@@ -581,7 +582,7 @@ namespace Test.MSAL.NET.Unit
             var cache = new TokenCache();
             TokenCacheHelper.PopulateCache(cache.tokenCacheAccessor);
 
-            var authority = Authority.CreateAuthority(TestConstants.AuthorityTestTenant, false).CanonicalAuthority;
+            var authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityTestTenant, false).CanonicalAuthority;
             var app = new ConfidentialClientApplication(TestConstants.ClientId, authority,
                 TestConstants.RedirectUri, new ClientCredential(TestConstants.ClientSecret),
                 null, cache)

--- a/msal/tests/Test.MSAL.NET.Unit/Mocks/MsalMockHelpers.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/Mocks/MsalMockHelpers.cs
@@ -61,7 +61,7 @@ namespace Test.MSAL.NET.Unit.Mocks
         {
             IWebUIFactory mockFactory = Substitute.For<IWebUIFactory>();
             mockFactory.CreateAuthenticationDialog(Arg.Any<CoreUIParent>(), Arg.Any<RequestContext>()).Returns(webUi);
-            PlatformPlugin.WebUIFactory = mockFactory;
+            PlatformPlugin.SetWebUiFactory(mockFactory);
         }
     }
 }

--- a/msal/tests/Test.MSAL.NET.Unit/RequestsTests/DeviceCodeRequestTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/RequestsTests/DeviceCodeRequestTests.cs
@@ -156,7 +156,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
 
         private AuthenticationRequestParameters CreateAuthenticationParametersAndSetupMocks(out HashSet<string> expectedScopes)
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
             _cache = new TokenCache()
             {
                 ClientId = TestConstants.ClientId

--- a/msal/tests/Test.MSAL.NET.Unit/RequestsTests/InteractiveRequestTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/RequestsTests/InteractiveRequestTests.cs
@@ -75,7 +75,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void SliceParametersTest()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
             cache = new TokenCache()
             {
                 ClientId = TestConstants.ClientId
@@ -137,7 +137,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void NoCacheLookup()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
             cache = new TokenCache()
             {
                 ClientId = TestConstants.ClientId
@@ -209,7 +209,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void RedirectUriContainsFragmentErrorTest()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
             try
             {
                 AuthenticationRequestParameters parameters = new AuthenticationRequestParameters()
@@ -239,7 +239,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void OAuthClient_FailsWithServiceExceptionWhenItCannotParseJsonResponse()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler
             {
@@ -287,7 +287,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void OAuthClient_FailsWithServiceExceptionWhenItCanParseJsonResponse()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
 
             HttpMessageHandlerFactory.AddMockHandler(new MockHttpMessageHandler
             {
@@ -334,7 +334,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void VerifyAuthorizationResultTest()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
 
             RequestTestsCommon.MockInstanceDiscoveryAndOpenIdRequest();
 
@@ -399,7 +399,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("InteractiveRequestTests")]
         public void DuplicateQueryParameterErrorTest()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
 
             AuthenticationRequestParameters parameters = new AuthenticationRequestParameters()
             {

--- a/msal/tests/Test.MSAL.NET.Unit/RequestsTests/RequestValidationHelperTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/RequestsTests/RequestValidationHelperTests.cs
@@ -35,6 +35,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Identity.Core;
+using Test.Microsoft.Identity.Core.Unit;
 
 namespace Test.MSAL.NET.Unit.RequestsTests
 {
@@ -59,7 +60,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             var parameters = new AuthenticationRequestParameters();
             parameters.ClientCredential = credential;
             parameters.SendCertificate = false;
-            parameters.Authority = Authority.CreateAuthority(TestConstants.AuthorityCommonTenant, false);
+            parameters.Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityCommonTenant, false);
             parameters.Authority.SelfSignedJwtAudience = Audience1;
 
             //Validate cached client assertion with parameters
@@ -104,7 +105,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
             var parameters = new AuthenticationRequestParameters();
             parameters.ClientCredential = credential;
             parameters.SendCertificate = false;
-            parameters.Authority = Authority.CreateAuthority(TestConstants.AuthorityCommonTenant, false);
+            parameters.Authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityCommonTenant, false);
             parameters.Authority.SelfSignedJwtAudience = "Audience1";
 
             //Validate cached client assertion with expiration time

--- a/msal/tests/Test.MSAL.NET.Unit/RequestsTests/SilentRequestTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/RequestsTests/SilentRequestTests.cs
@@ -37,6 +37,7 @@ using Microsoft.Identity.Core.Helpers;
 using Microsoft.Identity.Core.Http;
 using Microsoft.Identity.Core.Instance;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Test.Microsoft.Identity.Core.Unit;
 using Test.Microsoft.Identity.Core.Unit.Mocks;
 using Test.MSAL.NET.Unit.Mocks;
 
@@ -70,7 +71,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("SilentRequestTests")]
         public void ConstructorTests()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
             TokenCache cache = new TokenCache()
             {
                 ClientId = TestConstants.ClientId
@@ -101,7 +102,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("SilentRequestTests")]
         public void ExpiredTokenRefreshFlowTest()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
             TokenCache cache = new TokenCache()
             {
                 ClientId = TestConstants.ClientId
@@ -141,7 +142,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("SilentRequestTests")]
         public void SilentRefreshFailedNullCacheTest()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
             cache = null;
 
             RequestTestsCommon.MockInstanceDiscoveryAndOpenIdRequest();
@@ -175,7 +176,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
         [TestCategory("SilentRequestTests")]
         public void SilentRefreshFailedNoCacheItemFoundTest()
         {
-            Authority authority = Authority.CreateAuthority(TestConstants.AuthorityHomeTenant, false);
+            Authority authority = Authority.CreateAuthority(new TestPlatformInformation(), TestConstants.AuthorityHomeTenant, false);
             cache = new TokenCache()
             {
                 ClientId = TestConstants.ClientId

--- a/msal/tests/Test.MSAL.NET.Unit/UnifiedCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit/UnifiedCacheTests.cs
@@ -37,6 +37,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
+using Test.Microsoft.Identity.Core.Unit;
 using Test.Microsoft.Identity.Core.Unit.Mocks;
 using Test.MSAL.NET.Unit.Mocks;
 
@@ -121,7 +122,7 @@ namespace Test.MSAL.NET.Unit
             Assert.IsTrue(adalCacheDictionary.Count == 1);
 
             var requestContext = new RequestContext(new MsalLogger(Guid.Empty, null));
-            var users = app.UserTokenCache.GetAccountsAsync(TestConstants.AuthorityCommonTenant, false, requestContext).Result;
+            var users = app.UserTokenCache.GetAccountsAsync(new TestPlatformInformation(), TestConstants.AuthorityCommonTenant, false, requestContext).Result;
             foreach (IAccount user in users)
             {
                 ISet<string> authorityHostAliases = new HashSet<string>();

--- a/msal/tests/dev apps/XForms/XForms/AcquirePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/AcquirePage.xaml.cs
@@ -212,7 +212,7 @@ namespace XForms
         {
             var tokenCache = App.MsalPublicClient.UserTokenCache;
             var users = await tokenCache.GetAccountsAsync
-                (App.Authority, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
+                (new PlatformInformation(), App.Authority, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
             foreach (var user in users)
             {
                 await App.MsalPublicClient.RemoveAsync(user).ConfigureAwait(false);

--- a/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
@@ -27,11 +27,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Core;
 using Microsoft.Identity.Core.Cache;
@@ -95,10 +91,7 @@ namespace XForms
 
         private async Task OnClearClickedAsync(object sender, EventArgs e)
         {
-            var tokenCache = App.MsalPublicClient.UserTokenCache;
-            var users = await tokenCache.GetAccountsAsync
-                (new PlatformInformation(), App.Authority, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
-            foreach (var user in users)
+            foreach (var user in await App.MsalPublicClient.GetAccountsAsync().ConfigureAwait(false))
             {
                 await App.MsalPublicClient.RemoveAsync(user).ConfigureAwait(false);
             }
@@ -108,13 +101,13 @@ namespace XForms
 
         private static long GetCurrentTimestamp()
         {
-            return (long) (DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
+            return (long)(DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
         }
 
         public void OnExpire(object sender, EventArgs e)
         {
-            var mi = ((MenuItem) sender);
-            var accessTokenCacheItem = (MsalAccessTokenCacheItem) mi.CommandParameter;
+            var mi = ((MenuItem)sender);
+            var accessTokenCacheItem = (MsalAccessTokenCacheItem)mi.CommandParameter;
             var tokenCache = App.MsalPublicClient.UserTokenCache;
 
             // set access token as expired
@@ -142,8 +135,8 @@ namespace XForms
 
         public void OnInvalidate(object sender, EventArgs e)
         {
-            var mi = ((MenuItem) sender);
-            var refreshTokenCacheItem = (MsalRefreshTokenCacheItem) mi.CommandParameter;
+            var mi = ((MenuItem)sender);
+            var refreshTokenCacheItem = (MsalRefreshTokenCacheItem)mi.CommandParameter;
             var tokenCache = App.MsalPublicClient.UserTokenCache;
 
             // invalidate refresh token
@@ -157,8 +150,8 @@ namespace XForms
 
         public async Task ShowAccessTokenDetailsAsync(object sender, EventArgs e)
         {
-            var mi = (MenuItem) sender;
-            var accessTokenCacheItem = (MsalAccessTokenCacheItem) mi.CommandParameter;
+            var mi = (MenuItem)sender;
+            var accessTokenCacheItem = (MsalAccessTokenCacheItem)mi.CommandParameter;
 
             // pass idtoken instead of null
             await Navigation.PushAsync(new AccessTokenCacheItemDetails(accessTokenCacheItem, null));

--- a/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
@@ -31,6 +31,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Core;
 using Microsoft.Identity.Core.Cache;
@@ -96,7 +97,7 @@ namespace XForms
         {
             var tokenCache = App.MsalPublicClient.UserTokenCache;
             var users = await tokenCache.GetAccountsAsync
-                (App.Authority, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
+                (new PlatformInformation(), App.Authority, true, new RequestContext(new MsalLogger(Guid.NewGuid(), null))).ConfigureAwait(false);
             foreach (var user in users)
             {
                 await App.MsalPublicClient.RemoveAsync(user).ConfigureAwait(false);


### PR DESCRIPTION
From issue [629] we have a static race condition related to PlatformPlugin and CorePlatformInformationBase static initializers.  This removes the statics there and forces the core classes to hit the module initializer directly for the remaining statics we're on a path to removing over time.