### PR TITLE
remove MSAL from authActivity name to avoid issues w/MSAL authActiivty

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/SystemWebview/AuthenticationActivity.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/SystemWebview/AuthenticationActivity.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Identity.Core.UI.SystemWebview
 {
     /// <summary>
     /// </summary>
-    [Activity(Name = "microsoft.identity.client.AuthenticationActivity")]
+    [Activity(Name = "microsoft.identitymodel.clients.AuthenticationActivity")]
     [Android.Runtime.Preserve(AllMembers = true)]
     internal class AuthenticationActivity : Activity
     {


### PR DESCRIPTION
Same issue as MSAL with iOS UniversalViews, but this time w/Android. Since the name was MSAL, I made the change in ADAL instead. Have verified it fixes the issue w/a new customer sample and am waiting for verification from them w/the release build I sent.

Here's the error message: 
![image](https://user-images.githubusercontent.com/19942418/50947256-39234f80-1452-11e9-8793-697c889cac7b.png)
