### PR TITLE
Add a public ctor to AuthenticationResult to allow developers to mock auth flows

### DIFF
--- a/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Identity.Client
         /// Client applications accept extended life time tokens only if
         /// the ExtendedLifeTimeEnabled Boolean is set to true on ClientApplicationBase.
         /// </summary>
-        public bool IsExtendedLifeTimeToken { get; internal set; }
+        public bool IsExtendedLifeTimeToken { get; }
 
         /// <summary>
         /// Gets the Unique Id of the account. It can be null. When the <see cref="IdToken"/> is not <c>null</c>, this is its ID, that

--- a/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -91,7 +91,8 @@ namespace Microsoft.Identity.Client
             this.ExtendedExpiresOn = msalAccessTokenCacheItem.ExtendedExpiresOn;
             this.TenantId = msalIdTokenCacheItem?.IdToken?.TenantId;
             this.IdToken = msalIdTokenCacheItem?.Secret;
-            this.Scopes = msalAccessTokenCacheItem.ScopeSet;            
+            this.Scopes = msalAccessTokenCacheItem.ScopeSet;
+            this.IsExtendedLifeTimeToken = msalAccessTokenCacheItem.IsExtendedLifeTimeToken;
         }
 
         /// <summary>

--- a/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -46,8 +46,8 @@ namespace Microsoft.Identity.Client
         private const string Oauth2AuthorizationHeader = "Bearer ";
 
         /// <summary>
