### PR TITLE
Fix release build and enable rules CA1305 and CA1304

### DIFF
--- a/adal/tests/Test.ADAL.NET.Common/Mocks/MockHelpers.cs
+++ b/adal/tests/Test.ADAL.NET.Common/Mocks/MockHelpers.cs
@@ -161,8 +161,8 @@ namespace Test.ADAL.NET.Common.Mocks
 
             HttpContent content = new StringContent(
                 "{\"user_code\":\"some-user-code\",\"device_code\":\"some-device-code\",\"verification_url\":\"some-URL\"," +
-                "\"expires_in\":\"" + expirationTimeInSeconds.ToString() + "\"," +
-                "\"interval\":\"" + retryInternvalInSeconds.ToString() + "\"," +
+                "\"expires_in\":\"" + expirationTimeInSeconds.ToString(CultureInfo.InvariantCulture) + "\"," +
+                "\"interval\":\"" + retryInternvalInSeconds.ToString(CultureInfo.InvariantCulture) + "\"," +
                 "\"message\":\"some-message\"}");
             responseMessage.Content = content;
             return responseMessage;

--- a/adal/tests/Test.ADAL.NET.Unit.net45/Integration/SovereignCloudsTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit.net45/Integration/SovereignCloudsTests.cs
@@ -41,6 +41,7 @@ using System.Net;
 using TokenResponseClaim = Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.OAuth2.TokenResponseClaim;
 using Microsoft.Identity.Core.UI;
 using Test.ADAL.NET.Unit;
+using System.Globalization;
 
 namespace Test.ADAL.NET.Integration
 {
@@ -51,7 +52,11 @@ namespace Test.ADAL.NET.Integration
         private IPlatformParameters _platformParameters;
         private const string SovereignAuthorityHost = "login.microsoftonline.de";
 
-        private readonly string _sovereignTenantSpecificAuthority = String.Format("https://{0}/{1}/", SovereignAuthorityHost, AdalTestConstants.SomeTenantId);
+        private readonly string _sovereignTenantSpecificAuthority = String.Format(
+            CultureInfo.InvariantCulture, 
+            "https://{0}/{1}/", 
+            SovereignAuthorityHost, 
+            AdalTestConstants.SomeTenantId);
 
         [TestInitialize]
         public void Initialize()

--- a/adal/tests/Test.ADAL.NET.Unit.net45/TokenCacheTests.cs
+++ b/adal/tests/Test.ADAL.NET.Unit.net45/TokenCacheTests.cs
@@ -311,7 +311,7 @@ namespace Test.ADAL.Common.Unit
                 cacheValue);
 
             var userId = new UserIdentifier(uniqueId, UserIdentifierType.UniqueId);
-            var userIdUpper = new UserIdentifier(displayableId.ToUpper(), UserIdentifierType.RequiredDisplayableId);
+            var userIdUpper = new UserIdentifier(displayableId.ToUpperInvariant(), UserIdentifierType.RequiredDisplayableId);
 
             authenticationResultFromCache = await acWithLocalCache.AcquireTokenSilentAsync(resource, clientId, userId).ConfigureAwait(false);
             VerifyAuthenticationResultsAreEqual(new AuthenticationResult(cacheValue.Result), authenticationResultFromCache);

--- a/build/SolutionWideAnalyzerConfig.ruleset
+++ b/build/SolutionWideAnalyzerConfig.ruleset
@@ -22,7 +22,7 @@
     <Rule Id="CA5351" Action="None" />
   </Rules>
   <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
-    <Rule Id="CA1304" Action="None" />
+    <Rule Id="CA1304" Action="Error" />
     <Rule Id="CA1305" Action="Error" />
     <Rule Id="CA1307" Action="None" />
     <Rule Id="CA1308" Action="None" />

--- a/build/SolutionWideAnalyzerConfig.ruleset
+++ b/build/SolutionWideAnalyzerConfig.ruleset
@@ -23,7 +23,7 @@
   </Rules>
   <Rules AnalyzerId="Microsoft.NetCore.Analyzers" RuleNamespace="Microsoft.NetCore.Analyzers">
     <Rule Id="CA1304" Action="None" />
-    <Rule Id="CA1305" Action="None" />
+    <Rule Id="CA1305" Action="Error" />
     <Rule Id="CA1307" Action="None" />
     <Rule Id="CA1308" Action="None" />
     <Rule Id="CA1401" Action="None" />

