### PR TITLE
[NetStandard Unification] Integrated Windows Auth

### DIFF
--- a/msal/src/MSAL.Common.props
+++ b/msal/src/MSAL.Common.props
@@ -98,11 +98,13 @@
     <None Include="$(PathToCoreSources)\*.md" LinkBase="Core" />
     <Compile Remove="$(PathToCoreSources)\Platforms\**\*.cs" />
     <Compile Remove="$(PathToCoreSources)\Features\**\*.*" />
-    
+
     <!-- Any feature that is included in NetStandard MUST be included in ALL frameworks. 
     Non-implementing frameworks should throw a PlatformNotImplementedEx and hide the public surface at build time-->
     <Compile Include="$(PathToMsalSources)\Features\PublicClientWithTokenCache\**\*.cs" LinkBase="Features\PublicClientWithTokenCache" />
-    
+    <Compile Include="$(PathToMsalSources)\Features\DeviceCode\**\*.cs" LinkBase="Features\DeviceCode" />
+    <Compile Include="$(PathToMsalSources)\Features\IntegratedWindowsAuth\**\*.cs" LinkBase="Features\IntegratedWindowsAuth" />
+
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
@@ -111,7 +113,6 @@
     <Compile Include="$(PathToCoreSources)\Features\Cache\**\*.cs" LinkBase="Core\Features\Cache" />
     <Compile Include="$(PathToMsalSources)\Features\ConfidentialClient\**\*.cs"  LinkBase="Features\ConfidentialClient" />
     <Compile Include="$(PathToMsalSources)\Features\EventSource\**\*.cs" LinkBase="Features\EventSource" />
-    <Compile Include="$(PathToMsalSources)\Features\DeviceCode\**\*.cs" LinkBase="Features\DeviceCode"/>
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
@@ -121,6 +122,7 @@
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Xml.XmlDocument" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="System.Security.SecureString" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
@@ -131,15 +133,15 @@
     <Compile Include="$(PathToMsalSources)\Platforms\netcore\**\*.cs" LinkBase="Platforms\netcore" />
     <Compile Include="$(PathToMsalSources)\Features\ConfidentialClient\**\*.cs" />
     <Compile Include="$(PathToMsalSources)\Features\EventSource\**\*.cs" />
-    <Compile Include="$(PathToMsalSources)\Features\IntegratedWindowsAuth\**\*.cs" />
-    <Compile Include="$(PathToMsalSources)\Features\UsernamePassword\**\*.cs" />
-    <Compile Include="$(PathToMsalSources)\Features\DeviceCode\**\*.cs" />
+    <Compile Include="$(PathToMsalSources)\Features\UsernamePassword\**\*.cs" LinkBase="Features\UsernamePassword"/>
+    
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Security.SecureString" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
@@ -149,9 +151,7 @@
     <Compile Include="$(PathToMsalSources)\Platforms\net45\**\*.cs" LinkBase="Platforms\net45" />
 
     <Compile Include="$(PathToMsalSources)\Features\EventSource\**\*.cs" LinkBase="Features\EventsSource" />
-    <Compile Include="$(PathToMsalSources)\Features\IntegratedWindowsAuth\**\*.cs" LinkBase="Features\IntegratedWindowsAuth" />
     <Compile Include="$(PathToMsalSources)\Features\UsernamePassword\**\*.cs" LinkBase="Features\UsernamePassword"/>
-    <Compile Include="$(PathToMsalSources)\Features\DeviceCode\**\*.cs" LinkBase="Features\DeviceCode" />
     <Compile Include="$(PathToMsalSources)\Features\ConfidentialClient\**\*.cs" LinkBase="Features\ConfidentialClient" />
     <Compile Update="$(PathToMsalSources)\Platforms\net45\CustomWebBrowser.CustomWebBrowserEvent.cs" SubType="Component" />
     <Compile Update="$(PathToMsalSources)\Platforms\net45\CustomWebBrowser.cs" SubType="Component" />
