### PR TITLE
Jennyf/ios

### DIFF
--- a/core/src/Platforms/iOS/EmbeddedWebview/AuthenticationAgentUIViewController.cs
+++ b/core/src/Platforms/iOS/EmbeddedWebview/AuthenticationAgentUIViewController.cs
@@ -106,7 +106,6 @@ namespace Microsoft.Identity.Core.UI.EmbeddedWebview
 
         public void CancelAuthentication(object sender, EventArgs e)
         {
-            this.callbackMethod(new AuthorizationResult(AuthorizationStatus.UserCancel, null));
             this.DismissViewController(true, () =>
                     callbackMethod(new AuthorizationResult(AuthorizationStatus.UserCancel, null)));
         }


### PR DESCRIPTION
Remove extra callback...causes problems are reported with this [issue](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/672). I verified, as did the customer, that this fix addresses the problem. Does not affect other cancellation operations on iOS. Would be nice to get in next release.