--- a/core/src/Cache/Items/MsalAccessTokenCacheItem.cs
+++ b/core/src/Cache/Items/MsalAccessTokenCacheItem.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Identity.Core.Cache
             get
             {
                 DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-                var expiresLong = Convert.ToInt64(ExpiresOnUnixTimestamp, CultureInfo.InvariantCulture);
+                var expiresLong = Convert.ToInt64(ExtendedExpiresOnUnixTimestamp, CultureInfo.InvariantCulture);
 
                 return dtDateTime.AddSeconds(expiresLong).ToUniversalTime();
             }

--- a/core/src/Cache/Items/MsalAccessTokenCacheItem.cs
+++ b/core/src/Cache/Items/MsalAccessTokenCacheItem.cs
@@ -101,7 +101,8 @@ namespace Microsoft.Identity.Core.Cache
             get
             {
                 DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-                return dtDateTime.AddSeconds(Convert.ToInt64(ExpiresOnUnixTimestamp)).ToUniversalTime();
+                var expiresLong = Convert.ToInt64(ExpiresOnUnixTimestamp, CultureInfo.InvariantCulture);
+                return dtDateTime.AddSeconds(expiresLong).ToUniversalTime();
             }
         }
 
@@ -110,7 +111,9 @@ namespace Microsoft.Identity.Core.Cache
             get
             {
                 DateTime dtDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
-                return dtDateTime.AddSeconds(Convert.ToInt64(ExtendedExpiresOnUnixTimestamp)).ToUniversalTime();
+                var expiresLong = Convert.ToInt64(ExpiresOnUnixTimestamp, CultureInfo.InvariantCulture);
+
+                return dtDateTime.AddSeconds(expiresLong).ToUniversalTime();
             }
         }
 

--- a/core/src/Cache/Keys/MsalAccountCacheKey.cs
+++ b/core/src/Cache/Keys/MsalAccountCacheKey.cs
@@ -76,17 +76,17 @@ namespace Microsoft.Identity.Core.Cache
 
             stringBuilder.Append(_environment);
 
-            return stringBuilder.ToString().ToLower();
+            return stringBuilder.ToString().ToLowerInvariant();
         }
 
         public string GetiOSServiceKey()
         {
-            return (_tenantId ?? "").ToLower();
+            return (_tenantId ?? "").ToLowerInvariant();
         }
 
         public string GetiOSGenericKey()
         {
-            return _username.ToLower();
+            return _username.ToLowerInvariant();
         }
 
 

--- a/core/src/Cache/MsalCacheCommon.cs
+++ b/core/src/Cache/MsalCacheCommon.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Identity.Core.Cache
 
             stringBuilder.Append(scopes ?? "");
 
-            return stringBuilder.ToString().ToLower();
+            return stringBuilder.ToString().ToLowerInvariant();
         }
 
         public static string GetiOSAccountKey(string homeAccountId, string environment)
@@ -75,7 +75,7 @@ namespace Microsoft.Identity.Core.Cache
 
             stringBuilder.Append(environment);
 
-            return stringBuilder.ToString().ToLower();
+            return stringBuilder.ToString().ToLowerInvariant();
         }
 
 
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Core.Cache
 
             stringBuilder.Append(scopes ?? "");
 
-            return stringBuilder.ToString().ToLower();
+            return stringBuilder.ToString().ToLowerInvariant();
         }
 
         public static string GetiOSGenericKey(string keyDescriptor, string clientId, string tenantId)
@@ -109,7 +109,7 @@ namespace Microsoft.Identity.Core.Cache
 
             stringBuilder.Append(tenantId ?? "");
 
-            return stringBuilder.ToString().ToLower();
+            return stringBuilder.ToString().ToLowerInvariant();
         }
     }
 }

--- a/core/src/Helpers/CoreHelpers.cs
+++ b/core/src/Helpers/CoreHelpers.cs
@@ -56,21 +56,21 @@ namespace Microsoft.Identity.Core.Helpers
 
         public static DateTime UnixTimestampStringToDateTime(string str)
         {
-            return UnixTimestampToDateTime(Convert.ToInt64(str));
+            return UnixTimestampToDateTime(Convert.ToInt64(str, CultureInfo.InvariantCulture));
         }
 
         public static string DateTimeToUnixTimestamp(DateTimeOffset dateTimeOffset)
         {
             DateTime dateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
             long unixTimestamp = (long)dateTimeOffset.Subtract(dateTime).TotalSeconds;
-            return unixTimestamp.ToString();
+            return unixTimestamp.ToString(CultureInfo.InvariantCulture);
         }
 
         public static string CurrDateTimeInUnixTimestamp()
         {
             var unixEpochDateTime = new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc);
             long unixTimestamp = (long)DateTime.UtcNow.Subtract(unixEpochDateTime).TotalSeconds;