-        /// Constructor meant for test purposes, to allow mocking of authentication flows. Developers should 
-        /// never new up <see cref="AuthenticationResult"/> in product code.
+        /// Constructor meant to help application developers test their apps. Allows mocking of authentication flows. 
+        /// App developers should never new-up <see cref="AuthenticationResult"/> in product code.
         /// </summary>
         public AuthenticationResult(
             string accessToken, 

--- a/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
+++ b/msal/src/Microsoft.Identity.Client/AuthenticationResult.cs
@@ -44,8 +44,32 @@ namespace Microsoft.Identity.Client
 #pragma warning restore CS1574 // XML comment has cref attribute that could not be resolved
     {
         private const string Oauth2AuthorizationHeader = "Bearer ";
-        private readonly MsalAccessTokenCacheItem _msalAccessTokenCacheItem;
-        private readonly MsalIdTokenCacheItem _msalIdTokenCacheItem;
+
+        /// <summary>
+        /// Constructor meant for test purposes, to allow mocking of authentication flows. Developers should 
+        /// never new up <see cref="AuthenticationResult"/> in product code.
+        /// </summary>
+        public AuthenticationResult(
+            string accessToken, 
+            bool isExtendedLifeTimeToken, 
+            string uniqueId, 
+            DateTimeOffset expiresOn, 
+            DateTimeOffset extendedExpiresOn, 
+            string tenantId, 
+            IAccount account, 
+            string idToken, 
+            IEnumerable<string> scopes)
+        {
+            AccessToken = accessToken;
+            IsExtendedLifeTimeToken = isExtendedLifeTimeToken;
+            UniqueId = uniqueId;
+            ExpiresOn = expiresOn;
+            ExtendedExpiresOn = extendedExpiresOn;
+            TenantId = tenantId;
+            Account = account;
+            IdToken = idToken;
+            Scopes = scopes;
+        }
 
         internal AuthenticationResult()
         {
@@ -53,19 +77,27 @@ namespace Microsoft.Identity.Client
 
         internal AuthenticationResult(MsalAccessTokenCacheItem msalAccessTokenCacheItem, MsalIdTokenCacheItem msalIdTokenCacheItem)
         {
-            _msalAccessTokenCacheItem = msalAccessTokenCacheItem;
-            _msalIdTokenCacheItem = msalIdTokenCacheItem;
-            if (_msalAccessTokenCacheItem.HomeAccountId != null)
+            if (msalAccessTokenCacheItem.HomeAccountId != null)
             {
-                Account = new Account(_msalAccessTokenCacheItem.HomeAccountId,
-                    _msalIdTokenCacheItem?.IdToken?.PreferredUsername, _msalAccessTokenCacheItem.Environment);
+                this.Account = new Account(
+                    msalAccessTokenCacheItem.HomeAccountId,
+                    msalIdTokenCacheItem?.IdToken?.PreferredUsername,
+                    msalAccessTokenCacheItem.Environment);
             }
+
+            this.AccessToken = msalAccessTokenCacheItem.Secret;
+            this.UniqueId = msalIdTokenCacheItem?.IdToken?.GetUniqueId();
+            this.ExpiresOn = msalAccessTokenCacheItem.ExpiresOn;
+            this.ExtendedExpiresOn = msalAccessTokenCacheItem.ExtendedExpiresOn;
+            this.TenantId = msalIdTokenCacheItem?.IdToken?.TenantId;
+            this.IdToken = msalIdTokenCacheItem?.Secret;
+            this.Scopes = msalAccessTokenCacheItem.ScopeSet;            
         }
 
         /// <summary>
-        /// Gets the Access Token to use as a bearer token to access the protected web API
+        /// Access Token that can be used as a bearer token to access protected web APIs
         /// </summary>
-        public virtual string AccessToken => _msalAccessTokenCacheItem.Secret;
+        public string AccessToken { get; }
 
         /// <summary>
         /// In case when Azure AD has an outage, to be more resilient, it can return tokens with
@@ -83,26 +115,26 @@ namespace Microsoft.Identity.Client
         /// Gets the Unique Id of the account. It can be null. When the <see cref="IdToken"/> is not <c>null</c>, this is its ID, that
         /// is its ObjectId claim, or if that claim is <c>null</c>, the Subject claim.
         /// </summary>
-        public virtual string UniqueId => _msalIdTokenCacheItem?.IdToken?.GetUniqueId();
+        public string UniqueId { get; }
 
         /// <summary>
         /// Gets the point in time in which the Access Token returned in the <see cref="AccessToken"/> property ceases to be valid.
         /// This value is calculated based on current UTC time measured locally and the value expiresIn received from the
         /// service.
         /// </summary>
-        public virtual DateTimeOffset ExpiresOn => _msalAccessTokenCacheItem.ExpiresOn;
+        public DateTimeOffset ExpiresOn { get; }
 
         /// <summary>
         /// Gets the point in time in which the Access Token returned in the AccessToken property ceases to be valid in MSAL's extended LifeTime.
         /// This value is calculated based on current UTC time measured locally and the value ext_expiresIn received from the service.
         /// </summary>
-        public virtual DateTimeOffset ExtendedExpiresOn => _msalAccessTokenCacheItem.ExtendedExpiresOn;
+        public DateTimeOffset ExtendedExpiresOn { get; }
 
         /// <summary>
         /// Gets an identifier for the Azure AD tenant from which the token was acquired. This property will be null if tenant information is
         /// not returned by the service.
         /// </summary>
-        public virtual string TenantId => _msalIdTokenCacheItem?.IdToken?.TenantId;
+        public string TenantId { get; }
 
         /// <summary>
         /// Gets the account information. Some elements in <see cref="IAccount"/> might be null if not returned by the
@@ -110,17 +142,17 @@ namespace Microsoft.Identity.Client
         /// as <see cref="IClientApplicationBase.AcquireTokenSilentAsync(IEnumerable{string}, IAccount)"/> or
         /// <see cref="IClientApplicationBase.RemoveAsync(IAccount)"/> for instance
         /// </summary>
-        public virtual IAccount Account { get; internal set; }
+        public IAccount Account { get; }
 
         /// <summary>
         /// Gets the  Id Token if returned by the service or null if no Id Token is returned.
         /// </summary>
-        public virtual string IdToken => _msalIdTokenCacheItem?.Secret;
+        public string IdToken { get; }
 
         /// <summary>
         /// Gets the granted scope values returned by the service.
         /// </summary>
-        public virtual IEnumerable<string> Scopes => _msalAccessTokenCacheItem.ScopeSet;
+        public IEnumerable<string> Scopes { get; }
 
         /// <summary>
         /// Creates the content for an HTTP authorization header from this authentication result, so
@@ -136,7 +168,7 @@ namespace Microsoft.Identity.Client
         /// HttpResponseMessage r = await client.GetAsync(urlOfTheProtectedApi);
         /// </code>
         /// </example>
-        public virtual string CreateAuthorizationHeader()
+        public string CreateAuthorizationHeader()
         {
             return Oauth2AuthorizationHeader + AccessToken;
         }

--- a/msal/tests/Test.MSAL.NET.Common/Core/Mocks/MockHttpManager.cs
+++ b/msal/tests/Test.MSAL.NET.Common/Core/Mocks/MockHttpManager.cs
@@ -56,7 +56,9 @@ namespace Test.Microsoft.Identity.Core.Unit.Mocks
             // This ensures we only check the mock queue on dispose when we're not in the middle of an
             // exception flow.  Otherwise, any early assertion will cause this to likely fail
             // even though it's not the root cause.
+#pragma warning disable CS0618 // Type or member is obsolete - this is non-production code so it's fine
             if (Marshal.GetExceptionCode() == 0)
+#pragma warning restore CS0618 // Type or member is obsolete
             {
                 Assert.AreEqual(0, _httpMessageHandlerQueue.Count, "All mocks should have been consumed");
             }

--- a/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/AuthenticationResultTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/AuthenticationResultTests.cs
@@ -1,0 +1,56 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+
+using Microsoft.Identity.Client;
+using Microsoft.Identity.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Test.MSAL.NET.Unit
+{
+    [TestClass]
+    public class AuthenticationResultTests
+    {
+        [TestMethod]
+        public void Foo()
+        {
+            var ctorParameters = typeof(AuthenticationResult)
+                .GetConstructors()
+                .First(ctor => ctor.GetParameters().Length > 3)
+                .GetParameters();
+
+            var classProperties = typeof(AuthenticationResult)
+                .GetProperties()
+                .Where(p => p.GetCustomAttribute(typeof(ObsoleteAttribute)) == null);
+
+            Assert.AreEqual(ctorParameters.Length, classProperties.Count(), "The <for test> constructor should include all properties of AuthenticationObject"); ;
+        }
+    }
+}

--- a/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/AuthenticationResultTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/AuthenticationResultTests.cs
@@ -39,7 +39,7 @@ namespace Test.MSAL.NET.Unit
     public class AuthenticationResultTests
     {
         [TestMethod]
-        public void Foo()
+        public void PublicTestConstructorCoversAllProperties()
         {
             var ctorParameters = typeof(AuthenticationResult)
                 .GetConstructors()

--- a/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/ConfidentialClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/ConfidentialClientApplicationTests.cs
@@ -70,9 +70,16 @@ namespace Test.MSAL.NET.Unit
         public void MockConfidentialClientApplication_AcquireToken()
         {
             // Setup up a confidential client application that returns a dummy result
-            var mockResult = Substitute.For<AuthenticationResult>();
-            mockResult.IdToken.Returns("id token");
-            mockResult.Scopes.Returns(new string[] { "scope1", "scope2" });
+            var mockResult = new AuthenticationResult(
+                accessToken: "",
+                isExtendedLifeTimeToken: false,
+                uniqueId: "",
+                expiresOn: DateTimeOffset.Now,
+                extendedExpiresOn: DateTimeOffset.Now, 
+                tenantId: "", 
+                account: null, 
+                idToken: "id token",
+                scopes: new[] { "scope1", "scope2" });
 
             var mockApp = Substitute.For<IConfidentialClientApplication>();
             mockApp.AcquireTokenByAuthorizationCodeAsync("123", null).Returns(mockResult);

--- a/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -81,9 +81,16 @@ namespace Test.MSAL.NET.Unit
         {
             // Setup up a public client application that returns a dummy result
             // The caller asks for two scopes, but only one is returned
-            var mockResult = Substitute.For<AuthenticationResult>();
-            mockResult.IdToken.Returns("id token");
-            mockResult.Scopes.Returns(new string[] { "scope1" });
+            var mockResult = new AuthenticationResult(
+               accessToken: "",
+               isExtendedLifeTimeToken: false,
+               uniqueId: "",
+               expiresOn: DateTimeOffset.Now,
+               extendedExpiresOn: DateTimeOffset.Now,
+               tenantId: "",
+               account: null,
+               idToken: "id token",
+               scopes: new[] { "scope1", "scope2" });
 
             var mockApp = Substitute.For<IPublicClientApplication>();
             mockApp.AcquireTokenAsync(new string[] { "scope1", "scope2" }).ReturnsForAnyArgs(mockResult);

--- a/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -90,7 +90,7 @@ namespace Test.MSAL.NET.Unit
                tenantId: "",
                account: null,
                idToken: "id token",
-               scopes: new[] { "scope1", "scope2" });
+               scopes: new[] { "scope1"});
 
             var mockApp = Substitute.For<IPublicClientApplication>();
             mockApp.AcquireTokenAsync(new string[] { "scope1", "scope2" }).ReturnsForAnyArgs(mockResult);


### PR DESCRIPTION
**Why?**
See customers feedback:
- [MSAL is difficult to test because AuthenticationResult is not mockable](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/682)
- [AcquireToken should return IAuthenticationResult instead of AuthenticationResult](https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/48*4)

**What?**
to avoid doing a breaking change, we decided to provide a constructor with all the properties, rather than adding an interface and changing all the AcquireTokenXX methods return types.