### PR TITLE
Automation Test refactoring and support for UIBehavior picker

### DIFF
--- a/adal/tests/Test.ADAL.NET.UIAutomation/ADALMobileTestHelper.cs
+++ b/adal/tests/Test.ADAL.NET.UIAutomation/ADALMobileTestHelper.cs
@@ -75,58 +75,58 @@ namespace Test.ADAL.UIAutomation
 
         public void AcquireTokenInteractiveHelper(UserQueryParameters userParams)
         {
-            var user = PrepareForAuthentication(_testController, userParams);
-            SetInputData(_testController, CoreUiTestConstants.MSIDLAB4ClientId, CoreUiTestConstants.MSGraph);
+            var user = PrepareForAuthentication(userParams);
+            SetInputData(CoreUiTestConstants.MSIDLAB4ClientId, CoreUiTestConstants.MSGraph);
             _coreMobileTestHelper.PerformSignInFlow(user);
         }
 
         public void AcquireTokenWithPromptBehaviorAlwaysHelper(UserQueryParameters userParams)
         {
-            var user = PrepareForAuthentication(_testController, userParams);
-            SetInputData(_testController, CoreUiTestConstants.MSIDLAB4ClientId, CoreUiTestConstants.MSGraph);
+            var user = PrepareForAuthentication(userParams);
+            SetInputData(CoreUiTestConstants.MSIDLAB4ClientId, CoreUiTestConstants.MSGraph);
 
             // AcquireToken promptBehavior.Auto to get a token in the cache 
-            SetPromptBehavior(_testController, CoreUiTestConstants.PromptBehaviorAuto);
+            SetPromptBehavior(CoreUiTestConstants.PromptBehaviorAuto);
             _coreMobileTestHelper.PerformSignInFlow(user);
 
             // AcquireToken promptBehavior.Always. Even with a token, the UI should be shown 
-            SetPromptBehavior(_testController, CoreUiTestConstants.PromptBehaviorAlways);
+            SetPromptBehavior(CoreUiTestConstants.PromptBehaviorAlways);
             _coreMobileTestHelper.PerformSignInFlow(user);
 
             // AcquireToken promptBehavior.Auto. No UI should be shown. 
-            SetPromptBehavior(_testController, CoreUiTestConstants.PromptBehaviorAuto);
+            SetPromptBehavior(CoreUiTestConstants.PromptBehaviorAuto);
             _coreMobileTestHelper.PerformSignInFlowWithoutUI();
             _coreMobileTestHelper.VerifyResult();
         }
 
-        private IUser PrepareForAuthentication(ITestController controller, UserQueryParameters userParams)
+        private IUser PrepareForAuthentication(UserQueryParameters userParams)
         {
             //Navigate to second page
-            controller.Tap(CoreUiTestConstants.SecondPageID);
+            _testController.Tap(CoreUiTestConstants.SecondPageID);
 
             //Clear Cache
-            controller.Tap(CoreUiTestConstants.ClearCacheID);
+            _testController.Tap(CoreUiTestConstants.ClearCacheID);
 
             //Get User from Lab
-            return controller.GetUser(userParams);
+            return _testController.GetUser(userParams);
         }
 
-        private void SetInputData(ITestController controller, string clientID, string resource)
+        private void SetInputData(string clientID, string resource)
         {
             //Enter ClientID
-            controller.EnterText(CoreUiTestConstants.ClientIdEntryID, clientID, false);
-            controller.DismissKeyboard();
+            _testController.EnterText(CoreUiTestConstants.ClientIdEntryID, clientID, false);
+            _testController.DismissKeyboard();
 
             //Enter Resource
-            controller.EnterText(CoreUiTestConstants.ResourceEntryID, resource, false);
-            controller.DismissKeyboard();
+            _testController.EnterText(CoreUiTestConstants.ResourceEntryID, resource, false);
+            _testController.DismissKeyboard();
         }
 
