### PR TITLE
fix [1406] and cache DeviceId in platformproxy on net desktop

### DIFF
--- a/core/src/Platforms/net45/NetDesktopPlatformProxy.cs
+++ b/core/src/Platforms/net45/NetDesktopPlatformProxy.cs
@@ -215,14 +215,17 @@ namespace Microsoft.Identity.Core
             return Assembly.GetEntryAssembly()?.GetName()?.Version?.ToString();
         }
 
+        private static readonly Lazy<string> DeviceId = new Lazy<string>(
+            () => NetworkInterface.GetAllNetworkInterfaces().Where(nic => nic.OperationalStatus == OperationalStatus.Up)
+                                  .Select(nic => nic.GetPhysicalAddress()?.ToString()).FirstOrDefault());
+
         /// <summary>
-        /// Considered PII, ensure that it is hashed. 
+        /// Considered PII, ensure that it is hashed.
         /// </summary>
         /// <returns>Device identifier</returns>
         public string GetDeviceId()
         {
-            return  NetworkInterface.GetAllNetworkInterfaces().Where(nic => nic.OperationalStatus == OperationalStatus.Up)
-                .Select(nic => nic.GetPhysicalAddress()?.ToString()).FirstOrDefault();
+            return DeviceId.Value;
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1406