### PR TITLE
Allow users to set HttpMessageHandler

### DIFF
--- a/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/adal/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -26,6 +26,7 @@
 //------------------------------------------------------------------------------
 
 using System;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Identity.Core;
 using Microsoft.Identity.Core.Cache;
@@ -52,8 +53,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
     /// </summary>
     public sealed class AuthenticationContext
     {
-        private readonly IHttpManager _httpManager;
-        private readonly IWsTrustWebRequestManager _wsTrustWebRequestManager;
+        private IHttpManager _httpManager;
+        private IWsTrustWebRequestManager _wsTrustWebRequestManager;
 
         static AuthenticationContext()
         {
@@ -116,6 +117,15 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             this.TokenCache = tokenCache;
 
             _httpManager = httpManager ?? new HttpManager();
+            _wsTrustWebRequestManager = new WsTrustWebRequestManager(_httpManager);
+        }
+
+        /// <summary>
+        /// Provides a mechanism for adding custom message handlers in the HttpClient used by this library.
+        /// </summary>
+        public void UseCustomHttpMessageHandler(HttpMessageHandler httpMessageHandler)
+        {
+            _httpManager = new HttpManager(httpMessageHandler);
             _wsTrustWebRequestManager = new WsTrustWebRequestManager(_httpManager);
         }
 

--- a/core/src/Http/HttpClientFactory.cs
+++ b/core/src/Http/HttpClientFactory.cs
@@ -40,17 +40,18 @@ namespace Microsoft.Identity.Core.Http
         // The HttpClient is a singleton per ClientApplication so that we don't have a process wide singleton.
         public const long MaxResponseContentBufferSizeInBytes = 1024*1024;
 
-        public HttpClientFactory()
+        public HttpClientFactory(HttpMessageHandler customHttpMessageHandler = null)
         {
-            var httpClient = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true })
-            {
-                MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
-            };
+            HttpMessageHandler httpMessageHandler = customHttpMessageHandler ?? new HttpClientHandler() { UseDefaultCredentials = true };
 
+            var httpClient = new HttpClient(httpMessageHandler);
+
+            httpClient.MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes;
             httpClient.DefaultRequestHeaders.Accept.Clear();
             httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
 
             HttpClient = httpClient;
+            
         }
 
         public HttpClient HttpClient { get; }

--- a/core/src/Http/HttpManager.cs
+++ b/core/src/Http/HttpManager.cs
@@ -46,6 +46,17 @@ namespace Microsoft.Identity.Core.Http
             _httpClientFactory = httpClientFactory ?? new HttpClientFactory();
         }
 
+        public HttpManager(HttpMessageHandler customMessageHandler)
+        {
+            if (customMessageHandler == null)
+            {
+                throw new ArgumentNullException(nameof(customMessageHandler));
+            }
+
+            _httpClientFactory = new HttpClientFactory(customMessageHandler);
+            _coreExceptionFactory = CoreExceptionFactory.Instance;
+        }
+
         protected virtual HttpClient GetHttpClient()
         {
             return _httpClientFactory.HttpClient;


### PR DESCRIPTION
This is related to https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1397. This PR is incomplete (needs the same on MSAL and needs unit tests), but I'd like to an input on the approach / public API. 