-        private void SetPromptBehavior(ITestController controller, string promptBehavior)
+        private void SetPromptBehavior(string promptBehavior)
         {
             //Select PromptBehavior 
-            controller.EnterText(CoreUiTestConstants.PromptBehaviorEntryID, promptBehavior, false);
-            controller.DismissKeyboard();
+            _testController.EnterText(CoreUiTestConstants.PromptBehaviorEntryID, promptBehavior, false);
+            _testController.DismissKeyboard();
         }
     }
 }

--- a/adal/tests/Test.ADAL.NET.UIAutomation/ADALMobileTestHelper.cs
+++ b/adal/tests/Test.ADAL.NET.UIAutomation/ADALMobileTestHelper.cs
@@ -26,13 +26,7 @@
 //------------------------------------------------------------------------------
 
 using Test.Microsoft.Identity.LabInfrastructure;
-using NUnit.Framework;
 using Test.Microsoft.Identity.Core.UIAutomation;
-using Xamarin.UITest;
-using Xamarin.UITest.Queries;
-using System.Threading;
-using System;
-using System.Threading.Tasks;
 
 namespace Test.ADAL.UIAutomation
 {
@@ -41,61 +35,68 @@ namespace Test.ADAL.UIAutomation
     /// </summary>
 	public class ADALMobileTestHelper
     {
-        CoreMobileTestHelper CoreMobileTestHelper = new CoreMobileTestHelper();
+        private ITestController _testController;
+        private CoreMobileTestHelper _coreMobileTestHelper;
+
+        public ADALMobileTestHelper(ITestController testController)
+        {
+            _testController = testController;
+            _coreMobileTestHelper = new CoreMobileTestHelper(testController);
+        }
 
         /// <summary>
         /// Runs through the standard acquire token interactive flow
         /// </summary>
         /// <param name="controller">The test framework that will execute the test interaction</param>
-        public void AcquireTokenInteractiveTestHelper(ITestController controller, UserQueryParameters userParams)
+        public void AcquireTokenInteractiveTestHelper(UserQueryParameters userParams)
         {
-            AcquireTokenInteractiveHelper(controller, userParams);
-            CoreMobileTestHelper.VerifyResult(controller);
+            AcquireTokenInteractiveHelper(userParams);
+            _coreMobileTestHelper.VerifyResult();
         }
 
         /// <summary>
         /// Runs through the standard acquire token silent flow
         /// </summary>
         /// <param name="controller">The test framework that will execute the test interaction</param>
-        public void AcquireTokenSilentTestHelper(ITestController controller, UserQueryParameters userParams)
+        public void AcquireTokenSilentTestHelper(UserQueryParameters userParams)
         {
-            AcquireTokenInteractiveHelper(controller, userParams);
-            CoreMobileTestHelper.VerifyResult(controller);
+            AcquireTokenInteractiveHelper(userParams);
+            _coreMobileTestHelper.VerifyResult();
 
             //Enter 2nd Resource
-            controller.EnterText(CoreUiTestConstants.ResourceEntryID, CoreUiTestConstants.Exchange, false);
-            controller.DismissKeyboard();
+            _testController.EnterText(CoreUiTestConstants.ResourceEntryID, CoreUiTestConstants.Exchange, false);
+            _testController.DismissKeyboard();
 
             //Acquire token silently
-            controller.Tap(CoreUiTestConstants.AcquireTokenSilentID);
+            _testController.Tap(CoreUiTestConstants.AcquireTokenSilentID);
 
-            CoreMobileTestHelper.VerifyResult(controller);
+            _coreMobileTestHelper.VerifyResult();
         }
 
-        public void AcquireTokenInteractiveHelper(ITestController controller, UserQueryParameters userParams)
+        public void AcquireTokenInteractiveHelper(UserQueryParameters userParams)
         {
-            var user = PrepareForAuthentication(controller, userParams);
-            SetInputData(controller, CoreUiTestConstants.MSIDLAB4ClientId, CoreUiTestConstants.MSGraph);
-            CoreMobileTestHelper.PerformSignInFlow(controller, user);
+            var user = PrepareForAuthentication(_testController, userParams);
+            SetInputData(_testController, CoreUiTestConstants.MSIDLAB4ClientId, CoreUiTestConstants.MSGraph);
+            _coreMobileTestHelper.PerformSignInFlow(user);
         }
 
-        public void AcquireTokenWithPromptBehaviorAlwaysHelper(ITestController controller, UserQueryParameters userParams)
+        public void AcquireTokenWithPromptBehaviorAlwaysHelper(UserQueryParameters userParams)
         {
-            var user = PrepareForAuthentication(controller, userParams);
-            SetInputData(controller, CoreUiTestConstants.MSIDLAB4ClientId, CoreUiTestConstants.MSGraph);
+            var user = PrepareForAuthentication(_testController, userParams);
+            SetInputData(_testController, CoreUiTestConstants.MSIDLAB4ClientId, CoreUiTestConstants.MSGraph);
 
             // AcquireToken promptBehavior.Auto to get a token in the cache 
-            SetPromptBehavior(controller, CoreUiTestConstants.PromptBehaviorAuto);
-            CoreMobileTestHelper.PerformSignInFlow(controller, user);
+            SetPromptBehavior(_testController, CoreUiTestConstants.PromptBehaviorAuto);
+            _coreMobileTestHelper.PerformSignInFlow(user);
 
             // AcquireToken promptBehavior.Always. Even with a token, the UI should be shown 
-            SetPromptBehavior(controller, CoreUiTestConstants.PromptBehaviorAlways);
-            CoreMobileTestHelper.PerformSignInFlow(controller, user);
+            SetPromptBehavior(_testController, CoreUiTestConstants.PromptBehaviorAlways);
+            _coreMobileTestHelper.PerformSignInFlow(user);
 
             // AcquireToken promptBehavior.Auto. No UI should be shown. 
-            SetPromptBehavior(controller, CoreUiTestConstants.PromptBehaviorAuto);
-            CoreMobileTestHelper.PerformSignInFlowWithoutUI(controller);
-            CoreMobileTestHelper.VerifyResult(controller);
+            SetPromptBehavior(_testController, CoreUiTestConstants.PromptBehaviorAuto);
+            _coreMobileTestHelper.PerformSignInFlowWithoutUI();
+            _coreMobileTestHelper.VerifyResult();
         }
 
         private IUser PrepareForAuthentication(ITestController controller, UserQueryParameters userParams)

--- a/adal/tests/Test.ADAL.NET.UIAutomation/XamarinDroidADALTests.cs
+++ b/adal/tests/Test.ADAL.NET.UIAutomation/XamarinDroidADALTests.cs
@@ -44,14 +44,14 @@ namespace Test.ADAL.UIAutomation
     [TestFixture(Platform.Android)]
     public class XamarinDroidADALTests
     {
-        IApp app;
-        Platform platform;
-        ITestController xamarinController = new XamarinUITestController();
-        ADALMobileTestHelper _adalMobileTestHelper = new ADALMobileTestHelper();
+        IApp _app;
+        Platform _platform;
+        ITestController _testController;
+        ADALMobileTestHelper _adalMobileTestHelper;
 
         public XamarinDroidADALTests(Platform platform)
         {
-            this.platform = platform;
+            this._platform = platform;
         }
 
         /// <summary>
@@ -60,8 +60,10 @@ namespace Test.ADAL.UIAutomation
         [SetUp]
         public void InitializeTest()
         {
-            app = AppFactory.StartApp(platform, "com.Microsoft.XFormsDroid.ADAL");
-            xamarinController.Application = app;
+            _app = AppFactory.StartApp(_platform, "com.Microsoft.XFormsDroid.ADAL");
+            _testController = new XamarinUITestController();
+            _testController.Application = _app;
+            _adalMobileTestHelper = new ADALMobileTestHelper(_testController);
         }
 
         /// <summary>
@@ -70,7 +72,7 @@ namespace Test.ADAL.UIAutomation
         [Test]
         public void AcquireTokenInteractiveTest()
         {
-            _adalMobileTestHelper.AcquireTokenInteractiveTestHelper(xamarinController, LabUserHelper.DefaultUserQuery);
+            _adalMobileTestHelper.AcquireTokenInteractiveTestHelper(LabUserHelper.DefaultUserQuery);
         }
 
         /// <summary>
@@ -79,7 +81,7 @@ namespace Test.ADAL.UIAutomation
         [Test]
         public void AcquireTokenSilentTest()
         {
-            _adalMobileTestHelper.AcquireTokenSilentTestHelper(xamarinController, LabUserHelper.DefaultUserQuery);
+            _adalMobileTestHelper.AcquireTokenSilentTestHelper(LabUserHelper.DefaultUserQuery);
         }
 
         /// <summary>
@@ -90,7 +92,7 @@ namespace Test.ADAL.UIAutomation
         [Test]
         public void AcquireTokenInteractiveWithPromptAlwaysTest()
         {
-            _adalMobileTestHelper.AcquireTokenWithPromptBehaviorAlwaysHelper(xamarinController, LabUserHelper.DefaultUserQuery);
+            _adalMobileTestHelper.AcquireTokenWithPromptBehaviorAlwaysHelper(LabUserHelper.DefaultUserQuery);
         }
 
         /// <summary>
@@ -103,7 +105,7 @@ namespace Test.ADAL.UIAutomation
             user.FederationProvider = FederationProvider.AdfsV4;
             user.IsFederatedUser = true;
 
-            _adalMobileTestHelper.AcquireTokenInteractiveTestHelper(xamarinController, user);
+            _adalMobileTestHelper.AcquireTokenInteractiveTestHelper(user);
         }
 
         /// <summary>
@@ -116,7 +118,7 @@ namespace Test.ADAL.UIAutomation
             user.FederationProvider = FederationProvider.AdfsV4;
             user.IsFederatedUser = false;
 
-            _adalMobileTestHelper.AcquireTokenInteractiveTestHelper(xamarinController, user);
+            _adalMobileTestHelper.AcquireTokenInteractiveTestHelper(user);
         }
 
         /// <summary>
@@ -129,7 +131,7 @@ namespace Test.ADAL.UIAutomation
             user.FederationProvider = FederationProvider.AdfsV3;
             user.IsFederatedUser = true;
 
-            _adalMobileTestHelper.AcquireTokenInteractiveTestHelper(xamarinController, user);
+            _adalMobileTestHelper.AcquireTokenInteractiveTestHelper(user);
         }
 
         /// <summary>