-            return unixTimestamp.ToString();
+            return unixTimestamp.ToString(CultureInfo.InvariantCulture);
         }
 
         public static long DateTimeToUnixTimestampMilliseconds(DateTimeOffset dateTimeOffset)

--- a/core/src/Platforms/iOS/iOSPlatformProxy.cs
+++ b/core/src/Platforms/iOS/iOSPlatformProxy.cs
@@ -26,6 +26,7 @@
 // ------------------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Identity.Core.Cache;
 using UIKit;
@@ -113,7 +114,12 @@ namespace Microsoft.Identity.Core
         /// <inheritdoc />
         public string GetDefaultRedirectUri(string correlationId)
         {
-            return _isMsal ? string.Format(IosDefaultRedirectUriTemplate, correlationId) : Constants.DefaultRedirectUri;
+            return _isMsal ?
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    IosDefaultRedirectUriTemplate,
+                    correlationId)
+                : Constants.DefaultRedirectUri;
         }
 
         public string GetProductName()

--- a/core/src/Telemetry/ApiEvent.cs
+++ b/core/src/Telemetry/ApiEvent.cs
@@ -126,8 +126,11 @@ namespace Microsoft.Identity.Core.Telemetry
 
         public bool WasSuccessful
         {
+#pragma warning disable CA1305 // .net standard does not have an overload for ToString() with Culture
             set { this[WasSuccessfulKey] = value.ToString().ToLowerInvariant(); }
             get { return this[WasSuccessfulKey] == true.ToString().ToLowerInvariant(); }
+#pragma warning restore CA1305 // Specify IFormatProvider
+
         }
 
         public string CorrelationId
@@ -142,7 +145,9 @@ namespace Microsoft.Identity.Core.Telemetry
 
         public bool IsConfidentialClient
         {
+#pragma warning disable CA1305 // Specify IFormatProvider
             set { this[IsConfidentialClientKey] = value.ToString().ToLowerInvariant(); }
+#pragma warning restore CA1305 // Specify IFormatProvider
         }
 
         public string ApiErrorCode {

--- a/core/src/Telemetry/UiEvent.cs
+++ b/core/src/Telemetry/UiEvent.cs
@@ -37,12 +37,16 @@ namespace Microsoft.Identity.Core.Telemetry
 
         public bool UserCancelled
         {
+#pragma warning disable CA1305 // .net standard does not have an overload for this
             set { this[UserCancelledKey] = value.ToString().ToLowerInvariant(); }
+#pragma warning restore CA1305 // Specify IFormatProvider
         }
 
         public bool AccessDenied
         {
+#pragma warning disable CA1305 // .net standard does not have an overload for this
             set { this[AccessDeniedKey] = value.ToString().ToLowerInvariant(); }
+#pragma warning restore CA1305 // Specify IFormatProvider
         }
     }
 }

--- a/core/src/WsTrust/WsTrustEndpoint.cs
+++ b/core/src/WsTrust/WsTrustEndpoint.cs
@@ -108,7 +108,9 @@ namespace Microsoft.Identity.Core.WsTrust
                     writer.WriteEndElement(); // Action
 
                     writer.WriteStartElement("messageID", wsaNamespaceValue);
+#pragma warning disable CA1305 // Specify IFormatProvider - no overload on netcore
                     writer.WriteString($"urn:uuid:{_guidFactory.NewGuid().ToString("D")}");
+#pragma warning restore CA1305 // Specify IFormatProvider
                     writer.WriteEndElement(); // messageID
 
                     writer.WriteStartElement("ReplyTo", wsaNamespaceValue);
@@ -169,7 +171,9 @@ namespace Microsoft.Identity.Core.WsTrust
             string expiryTimeString = BuildTimeString(expiryTime);
 
             string versionString = Version == WsTrustVersion.WsTrust2005 ? "UnPwSecTok2005-" : "UnPwSecTok13-";
