### PR TITLE
add initial benchmark infrastructure

### DIFF
--- a/LibsNoSamples.sln
+++ b/LibsNoSamples.sln
@@ -36,7 +36,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.Microsoft.Identity.Lab
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.Microsoft.Identity.SideBySide", "core\tests\Test.Microsoft.Identity.SideBySide\Test.Microsoft.Identity.SideBySide.csproj", "{D3033A40-F2C2-4495-BC9F-C3C6D497D1CC}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Msal.Benchmarks", "msal\tests\Msal.Benchmarks\Msal.Benchmarks.csproj", "{D41FB9CF-9474-461D-A6EA-8A27C383446E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Msal.Benchmarks", "msal\tests\Msal.Benchmarks\Msal.Benchmarks.csproj", "{232B5361-18AE-4EA0-9EED-696F3564909C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -88,10 +88,10 @@ Global
 		{D3033A40-F2C2-4495-BC9F-C3C6D497D1CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3033A40-F2C2-4495-BC9F-C3C6D497D1CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3033A40-F2C2-4495-BC9F-C3C6D497D1CC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D41FB9CF-9474-461D-A6EA-8A27C383446E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D41FB9CF-9474-461D-A6EA-8A27C383446E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D41FB9CF-9474-461D-A6EA-8A27C383446E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D41FB9CF-9474-461D-A6EA-8A27C383446E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{232B5361-18AE-4EA0-9EED-696F3564909C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{232B5361-18AE-4EA0-9EED-696F3564909C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{232B5361-18AE-4EA0-9EED-696F3564909C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{232B5361-18AE-4EA0-9EED-696F3564909C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -107,7 +107,7 @@ Global
 		{FCDDA8D3-F299-426B-9CAD-0824D941ED53} = {DC4A6EAD-07D8-480A-A111-F2F8C359735B}
 		{E22918A8-8FE6-47D2-B65E-34436918C5D7} = {5D231979-0A13-456D-B9F9-CED41F935FD9}
 		{D3033A40-F2C2-4495-BC9F-C3C6D497D1CC} = {5D231979-0A13-456D-B9F9-CED41F935FD9}
-		{D41FB9CF-9474-461D-A6EA-8A27C383446E} = {459B71BF-176E-4E1D-B77A-D21862DB115E}
+		{232B5361-18AE-4EA0-9EED-696F3564909C} = {459B71BF-176E-4E1D-B77A-D21862DB115E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6C88EF77-AF03-4F82-B666-1831DABAA119}

--- a/LibsNoSamples.sln
+++ b/LibsNoSamples.sln
@@ -36,6 +36,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.Microsoft.Identity.Lab
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.Microsoft.Identity.SideBySide", "core\tests\Test.Microsoft.Identity.SideBySide\Test.Microsoft.Identity.SideBySide.csproj", "{D3033A40-F2C2-4495-BC9F-C3C6D497D1CC}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Msal.Benchmarks", "msal\tests\Msal.Benchmarks\Msal.Benchmarks.csproj", "{D41FB9CF-9474-461D-A6EA-8A27C383446E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -86,6 +88,10 @@ Global
 		{D3033A40-F2C2-4495-BC9F-C3C6D497D1CC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3033A40-F2C2-4495-BC9F-C3C6D497D1CC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3033A40-F2C2-4495-BC9F-C3C6D497D1CC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D41FB9CF-9474-461D-A6EA-8A27C383446E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D41FB9CF-9474-461D-A6EA-8A27C383446E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D41FB9CF-9474-461D-A6EA-8A27C383446E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D41FB9CF-9474-461D-A6EA-8A27C383446E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -101,6 +107,7 @@ Global
 		{FCDDA8D3-F299-426B-9CAD-0824D941ED53} = {DC4A6EAD-07D8-480A-A111-F2F8C359735B}
 		{E22918A8-8FE6-47D2-B65E-34436918C5D7} = {5D231979-0A13-456D-B9F9-CED41F935FD9}
 		{D3033A40-F2C2-4495-BC9F-C3C6D497D1CC} = {5D231979-0A13-456D-B9F9-CED41F935FD9}
+		{D41FB9CF-9474-461D-A6EA-8A27C383446E} = {459B71BF-176E-4E1D-B77A-D21862DB115E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6C88EF77-AF03-4F82-B666-1831DABAA119}

--- a/msal/tests/Msal.Benchmarks/ConfidentialClientAcquireTokenWithCache.cs
+++ b/msal/tests/Msal.Benchmarks/ConfidentialClientAcquireTokenWithCache.cs
@@ -1,0 +1,63 @@
+﻿// ------------------------------------------------------------------------------
+// 
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+// 
+// This code is licensed under the MIT License.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+// ------------------------------------------------------------------------------
+
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Engines;
+using Microsoft.Identity.Client;
+
+namespace Msal.Benchmarks
+{
+    [SimpleJob(RunStrategy.Throughput, invocationCount: 1000)]
+    public class ConfidentialClientAcquireTokenWithCache
+    {
+        private static readonly TokenCache Cache = new TokenCache();
+        private static readonly TokenCache Cache2 = new TokenCache();
+
+        private static readonly ConfidentialClientApplication App = new ConfidentialClientApplication(
+            "a40e1db0-b7a2-4e6e-af0e-b4987f73228f",
+            "https://login.microsoftonline.com/botframework.com",
+            "localhost:8040",
+            new ClientCredential("sbF0902^}tyvpvEDXTMX9^|"),
+            Cache2,
+            Cache);
+
+        private static readonly Semaphore AuthContextSemaphore = new Semaphore(1, 1);
+
+        [Benchmark]
+        public async Task AcquireToken()
+        {
+            await App.AcquireTokenForClientAsync(
+                new[]
+                {
+                    "https://api.botframework.com/.default"
+                },
+                false).ConfigureAwait(false);
+        }
+    }
+}

--- a/msal/tests/Msal.Benchmarks/Msal.Benchmarks.csproj
+++ b/msal/tests/Msal.Benchmarks/Msal.Benchmarks.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <AssemblyTitle>Msal.Benchmarks</AssemblyTitle>
+    <AssemblyName>Msal.Benchmarks</AssemblyName>
+    <TargetFrameworks>net46;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.2" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Identity.Client\Microsoft.Identity.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/msal/tests/Msal.Benchmarks/Program.cs
+++ b/msal/tests/Msal.Benchmarks/Program.cs
@@ -1,0 +1,51 @@
+﻿// ------------------------------------------------------------------------------
+// 
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+// 
+// This code is licensed under the MIT License.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+// ------------------------------------------------------------------------------
+
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Exporters.Json;
+using BenchmarkDotNet.Exporters.Xml;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+
+namespace Msal.Benchmarks
+{
+    public static class Program
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args, GetGlobalConfig());
+        }
+
+        private static IConfig GetGlobalConfig()
+        {
+            return DefaultConfig
+                   .Instance.With(MarkdownExporter.GitHub, JsonExporter.Brief, JsonExporter.Default, XmlExporter.Default)
+                   .With(Job.Clr).With(Job.Default.AsDefault());
+        }
+    }
+}

--- a/msal/tests/Msal.Benchmarks/Properties/launchSettings.json
+++ b/msal/tests/Msal.Benchmarks/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "Msal.Benchmarks": {
+      "commandName": "Project",
+      "commandLineArgs": "-f *"
+    }
+  }
+}

--- a/msal/tests/Msal.Benchmarks/SleepBench.cs
+++ b/msal/tests/Msal.Benchmarks/SleepBench.cs
@@ -1,0 +1,47 @@
+﻿// ------------------------------------------------------------------------------
+// 
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+// 
+// This code is licensed under the MIT License.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// 
+// ------------------------------------------------------------------------------
+
+using System.Threading;
+using BenchmarkDotNet.Attributes;
+
+namespace Msal.Benchmarks
+{
+    public class SleepBench
+    {
+        [Benchmark]
+        public void Sleep()
+        {
+            Thread.Sleep(10);
+        }
+
+        [Benchmark(Description = "Thread.Sleep(20)")]
+        public void SleepWithDescription()
+        {
+            Thread.Sleep(20);
+        }
+    }
+}


### PR DESCRIPTION
This adds a new msal "test" project which is a console app linked to [BenchmarkDotNet](https://benchmarkdotnet.org/).  

It's currently setup to output github markdown and json files.  I'll look into how we can set this up to report up to VSTS results on the benchmark values so we can look for regressions.  It is not yet wired up to run as part of any tests, but this makes sense to run with Integration and end to end validation.

We can also do memory analysis, GC analysis, framework/runtime comparisons, and stack analysis using ETW for deeper diagnosis and debugging.

This tech is used by the CoreFX and CLR teams as well for their profiling.