@@ -142,7 +144,9 @@ namespace Test.ADAL.UIAutomation
             user.FederationProvider = FederationProvider.AdfsV3;
             user.IsFederatedUser = false;
 
-            _adalMobileTestHelper.AcquireTokenInteractiveTestHelper(xamarinController, user);
+            _adalMobileTestHelper.AcquireTokenInteractiveTestHelper(user);
         }
+
+
     }
 }

--- a/core/tests/Test.Microsoft.Identity.Core.UIAutomation/CoreMobileTestHelper.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.UIAutomation/CoreMobileTestHelper.cs
@@ -38,7 +38,7 @@ namespace Test.Microsoft.Identity.Core.UIAutomation
 
         public CoreMobileTestHelper(ITestController testController)
         {
-            this._controller = testController;
+            _controller = testController;
         }
 
         public void PerformSignInFlow(IUser user)

--- a/core/tests/Test.Microsoft.Identity.Core.UIAutomation/CoreMobileTestHelper.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.UIAutomation/CoreMobileTestHelper.cs
@@ -33,37 +33,44 @@ using Test.Microsoft.Identity.LabInfrastructure;
 namespace Test.Microsoft.Identity.Core.UIAutomation
 {
     public class CoreMobileTestHelper
-    {   
-        public void PerformSignInFlow(ITestController controller, IUser user)
+    {
+        ITestController _controller;
+
+        public CoreMobileTestHelper(ITestController testController)
+        {
+            this._controller = testController;
+        }
+
+        public void PerformSignInFlow(IUser user)
         {
             UserInformationFieldIds userInformationFieldIds = new UserInformationFieldIds();
             userInformationFieldIds.DetermineUser(user);
 
             //Acquire token flow
-            controller.Tap(CoreUiTestConstants.AcquireTokenID);
+            _controller.Tap(CoreUiTestConstants.AcquireTokenID);
             //i0116 = UPN text field on AAD sign in endpoint
-            controller.EnterText(CoreUiTestConstants.WebUPNInputID, 20, user.Upn, true);
-            controller.DismissKeyboard();
+            _controller.EnterText(CoreUiTestConstants.WebUPNInputID, 20, user.Upn, true);
+            _controller.DismissKeyboard();
             //idSIButton9 = Sign in button
-            controller.Tap(CoreUiTestConstants.WebSubmitID, true);
+            _controller.Tap(CoreUiTestConstants.WebSubmitID, true);
             //i0118 = password text field
-            controller.EnterText(userInformationFieldIds.PasswordInputId, ((LabUser)user).GetPassword(), true);
-            controller.DismissKeyboard();
-            controller.Tap(userInformationFieldIds.SignInButtonId, true);
+            _controller.EnterText(userInformationFieldIds.PasswordInputId, ((LabUser)user).GetPassword(), true);
+            _controller.DismissKeyboard();
+            _controller.Tap(userInformationFieldIds.SignInButtonId, true);
         }
 
-        public void PerformSignInFlowWithoutUI(ITestController controller)
+        public void PerformSignInFlowWithoutUI()
         {
             //Acquire token flow
-            controller.Tap(CoreUiTestConstants.AcquireTokenID);
+            _controller.Tap(CoreUiTestConstants.AcquireTokenID);
         }
 
-        public void VerifyResult(ITestController controller)
+        public void VerifyResult()
         {
             RetryVerificationHelper(() =>
             {
                 //Test results are put into a label that is checked for messages
-                var result = controller.GetText(CoreUiTestConstants.TestResultID);
+                var result = _controller.GetText(CoreUiTestConstants.TestResultID);
                 if (result.Contains(CoreUiTestConstants.TestResultSuccsesfulMessage))
                 {
                     return;

--- a/core/tests/Test.Microsoft.Identity.Core.UIAutomation/CoreUiTestConstants.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.UIAutomation/CoreUiTestConstants.cs
@@ -66,9 +66,15 @@ namespace Test.Microsoft.Identity.Core.UIAutomation
         public const string CachePageID = "Cache";
         public const string SettingsPageID = "Settings";
         public const string ScopesEntryID = "scopesList";
+        public const string UiBehaviorID = "uiBehavior";
 
         //Test Constants
         public const int ResultCheckPolliInterval = 1000;
         public const int MaximumResultCheckRetryAttempts = 20;
+
+        // UIBehavior - these should match the public MSAL constants
+        public const string UIBehviorLogin = "login";
+        public const string UIBehviorConsent = "consent";
+        public const string UIBehviorSelectAccount = "select_account";
     }
 }

--- a/core/tests/Test.Microsoft.Identity.Core.UIAutomation/StringExtensions.cs
+++ b/core/tests/Test.Microsoft.Identity.Core.UIAutomation/StringExtensions.cs
@@ -1,0 +1,44 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+using System.Text;
+
+namespace Test.Microsoft.Identity.Core.UIAutomation
+{
+    public static class StringExtensions
+    {
+     
+
+        /// <summary>
+        /// Equals with an OrdinalIgnoreCase culture.
+        /// </summary>
+        public static bool CaseInsensitiveOrdinalEquals(this string stringInput, string otherString)
+        {
+            return string.Equals(stringInput, otherString, System.StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/core/tests/Test.Microsoft.Identity.Core.UIAutomation/Test.Microsoft.Identity.Core.UIAutomation.csproj
+++ b/core/tests/Test.Microsoft.Identity.Core.UIAutomation/Test.Microsoft.Identity.Core.UIAutomation.csproj
@@ -85,6 +85,7 @@
     <Compile Include="PlatformNotSupportedException.cs" />
     <Compile Include="ResultVerificationFailureException.cs" />
     <Compile Include="CoreUiTestConstants.cs" />
+    <Compile Include="StringExtensions.cs" />
     <Compile Include="UserInformationFieldIds.cs" />
     <Compile Include="XamarinUITestController.cs" />
   </ItemGroup>

--- a/msal/tests/Test.MSAL.NET.UIAutomation/MSALMobileTestHelper.cs
+++ b/msal/tests/Test.MSAL.NET.UIAutomation/MSALMobileTestHelper.cs
@@ -26,11 +26,7 @@
 //------------------------------------------------------------------------------
 
 using Test.Microsoft.Identity.LabInfrastructure;
-using NUnit.Framework;
 using Test.Microsoft.Identity.Core.UIAutomation;
-using System.Threading;
-using System;
-using System.Threading.Tasks;
 
 namespace Test.MSAL.UIAutomation
 {
@@ -39,64 +35,74 @@ namespace Test.MSAL.UIAutomation
     /// </summary>
     public class MSALMobileTestHelper
     {
-        CoreMobileTestHelper _coreMobileTestHelper = new CoreMobileTestHelper();
+        CoreMobileTestHelper _coreMobileTestHelper;
+        ITestController _testController;
 
+        public MSALMobileTestHelper(ITestController testController)
+        {
+            _testController = testController;
+            _coreMobileTestHelper = new CoreMobileTestHelper(testController);
+        }
         /// <summary>
         /// Runs through the standard acquire token flow
         /// </summary>
         /// <param name="controller">The test framework that will execute the test interaction</param>
-        public void AcquireTokenInteractiveTestHelper(ITestController controller, UserQueryParameters userParams)
+        public void AcquireTokenInteractiveTestHelper(
+            UserQueryParameters userParams,
+            string uiBehavior = "login")
         {
-            AcquireTokenInteractiveHelper(controller, userParams);
-            _coreMobileTestHelper.VerifyResult(controller);
+            AcquireTokenInteractiveHelper(userParams, uiBehavior);
+            _coreMobileTestHelper.VerifyResult();
         }
 
         /// <summary>
         /// Runs through the standard acquire token silent flow
         /// </summary>
         /// <param name="controller">The test framework that will execute the test interaction</param>
-        public void AcquireTokenSilentTestHelper(ITestController controller, UserQueryParameters userParams)
+        public void AcquireTokenSilentTestHelper(UserQueryParameters userParams)
         {
             //acquire token for 1st resource
-            AcquireTokenInteractiveHelper(controller, userParams);
-            _coreMobileTestHelper.VerifyResult(controller);
+            AcquireTokenInteractiveHelper(userParams, "login");
+            _coreMobileTestHelper.VerifyResult();
 
             //acquire token for 2nd resource with refresh token
-            SetInputData(controller, CoreUiTestConstants.UIAutomationAppV2, CoreUiTestConstants.DefaultScope);
-            controller.Tap(CoreUiTestConstants.AcquireTokenSilentID);
-            _coreMobileTestHelper.VerifyResult(controller);
+            SetInputData(CoreUiTestConstants.UIAutomationAppV2, CoreUiTestConstants.DefaultScope);
+            _testController.Tap(CoreUiTestConstants.AcquireTokenSilentID);
+            _coreMobileTestHelper.VerifyResult();
         }
 
-        private void AcquireTokenInteractiveHelper(ITestController controller, UserQueryParameters userParams)
+        private void AcquireTokenInteractiveHelper(
+            UserQueryParameters userParams,
+            string uiBehavior)
         {
-            var user = PrepareForAuthentication(controller, userParams);
-            SetInputData(controller, CoreUiTestConstants.UIAutomationAppV2, CoreUiTestConstants.DefaultScope);
-            _coreMobileTestHelper.PerformSignInFlow(controller, user);
+            var user = PrepareForAuthentication(userParams);
+            SetInputData(CoreUiTestConstants.UIAutomationAppV2, CoreUiTestConstants.DefaultScope);
+            _coreMobileTestHelper.PerformSignInFlow(user);
         }
 
-        private IUser PrepareForAuthentication(ITestController controller, UserQueryParameters userParams)
+        private IUser PrepareForAuthentication(UserQueryParameters userParams)
         {
             //Clear Cache
-            controller.Tap(CoreUiTestConstants.CachePageID);
-            controller.Tap(CoreUiTestConstants.ClearCacheID);
+            _testController.Tap(CoreUiTestConstants.CachePageID);
+            _testController.Tap(CoreUiTestConstants.ClearCacheID);
 
             //Get User from Lab
-            return controller.GetUser(userParams);
+            return _testController.GetUser(userParams);
         }
 
-        private void SetInputData(ITestController controller, string ClientID, string scopes)
+        private void SetInputData(string clientId, string scopes)
         {
-            controller.Tap(CoreUiTestConstants.SettingsPageID);
+            _testController.Tap(CoreUiTestConstants.SettingsPageID);
 
             //Enter ClientID
-            controller.EnterText(CoreUiTestConstants.ClientIdEntryID, ClientID, false);
-            controller.DismissKeyboard();
-            controller.Tap(CoreUiTestConstants.SaveID);
+            _testController.EnterText(CoreUiTestConstants.ClientIdEntryID, clientId, false);
+            _testController.DismissKeyboard();
+            _testController.Tap(CoreUiTestConstants.SaveID);
 
             //Enter Scopes
-            controller.Tap(CoreUiTestConstants.AcquireTokenID);
-            controller.EnterText(CoreUiTestConstants.ScopesEntryID, scopes, false);
-            controller.DismissKeyboard();
+            _testController.Tap(CoreUiTestConstants.AcquireTokenID);
+            _testController.EnterText(CoreUiTestConstants.ScopesEntryID, scopes, false);
+            _testController.DismissKeyboard();
         }
     }
 }

--- a/msal/tests/Test.MSAL.NET.UIAutomation/Test.MSAL.UIAutomation.csproj
+++ b/msal/tests/Test.MSAL.NET.UIAutomation/Test.MSAL.UIAutomation.csproj
@@ -10,10 +10,6 @@
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>
-  <PropertyGroup>
-    <SignAssembly>true</SignAssembly>
-    <AssemblyOriginatorKeyFile>../../../build/MSAL.snk</AssemblyOriginatorKeyFile>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -64,7 +60,6 @@
   </ItemGroup>
   <!-- This is how it runs in AppCenter -->
   <ItemGroup Condition="'$(NUNIT_HACK)' == ''">
-    <!--<PackageReference Include="Newtonsoft.Json" Version="6.0.8"/>-->
     <PackageReference Include="NUnit" Version="2.6.4" />
     <PackageReference Include="NUnitTestAdapter" Version="2.1.1" />
   </ItemGroup>

--- a/msal/tests/Test.MSAL.NET.UIAutomation/XamarinDroidMSALTests.cs
+++ b/msal/tests/Test.MSAL.NET.UIAutomation/XamarinDroidMSALTests.cs
@@ -43,14 +43,14 @@ namespace Test.MSAL.UIAutomation
     [TestFixture(Platform.Android)]
     public class XamarinMSALDroidTests
     {
-        IApp app;
-        Platform platform;
-        ITestController xamarinController = new XamarinUITestController();
-        MSALMobileTestHelper _msalMobileTestHelper = new MSALMobileTestHelper();
+        IApp _app;
+        Platform _platform;
+        ITestController _xamarinController;
+        MSALMobileTestHelper _msalMobileTestHelper;
 
         public XamarinMSALDroidTests(Platform platform)
         {
-            this.platform = platform;
+            this._platform = platform;
         }
 
         /// <summary>
@@ -59,8 +59,11 @@ namespace Test.MSAL.UIAutomation
         [SetUp]
         public void InitializeBeforeTest()
         {
-            app = AppFactory.StartApp(platform, "com.Microsoft.XFormsDroid.MSAL");
-            xamarinController.Application = app;
+            _app = AppFactory.StartApp(_platform, "com.Microsoft.XFormsDroid.MSAL");
+            _xamarinController = new XamarinUITestController();
+            _msalMobileTestHelper = new MSALMobileTestHelper(_xamarinController);
+
+            _xamarinController.Application = _app;
         }
 
         /// <summary>
@@ -69,16 +72,16 @@ namespace Test.MSAL.UIAutomation
         [Test]
         public void AcquireTokenTest()
         {
-            _msalMobileTestHelper.AcquireTokenInteractiveTestHelper(xamarinController, LabUserHelper.DefaultUserQuery);
+            _msalMobileTestHelper.AcquireTokenInteractiveTestHelper(LabUserHelper.DefaultUserQuery);
         }
-
+    
         /// <summary>
         /// Runs through the standard acquire token silent flow
         /// </summary>
         [Test]
         public void AcquireTokenSilentTest()
         {
-            _msalMobileTestHelper.AcquireTokenSilentTestHelper(xamarinController, LabUserHelper.DefaultUserQuery);
+            _msalMobileTestHelper.AcquireTokenSilentTestHelper(LabUserHelper.DefaultUserQuery);
         }
 
         /// <summary>
@@ -91,7 +94,7 @@ namespace Test.MSAL.UIAutomation
             user.FederationProvider = FederationProvider.AdfsV4;
             user.IsFederatedUser = true;
 
-            _msalMobileTestHelper.AcquireTokenInteractiveTestHelper(xamarinController, user);
+            _msalMobileTestHelper.AcquireTokenInteractiveTestHelper(user);
         }
 
         /// <summary>
@@ -104,7 +107,7 @@ namespace Test.MSAL.UIAutomation
             user.FederationProvider = FederationProvider.AdfsV3;
             user.IsFederatedUser = true;
 
-            _msalMobileTestHelper.AcquireTokenInteractiveTestHelper(xamarinController, user);
+            _msalMobileTestHelper.AcquireTokenInteractiveTestHelper(user);
         }
 
         /// <summary>
@@ -117,7 +120,7 @@ namespace Test.MSAL.UIAutomation
             user.FederationProvider = FederationProvider.AdfsV4;
             user.IsFederatedUser = false;
 
-            _msalMobileTestHelper.AcquireTokenInteractiveTestHelper(xamarinController, user);
+            _msalMobileTestHelper.AcquireTokenInteractiveTestHelper(user);
         }
 
         /// <summary>
@@ -130,7 +133,7 @@ namespace Test.MSAL.UIAutomation
             user.FederationProvider = FederationProvider.AdfsV3;
             user.IsFederatedUser = false;
 
-            _msalMobileTestHelper.AcquireTokenInteractiveTestHelper(xamarinController, user);
+            _msalMobileTestHelper.AcquireTokenInteractiveTestHelper(user);
         }
     }
 }


### PR DESCRIPTION
1. Add more state to objects instead of passing state in each method
2. Remove signing on MSAL test to be able to take dependency on Xamarin.UITest