### PR TITLE
Updated Xamarin.Android support libraries to latest version

### DIFF
--- a/devApps/AdalAndroidTestApp/AdalAndroidTestApp.csproj
+++ b/devApps/AdalAndroidTestApp/AdalAndroidTestApp.csproj
@@ -108,7 +108,7 @@
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Xamarin.Android.Support.Compat">
-      <Version>27.0.2</Version>
+      <Version>27.0.2.1</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/devApps/XFormsApp.Droid/XFormsApp.Droid.csproj
+++ b/devApps/XFormsApp.Droid/XFormsApp.Droid.csproj
@@ -111,16 +111,16 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Xamarin.Android.Support.V4" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Compat" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Core.UI" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Annotations" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v7.Palette" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.V4" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Compat" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Design" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Core.UI" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.v7.CardView" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Annotations" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.Core.Utils" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.v7.MediaRouter" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.v7.Palette" Version="27.0.2.1" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="StrongNamer">

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Microsoft.IdentityModel.Clients.ActiveDirectory.csproj
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Microsoft.IdentityModel.Clients.ActiveDirectory.csproj
@@ -131,8 +131,8 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Xml" />
-    <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="27.0.2" />
-    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2" />
+    <PackageReference Include="Xamarin.Android.Support.CustomTabs" Version="27.0.2.1" />
+    <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="27.0.2.1" />
     <Compile Include="Platforms\android\**\*.cs" />
     <Compile Include="Features\NonWinCommon\**\*.cs" />
   </ItemGroup>


### PR DESCRIPTION
This PR includes a change to the NuGet package references for the Xamarin.Android.Support libraries which are referenced for the latest version of Android 8.1.

The references are revved to provide installation support for Android 8.1 targetted projects which reference the latest support libraries as mentioned as an issue in #1486.

Unsure whether there should be a consideration to move to Android 9.0 support and use the later 28.x NuGet packages.