+#pragma warning disable CA1305 // no overload on netcore
             string trustId = $"{versionString}{_guidFactory.NewGuid().ToString("D")}";
+#pragma warning restore CA1305 // Specify IFormatProvider
 
             writer.WriteStartElement("wsse", "Security", wsseNamespaceValue);
             writer.WriteAttributeString("mustUnderstand", envelopeNamespaceValue, "1");

--- a/core/tests/Test.Microsoft.Identity.Core.UIAutomation/XamarinUITestController.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.UIAutomation/XamarinUITestController.cs
@@ -30,6 +30,7 @@ using NUnit.Framework;
 using System;
 using System.Linq;
 using Xamarin.UITest;
+using System.Globalization;
 
 namespace Test.Microsoft.Identity.Core.UIAutomation
 {
@@ -83,7 +84,7 @@ namespace Test.Microsoft.Identity.Core.UIAutomation
         {
             if (isWebElement)
             {
-                return Application.WaitForElement(c => c.Css(String.Format(CSSIDSelector, elementID)), "Could not find element", defaultSearchTimeout, defaultRetryFrequency, defaultPostTimeout);
+                return Application.WaitForElement(c => c.Css(String.Format(CultureInfo.InvariantCulture, CSSIDSelector, elementID)), "Could not find element", defaultSearchTimeout, defaultRetryFrequency, defaultPostTimeout);
             }
             else
             {
@@ -95,8 +96,8 @@ namespace Test.Microsoft.Identity.Core.UIAutomation
         {
             if (isWebElement)
             {
-                Application.WaitForElement(c => c.Css(String.Format(CSSIDSelector, elementID)), "Could not find element", timeout, defaultRetryFrequency, defaultPostTimeout);
-                Application.Tap(c => c.Css(String.Format(CSSIDSelector, elementID)));
+                Application.WaitForElement(c => c.Css(String.Format(CultureInfo.InvariantCulture, CSSIDSelector, elementID)), "Could not find element", timeout, defaultRetryFrequency, defaultPostTimeout);
+                Application.Tap(c => c.Css(String.Format(CultureInfo.InvariantCulture, CSSIDSelector, elementID)));
             }
             else
             {
@@ -109,8 +110,8 @@ namespace Test.Microsoft.Identity.Core.UIAutomation
         {
             if (isWebElement)
             {
-                Application.WaitForElement(c => c.Css(String.Format(CSSIDSelector, elementID)), "Could not find element", timeout, defaultRetryFrequency, defaultPostTimeout);
-                Application.EnterText(c => c.Css(String.Format(CSSIDSelector, elementID)), text);
+                Application.WaitForElement(c => c.Css(String.Format(CultureInfo.InvariantCulture, CSSIDSelector, elementID)), "Could not find element", timeout, defaultRetryFrequency, defaultPostTimeout);
+                Application.EnterText(c => c.Css(String.Format(CultureInfo.InvariantCulture, CSSIDSelector, elementID)), text);
             }
             else
             {

--- a/core/tests/Test.Microsoft.Identity.SideBySide/UnifiedCacheTests.cs
+++ b/core/tests/Test.Microsoft.Identity.SideBySide/UnifiedCacheTests.cs
@@ -34,6 +34,7 @@ using System.Net;
 using System.Security;
 using System.Threading.Tasks;
 using System.Linq;
+using System.Globalization;
 
 namespace Test.MSAL.NET.Integration
 {
@@ -72,7 +73,10 @@ namespace Test.MSAL.NET.Integration
 
                 string stringPassword = ((LabUser)user).GetPassword();
                 securePassword = new NetworkCredential("", stringPassword).SecurePassword;
-                authority = string.Format(AuthorityTemplate, user.CurrentTenantId);
+                authority = string.Format(
+                    CultureInfo.InvariantCulture, 
+                    AuthorityTemplate, 
+                    user.CurrentTenantId);
             }
 
             InitAdal();

--- a/msal/samples/desktop/SampleApp/MainForm.cs
+++ b/msal/samples/desktop/SampleApp/MainForm.cs
@@ -79,7 +79,7 @@ namespace SampleApp
 
         private async void acquireTokenUsernamePasswordButton_Click(object sender, EventArgs e)
         {
-            tokenResultBox.Text = string.Format("");
+            tokenResultBox.Text = string.Empty;
             SecureString securePassword = ConvertToSecureString(tokenResultBox);
             token = await _msalHelper.GetTokenWithUsernamePasswordAsync(new[] { "user.read" }, securePassword).ConfigureAwait(true);
         }

--- a/msal/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
+++ b/msal/src/Microsoft.Identity.Client/Internal/Requests/RequestBase.cs
@@ -177,7 +177,9 @@ namespace Microsoft.Identity.Client.Internal.Requests
             var apiEvent = new ApiEvent(AuthenticationRequestParameters.RequestContext.Logger)
             {
                 ApiId = _apiId,
+#pragma warning disable CA1305 // netcore does not have bool.tostring(culture)
                 ValidationStatus = AuthenticationRequestParameters.ValidateAuthority.ToString(),
+#pragma warning restore CA1305 // Specify IFormatProvider
                 AccountId = accountId ?? "",
                 CorrelationId = AuthenticationRequestParameters.RequestContext.Logger.CorrelationId.ToString(),
                 RequestId = AuthenticationRequestParameters.RequestContext.TelemetryRequestId,

--- a/msal/tests/Test.MSAL.NET.Unit.net45/CacheTests/TokenCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit.net45/CacheTests/TokenCacheTests.cs
@@ -1059,7 +1059,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
 
                 string scopeInCache = MsalTestConstants.Scope.FirstOrDefault();
 
-                string upperCaseScope = scopeInCache.ToUpper();
+                string upperCaseScope = scopeInCache.ToUpperInvariant();
                 param.Scope.Add(upperCaseScope);
 
                 var item = tokenCache.FindAccessTokenAsync(param).Result;

--- a/msal/tests/Test.MSAL.NET.Unit.net45/CacheTests/TokenCacheTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit.net45/CacheTests/TokenCacheTests.cs
@@ -125,7 +125,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                     }).Result;
 
                 Assert.IsNotNull(item);
-                Assert.AreEqual(atKey.ToString(), item.Secret);
+                Assert.AreEqual(atKey, item.Secret);
             }
         }
 
@@ -173,7 +173,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                 var item = cache.FindAccessTokenAsync(param).Result;
 
                 Assert.IsNotNull(item);
-                Assert.AreEqual(atKey.ToString(), item.Secret);
+                Assert.AreEqual(atKey, item.Secret);
             }
         }
 
@@ -558,7 +558,7 @@ namespace Test.MSAL.NET.Unit.CacheTests
                     ClientId = MsalTestConstants.ClientId,
                     Authority = Authority.CreateAuthority(MsalTestConstants.AuthorityHomeTenant, false),
                     Scope = MsalTestConstants.Scope,
-                    UserAssertion = new UserAssertion(PlatformProxyFactory.GetPlatformProxy().CryptographyManager.CreateBase64UrlEncodedSha256Hash(atKey.ToString()))
+                    UserAssertion = new UserAssertion(PlatformProxyFactory.GetPlatformProxy().CryptographyManager.CreateBase64UrlEncodedSha256Hash(atKey))
                 };
 
                 var item = cache.FindAccessTokenAsync(param).Result;
@@ -658,14 +658,14 @@ namespace Test.MSAL.NET.Unit.CacheTests
                     ClientId = MsalTestConstants.ClientId,
                     Authority = Authority.CreateAuthority(MsalTestConstants.AuthorityTestTenant, false),
                     Scope = MsalTestConstants.Scope,
-                    UserAssertion = new UserAssertion(atKey.ToString())
+                    UserAssertion = new UserAssertion(atKey)
                 };
 
                 cache.AfterAccess = AfterAccessNoChangeNotification;
                 var item = cache.FindAccessTokenAsync(param).Result;
 
                 Assert.IsNotNull(item);
