### PR TITLE
Allow HttpClient to be provided when creating AuthenticationContext

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/HttpClientFactory.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/HttpClientFactory.cs
@@ -40,15 +40,18 @@ namespace Microsoft.Identity.Core.Http
         // The HttpClient is a singleton per ClientApplication so that we don't have a process wide singleton.
         public const long MaxResponseContentBufferSizeInBytes = 1024*1024;
 
-        public HttpClientFactory()
+        public HttpClientFactory(HttpClient httpClient = null)
         {
-            var httpClient = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true })
+            if (httpClient == null)
             {
-                MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
-            };
-
-            httpClient.DefaultRequestHeaders.Accept.Clear();
-            httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                httpClient = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true })
+                {
+                    MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
+                };
+                
+                httpClient.DefaultRequestHeaders.Accept.Clear();
+                httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            }
 
             HttpClient = httpClient;
         }


### PR DESCRIPTION
This is a fix for issue #1459

When interacting with multiple different tenants new instances of the AuthenticationContext need to be created for each tenant.  Under the covers this causes a new instance of an HttpClient to be created.  This usage pattern causes connections to be re-established for each tenant and this can cause problems when working with large number of different tenants.

To resolve this, a new constructor has been added to the AuthenticationContext which allows a HttpClient instance to be provided.  This allows the user of the SDK to control the reuse of the HttpClient in scenarios where this is needed.