### PR TITLE
Fix for [1277] Cross-thread operation exception when setting ownerWindow in PlatformParameters 

### DIFF
--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/PlatformParameters.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/PlatformParameters.cs
@@ -25,6 +25,7 @@
 //
 //------------------------------------------------------------------------------
 
+using System.Threading;
 using Microsoft.Identity.Core.UI;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory
@@ -34,6 +35,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// </summary>
     public class PlatformParameters : IPlatformParameters
     {
+        public static SynchronizationContext _syncContext = null;
+
         /// <summary>
         /// 
         /// </summary>
@@ -49,6 +52,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="ownerWindow"></param>
         public PlatformParameters(PromptBehavior promptBehavior, object ownerWindow)
         {
+            _syncContext = SynchronizationContext.Current;
             this.PromptBehavior = promptBehavior;
             this.OwnerWindow = ownerWindow;
         }

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/PlatformParameters.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/PlatformParameters.cs
@@ -52,7 +52,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="ownerWindow"></param>
         public PlatformParameters(PromptBehavior promptBehavior, object ownerWindow)
         {
-            _syncContext = SynchronizationContext.Current;
+            _syncContext = SynchronizationContext.Current ?? new SynchronizationContext();
             this.PromptBehavior = promptBehavior;
             this.OwnerWindow = ownerWindow;
         }

--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/WebUI.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/WebUI.cs
@@ -48,13 +48,47 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         {
             AuthorizationResult authorizationResult = null;
 
-            var other = PlatformParameters._syncContext;
-            other.Send(state =>
+            var sendAuthorizeRequest = new Action(() =>
+            {
+                var other = PlatformParameters._syncContext;
+                other.Send(state =>
+                    {
+                        var tup = (Tuple<Uri, Uri>) state;
+                        authorizationResult = this.Authenticate(tup.Item1, tup.Item2);
+                    },
+                    Tuple.Create(authorizationUri, redirectUri));
+            });
+
+            // If the thread is MTA, it cannot create or communicate with WebBrowser which is a COM control.
+            // In this case, we have to create the browser in an STA thread via StaTaskScheduler object.
+            if (Thread.CurrentThread.GetApartmentState() == ApartmentState.MTA)
+            {
+                using (var staTaskScheduler = new StaTaskScheduler(1))
                 {
-                    var tup = (Tuple<Uri, Uri>)state;
-                    authorizationResult = this.Authenticate(tup.Item1, tup.Item2);
-                },
-            Tuple.Create(authorizationUri, redirectUri));
+                    try
+                    {
+                        Task.Factory.StartNew(sendAuthorizeRequest, CancellationToken.None, TaskCreationOptions.None, staTaskScheduler).Wait();
+                    }
+                    catch (AggregateException ae)
+                    {
+                        // Any exception thrown as a result of running task will cause AggregateException to be thrown with 
+                        // actual exception as inner.
+                        Exception innerException = ae.InnerExceptions[0];
+
+                        // In MTA case, AggregateException is two layer deep, so checking the InnerException for that.
+                        if (innerException is AggregateException)
+                        {
+                            innerException = ((AggregateException)innerException).InnerExceptions[0];
+                        }
+
+                        throw innerException;
+                    }
+                }
+            }
+            else
+            {
+                sendAuthorizeRequest();
+            }
 
             return await Task.Factory.StartNew(() => authorizationResult).ConfigureAwait(false);
         }


### PR DESCRIPTION
This PR is still a hack but I want to start talking about it with the team.  The concept itself works, but the way we're passing the SynchronizationContext around is totally wrong.  We probably want to plumb it through the same way as the ownerWindow object.

Our sample adal app has been working because it's actually a console app and so the STA scheduler creates the first and only STA thread and there isn't a UI thread / winforms object to interact with.  If we have a winforms app (such as the example provided in #1277) then because of the async methods added in restructuring between 3.17.x and 3.18, we're on an MTA thread.  We create a _new_ STA thread with the STA Scheduler and that isn't the same thread that the UI is running on, so we get the error as shown in the bug.

The proposed fix is to use SynchronizationContext which should work from both WinForms and WPF applications (both implement it in their main UI thread) and then we can call SynchronizationContext.Send() with the delegate method doing the browser loop.  This is the equivalent of calling Control.Invoke() without having a Control object.  In the case of our sample console app, we can create a new SynchronizationContext in the root and use that to execute with but we still need the STA thread to be created because our sample doesn't create a default STA thread since it's a console app.

We could look into deciding not to support raw console applications and require winforms/wpf which would then bring in the assurance we have an STAThread at root and then we could remove the STAScheduler altogether.  The STAScheduler is only needed to cover the console app case in our sample.