-                Assert.AreEqual(atKey.ToString(), item.Secret);
+                Assert.AreEqual(atKey, item.Secret);
             }
         }
 

--- a/msal/tests/Test.MSAL.NET.Unit.net45/RequestsTests/SilentRequestTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit.net45/RequestsTests/SilentRequestTests.cs
@@ -26,6 +26,7 @@
 // ------------------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -131,7 +132,7 @@ namespace Test.MSAL.NET.Unit.RequestsTests
                     MsalAccessTokenCacheItem accessItem =
                         JsonHelper.DeserializeFromJson<MsalAccessTokenCacheItem>(atCacheItemStr);
                     accessItem.ExpiresOnUnixTimestamp =
-                        ((long)((DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds)).ToString();
+                        ((long)((DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds)).ToString(CultureInfo.InvariantCulture);
 
                     cache.AddAccessTokenCacheItem(accessItem);
                 }

--- a/msal/tests/dev apps/DesktopTestApp/MainForm.cs
+++ b/msal/tests/dev apps/DesktopTestApp/MainForm.cs
@@ -29,6 +29,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Security;
@@ -307,12 +308,17 @@ namespace DesktopTestApp
 
             if (exception != null)
             {
-                output += string.Format("Error Code - {0}" + Environment.NewLine + "Message - {1}" + Environment.NewLine, exception.ErrorCode, exception.Message);
+                output += string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Error Code - {0}" + Environment.NewLine + "Message - {1}" + Environment.NewLine,
+                    exception.ErrorCode,
+                    exception.Message);
+
                 if (exception is MsalServiceException)
                 {
-                    output += string.Format("Status Code - {0}" + Environment.NewLine, ((MsalServiceException)exception).StatusCode);
-                    output += string.Format("Claims - {0}" + Environment.NewLine, ((MsalServiceException)exception).Claims);
-                    output += string.Format("Raw Response - {0}" + Environment.NewLine, ((MsalServiceException)exception).ResponseBody);
+                    output += string.Format(CultureInfo.InvariantCulture, "Status Code - {0}" + Environment.NewLine, ((MsalServiceException)exception).StatusCode);
+                    output += string.Format(CultureInfo.InvariantCulture, "Claims - {0}" + Environment.NewLine, ((MsalServiceException)exception).Claims);
+                    output += string.Format(CultureInfo.InvariantCulture, "Raw Response - {0}" + Environment.NewLine, ((MsalServiceException)exception).ResponseBody);
                 }
             }
             else