@@ -176,8 +176,6 @@
     <Compile Include="$(PathToMsalSources)\Features\EventSource\**\*.cs" />
     <!-- Bug on UWP where we accidentally included this feature. Not worth removing and breaking backwards compat now -->
     <Compile Remove="$(PathToMsalSources)\Features\PublicClientWithTokenCache\TokenCacheExtensions.cs" />
-    <Compile Include="$(PathToMsalSources)\Features\IntegratedWindowsAuth\**\*.cs" />
-    <Compile Include="$(PathToMsalSources)\Features\DeviceCode\**\*.cs" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
@@ -188,7 +186,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS10' ">
     <Compile Include="$(PathToMsalSources)\Platforms\iOS\**\*.cs" />
     <Compile Include="$(PathToCoreSources)\Platforms\iOS\**\*.cs" LinkBase="Core\Platforms\iOS" />
-    <Compile Include="$(PathToMsalSources)\Features\DeviceCode\**\*.cs" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel" />
@@ -205,7 +202,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'MonoAndroid8.1' ">
     <Compile Include="$(PathToMsalSources)\Platforms\Android\**\*.cs" />
     <Compile Include="$(PathToCoreSources)\Platforms\Android\**\*.cs" LinkBase="Core\Platforms\" />
-    <Compile Include="$(PathToMsalSources)\Features\DeviceCode\**\*.cs" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.IdentityModel" />

--- a/msal/src/Microsoft.Identity.Client/Features/IntegratedWindowsAuth/IPublicClientApplication.cs
+++ b/msal/src/Microsoft.Identity.Client/Features/IntegratedWindowsAuth/IPublicClientApplication.cs
@@ -31,6 +31,8 @@ using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Client
 {
+#if !ANDROID_BUILDTIME && !iOS_BUILDTIME
+
     /// <summary>
     /// Interface to be used with desktop or mobile applications (Desktop / UWP / Xamarin.iOS / Xamarin.Android).
     /// public client applications are not trusted to safely keep application secrets, and therefore they only access Web APIs in the name of the user only 
@@ -38,10 +40,7 @@ namespace Microsoft.Identity.Client
     /// </summary>
     public partial interface IPublicClientApplication : IClientApplicationBase
     {
-
-
-        // .net core does not support getting the upn from the OS, although it can be made to pull it from a Windows OS
-#if !NET_CORE
+#if !NET_CORE_BUILDTIME
 
         /// <summary>
         /// Non-interactive request to acquire a security token for the signed-in user in Windows, via Integrated Windows Authentication.
@@ -71,4 +70,5 @@ namespace Microsoft.Identity.Client
             string username);
 
     }
+#endif
 }

--- a/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
+++ b/msal/tests/Test.MSAL.NET.Unit.net45/PublicApiTests/PublicClientApplicationTests.cs
@@ -1369,7 +1369,7 @@ namespace Test.MSAL.NET.Unit
 #if NET_CORE
 
         [TestMethod]
-        public void NetCore_AcquireTokenInteractive_ThrowsPlatformNotSupported()
+        public void NetCore_AcquireToken_ThrowsPlatformNotSupported()
         {
             // Arrange
             PublicClientApplication pca = new PublicClientApplication("cid");
@@ -1423,6 +1423,8 @@ namespace Test.MSAL.NET.Unit
                     new[] {"extra scopes" },
                     CoreTestConstants.AuthorityCommonTenant,
                     (UIParent)null).ConfigureAwait(false),
+
+                async () => await pca.AcquireTokenByIntegratedWindowsAuthAsync(CoreTestConstants.Scope).ConfigureAwait(false)
 
             };
 


### PR DESCRIPTION
IWA has 2 overloads: 

(scopes, username) - make this available on .net desktop and UWP
(scopes) - .net desktop, UWP and .net core

For the rest of the platforms we will hide them and throw PlatformNotSupportedException