### PR TITLE
allow teamid to be accessible

### DIFF
--- a/core/src/Platforms/iOS/TokenCacheAccessor.cs
+++ b/core/src/Platforms/iOS/TokenCacheAccessor.cs
@@ -86,7 +86,7 @@ namespace Microsoft.Identity.Core
             {
                 Service = "",
                 Account = TeamIdKey,
-                Accessible = SecAccessible.Always
+                Accessible = _defaultAccessiblityPolicy
             };
 
             SecRecord match = SecKeyChain.QueryAsRecord(queryRecord, out SecStatusCode resultCode);

--- a/core/src/Platforms/iOS/TokenCacheAccessor.cs
+++ b/core/src/Platforms/iOS/TokenCacheAccessor.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Identity.Core
             var queryRecord = new SecRecord(SecKind.GenericPassword)
             {
                 Service = "",
-                Account = TeamIdKey
+                Account = TeamIdKey,
+                Accessible = SecAccessible.Always
             };
 
             SecRecord match = SecKeyChain.QueryAsRecord(queryRecord, out SecStatusCode resultCode);


### PR DESCRIPTION
Fixes MSAL.NET #[626](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/626): PublicClientApplication constructor throws exception when iPhone screen is locked

According to olga, the TeamId can be accessible always as there is no private info in it. This is to access TeamId when the phone is locked.