--- a/msal/tests/dev apps/DesktopTestApp/MsalUserAccessTokenControl.cs
+++ b/msal/tests/dev apps/DesktopTestApp/MsalUserAccessTokenControl.cs
@@ -1,5 +1,6 @@
 ﻿
 using System;
+using System.Globalization;
 using System.Windows.Forms;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Internal;
@@ -24,7 +25,7 @@ namespace DesktopTestApp
             _item = item;
             accessTokenAuthorityLabel.Text = _item.Authority;
             accessTokenScopesLabel.Text = _item.NormalizedScopes;
-            expiresOnLabel.Text = _item.ExpiresOn.ToString();
+            expiresOnLabel.Text = _item.ExpiresOn.ToString(CultureInfo.CurrentCulture);
         }
         
         public MsalUserAccessTokenControl()
@@ -34,7 +35,7 @@ namespace DesktopTestApp
 
         private void expireAccessTokenButton_Click(object sender, System.EventArgs e)
         {
-            expiresOnLabel.Text = DateTimeOffset.UtcNow.ToString();
+            expiresOnLabel.Text = DateTimeOffset.UtcNow.ToString(CultureInfo.CurrentCulture);
             _item.ExpiresOnUnixTimestamp = CoreHelpers.DateTimeToUnixTimestamp(DateTimeOffset.UtcNow);
             _cache.SaveAccesTokenCacheItem(_item, null);
         }

