### PR TITLE
- fix for accessible setting for TeamId

### DIFF
--- a/core/src/Platforms/iOS/TokenCacheAccessor.cs
+++ b/core/src/Platforms/iOS/TokenCacheAccessor.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Identity.Core
         private const SecAccessible _defaultAccessiblityPolicy = SecAccessible.AfterFirstUnlockThisDeviceOnly;
 
         private readonly string DefaultKeychainGroup = "com.microsoft.adalcache";
-        private readonly string TeamIdKey = "teamIDHint";
+        private readonly string TeamIdKey = ".NetTeamIDHint";
 
         private string keychainGroup;
         private RequestContext _requestContext;
@@ -87,7 +87,7 @@ namespace Microsoft.Identity.Core
             {
                 Service = "",
                 Account = TeamIdKey,
-                Accessible = _defaultAccessiblityPolicy
+                Accessible = SecAccessible.Always
             };
 
             SecRecord match = SecKeyChain.QueryAsRecord(queryRecord, out SecStatusCode resultCode);

--- a/core/src/Platforms/iOS/TokenCacheAccessor.cs
+++ b/core/src/Platforms/iOS/TokenCacheAccessor.cs
@@ -58,8 +58,9 @@ namespace Microsoft.Identity.Core
         private const bool _defaultSyncSetting = false;
         private const SecAccessible _defaultAccessiblityPolicy = SecAccessible.AfterFirstUnlockThisDeviceOnly;
 
-        private readonly string DefaultKeychainGroup = "com.microsoft.adalcache";
-        private readonly string TeamIdKey = ".NetTeamIDHint";
+        private const string DefaultKeychainGroup = "com.microsoft.adalcache";
+        // Identifier for the keychain item used to retrieve current team ID
+        private const string TeamIdKey = "DotNetTeamIDHint";
 
         private string keychainGroup;
         private RequestContext _requestContext;


### PR DESCRIPTION
- change teamIdKey default value

I talked w/Olga on Friday, and these two fixes should address the issues I was having Friday w/iOS simulator. The teamID access needs to be always. 

@bgavrilMS we will need to test this before running a release build. I have tested and it works fine on simulator. 

cc: @jmprieur 