### PR TITLE
remove static http, it's now owned at clientapplicationbase

### DIFF
--- a/core/src/Http/HttpClientFactory.cs
+++ b/core/src/Http/HttpClientFactory.cs
@@ -37,12 +37,11 @@ namespace Microsoft.Identity.Core.Http
 
     internal class HttpClientFactory : IHttpClientFactory
     {
-        // as per guidelines HttpClient should be a singleton instance in an application.
-        private static HttpClient _client;
-        private static readonly object LockObj = new object();
+        // The HttpClient is a singleton per ClientApplication so that we don't have a process wide singleton.
+        private readonly HttpClient _httpClient;
         public const long MaxResponseContentBufferSizeInBytes = 1024*1024;
 
-        private static HttpClient CreateHttpClient()
+        public HttpClientFactory()
         {
             var httpClient = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true })
             {
@@ -52,28 +51,12 @@ namespace Microsoft.Identity.Core.Http
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            return httpClient;
+            _httpClient = httpClient;
         }
 
         public HttpClient GetHttpClient()
         {
-            return GetHttpClientStatic();
-        }
-
-        public static HttpClient GetHttpClientStatic()
-        {
-            if (_client == null)
-            {
-                lock (LockObj)
-                {
-                    if (_client == null)
-                    {
-                        _client = CreateHttpClient();
-                    }
-                }
-            }
-
-            return _client;
+            return _httpClient;
         }
     }
 }

--- a/core/src/Http/HttpClientFactory.cs
+++ b/core/src/Http/HttpClientFactory.cs
@@ -32,13 +32,12 @@ namespace Microsoft.Identity.Core.Http
 {
     internal interface IHttpClientFactory
     {
-        HttpClient GetHttpClient();
+        HttpClient HttpClient { get; }
     }
 
     internal class HttpClientFactory : IHttpClientFactory
     {
         // The HttpClient is a singleton per ClientApplication so that we don't have a process wide singleton.
-        private readonly HttpClient _httpClient;
         public const long MaxResponseContentBufferSizeInBytes = 1024*1024;
 
         public HttpClientFactory()
@@ -51,12 +50,9 @@ namespace Microsoft.Identity.Core.Http
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            _httpClient = httpClient;
+            HttpClient = httpClient;
         }
 
-        public HttpClient GetHttpClient()
-        {
-            return _httpClient;
-        }
+        public HttpClient HttpClient { get; }
     }
 }

--- a/core/src/Http/HttpManager.cs
+++ b/core/src/Http/HttpManager.cs
@@ -29,10 +29,8 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Core.Http
@@ -48,10 +46,7 @@ namespace Microsoft.Identity.Core.Http
             _httpClientFactory = httpClientFactory ?? new HttpClientFactory();
         }
 
-        protected virtual HttpClient GetHttpClient()
-        {
-            return _httpClientFactory.GetHttpClient();
-        }
+        protected virtual HttpClient HttpClient => _httpClientFactory.HttpClient;
 
         public async Task<HttpResponse> SendPostAsync(
             Uri endpoint,
@@ -201,7 +196,7 @@ namespace Microsoft.Identity.Core.Http
             HttpContent body,
             HttpMethod method)
         {
-            HttpClient client = GetHttpClient();
+            HttpClient client = HttpClient;
 
             using (HttpRequestMessage requestMessage = CreateRequestMessage(endpoint, headers))
             {

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/HttpTests/HttpClientFactoryTests.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/HttpTests/HttpClientFactoryTests.cs
@@ -39,14 +39,14 @@ namespace Test.Microsoft.Identity.Unit.HttpTests
         [TestCategory("HttpClientFactoryTests")]
         public void GetHttpClient_MaxRespContentBuffSizeSetTo1Mb()
         {
-            Assert.AreEqual(1024 * 1024, new HttpClientFactory().GetHttpClient().MaxResponseContentBufferSize);
+            Assert.AreEqual(1024 * 1024, new HttpClientFactory().HttpClient.MaxResponseContentBufferSize);
         }
 
         [TestMethod]
         [TestCategory("HttpClientFactoryTests")]
         public void GetHttpClient_DefaultHeadersSetToJson()
         {
-            var client = new HttpClientFactory().GetHttpClient();
+            var client = new HttpClientFactory().HttpClient;
             Assert.IsNotNull(client.DefaultRequestHeaders.Accept);
             Assert.IsTrue(
                 client.DefaultRequestHeaders.Accept.Any<MediaTypeWithQualityHeaderValue>(x => x.MediaType == "application/json"));

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/HttpTests/HttpClientFactoryTests.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/HttpTests/HttpClientFactoryTests.cs
@@ -39,14 +39,14 @@ namespace Test.Microsoft.Identity.Unit.HttpTests
         [TestCategory("HttpClientFactoryTests")]
         public void GetHttpClient_MaxRespContentBuffSizeSetTo1Mb()
         {
-            Assert.AreEqual(1024 * 1024, HttpClientFactory.GetHttpClientStatic().MaxResponseContentBufferSize);
+            Assert.AreEqual(1024 * 1024, new HttpClientFactory().GetHttpClient().MaxResponseContentBufferSize);
         }
 
         [TestMethod]
         [TestCategory("HttpClientFactoryTests")]
         public void GetHttpClient_DefaultHeadersSetToJson()
         {
-            var client = HttpClientFactory.GetHttpClientStatic();
+            var client = new HttpClientFactory().GetHttpClient();
             Assert.IsNotNull(client.DefaultRequestHeaders.Accept);
             Assert.IsTrue(
                 client.DefaultRequestHeaders.Accept.Any<MediaTypeWithQualityHeaderValue>(x => x.MediaType == "application/json"));

--- a/core/tests/Test.Microsoft.Identity.Core.Unit/Mocks/MockHttpManager.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.Unit/Mocks/MockHttpManager.cs
@@ -64,17 +64,20 @@ namespace Test.Microsoft.Identity.Core.Unit.Mocks
         }
 
         /// <inheritdoc />
-        protected override HttpClient GetHttpClient()
+        protected override HttpClient HttpClient
         {
-            var httpClient = new HttpClient(_httpMessageHandlerQueue.Dequeue())
+            get
             {
-                MaxResponseContentBufferSize = HttpClientFactory.MaxResponseContentBufferSizeInBytes
-            };
+                var httpClient = new HttpClient(_httpMessageHandlerQueue.Dequeue())
+                {
+                    MaxResponseContentBufferSize = HttpClientFactory.MaxResponseContentBufferSizeInBytes
+                };
 
-            httpClient.DefaultRequestHeaders.Accept.Clear();
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                httpClient.DefaultRequestHeaders.Accept.Clear();
+                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
-            return httpClient;
+                return httpClient;
+            }
         }
     }
 }


### PR DESCRIPTION
Now that HttpManager is fully plumbed through, we can remove the static HttpClient.  now, we have an HttpClient created per ClientApplicationBase/AuthenticationContext (via construction of a single HttpManager) that's not process wide static.