--- a/msal/tests/dev apps/WebTestApp/WebApp/Controllers/HomeController.cs
+++ b/msal/tests/dev apps/WebTestApp/WebApp/Controllers/HomeController.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -56,7 +57,7 @@ namespace WebApp.Controllers
 
         static HomeController()
         {
-            Logger.LogCallback = delegate(LogLevel level, string message, bool containsPii)
+            Logger.LogCallback = delegate (LogLevel level, string message, bool containsPii)
             {
                 lock (LogStringBuilder)
                 {
@@ -148,7 +149,9 @@ namespace WebApp.Controllers
         public ActionResult RequestApplicationPermissions()
         {
             return new RedirectResult(
-                string.Format(AdminConsentUrlFormat,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    AdminConsentUrlFormat,
                     Startup.Configuration["AzureAd:Tenant"],
                     Startup.Configuration["AzureAd:ClientId"],
                     Startup.Configuration["AzureAd:AdminConsentRedirectUri"]

--- a/msal/tests/dev apps/WebTestApp/WebApp/Utils/ConfidentialClientUtils.cs
+++ b/msal/tests/dev apps/WebTestApp/WebApp/Utils/ConfidentialClientUtils.cs
@@ -34,6 +34,7 @@ using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Identity.Client;
 using Microsoft.AspNetCore.Mvc;
+using System.Globalization;
 
 namespace WebApp.Utils
 {
@@ -107,7 +108,10 @@ namespace WebApp.Utils
         public static async Task<AuthenticationResult> AcquireTokenForClientAsync(IEnumerable<string> scopes,
             ISession session, ClientCredential clientCredential, string userId)
         {
-            var appAuthority = string.Format(Startup.Configuration["AzureAd:AuthorityForApplication"], Startup.Configuration["AzureAd:Tenant"]);
+            var appAuthority = string.Format(
+                CultureInfo.InvariantCulture,
+                Startup.Configuration["AzureAd:AuthorityForApplication"], 
+                Startup.Configuration["AzureAd:Tenant"]);
             var confidentialClient = GetConfidentialClientWithExtraParams(clientCredential, appAuthority, userId, session);
 
             return await confidentialClient.AcquireTokenForClientAsync(scopes).ConfigureAwait(false);

--- a/msal/tests/dev apps/XForms/XForms/AccessTokenCacheItemDetails.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/AccessTokenCacheItemDetails.xaml.cs
@@ -28,6 +28,7 @@
 using Microsoft.Identity.Core.Cache;
 using Microsoft.Identity.Core.Helpers;
 using System;
+using System.Globalization;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -50,10 +51,12 @@ namespace XForms
             userIdentifierLabel.Text = msalAccessTokenCacheItem.HomeAccountId;
             userAssertionHashLabel.Text = msalAccessTokenCacheItem.UserAssertionHash;
 
-            expiresOnLabel.Text = msalAccessTokenCacheItem.ExpiresOn.ToString();
+            expiresOnLabel.Text = msalAccessTokenCacheItem.ExpiresOn.ToString(CultureInfo.InvariantCulture);
             scopesLabel.Text = msalAccessTokenCacheItem.NormalizedScopes;
 
-            cachedAtLabel.Text = CoreHelpers.UnixTimestampStringToDateTime(msalAccessTokenCacheItem.CachedAt).ToString();
+            cachedAtLabel.Text = CoreHelpers
+                .UnixTimestampStringToDateTime(msalAccessTokenCacheItem.CachedAt)
+                .ToString(CultureInfo.InvariantCulture);
 
             rawClientInfoLabel.Text = msalAccessTokenCacheItem.RawClientInfo;
             clientInfoUniqueIdentifierLabel.Text = msalAccessTokenCacheItem.ClientInfo.UniqueObjectIdentifier;

--- a/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/CachePage.xaml.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client.Internal;
 using Microsoft.Identity.Core;
@@ -101,7 +102,8 @@ namespace XForms
 
         private static string GetCurrentTimestamp()
         {
-            return ((long)(DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds).ToString();
+            return ((long)(DateTime.UtcNow - new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds)
+                .ToString(CultureInfo.InvariantCulture);
         }
 
         public void OnExpire(object sender, EventArgs e)

--- a/msal/tests/dev apps/XForms/XForms/SettingsPage.xaml.cs
+++ b/msal/tests/dev apps/XForms/XForms/SettingsPage.xaml.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
@@ -50,13 +51,13 @@ namespace XForms
             clientIdEntry.Text = App.ClientId;
 
             numOfAtItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllAccessTokensAsString()
-                .Count.ToString();
+                .Count.ToString(CultureInfo.InvariantCulture);
             numOfRtItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllRefreshTokensAsString()
-                .Count.ToString();
+                .Count.ToString(CultureInfo.InvariantCulture);
             numOfIdItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllIdTokensAsString()
-                .Count.ToString();
+                .Count.ToString(CultureInfo.InvariantCulture);
             numOfAccountItems.Text = App.MsalPublicClient.UserTokenCache.tokenCacheAccessor.GetAllAccountsAsString()
-                .Count.ToString();
+                .Count.ToString(CultureInfo.InvariantCulture);
 
             validateAuthority.IsToggled = App.ValidateAuthority;
             RedirectUriLabel.Text = App.MsalPublicClient.RedirectUri;


### PR DESCRIPTION
Release build failing because FxCop rule CA1305 broken. Enabled this rule in our Roslyn analyzer and fixed all occurences. Note that Roslyn is not as powerful as FxCop for static analysis, but should catch most errors.