### PR TITLE
Throw a relevant timeout ADALServiceException instead of null ref

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Exceptions/AdalError.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Exceptions/AdalError.cs
@@ -322,5 +322,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// PromptBehavior.Never is supported in SSO mode only (null or application's callback URI as redirectUri)
         /// </summary>
         public const string UapRedirectUriUnsupported = "uap_redirect_uri_not_supported";
+
+        /// <summary>
+        /// An http request has timed out after being retried once
+        /// </summary>
+        public const string HttpRequestTimeoutResilience = "http_request_timeout";
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Exceptions/AdalErrorMessage.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Exceptions/AdalErrorMessage.cs
@@ -152,6 +152,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         public const string DeviceCodeAuthorizationCodeExpired = "Verification code expired before contacting the server";
 
         public const string IwaNotSupportedForManagedUser = "Integrated Windows Auth is not supported for managed users. See https://aka.ms/adal-iwa for details.";
+
+        public const string HttpRequestTimeoutResilience = "An HTTP request has timed out. ADAL has already retried once. See inner exception for details";
     }
     
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Exceptions/AdalException.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Exceptions/AdalException.cs
@@ -227,6 +227,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                     message = AdalErrorMessage.UapRedirectUriUnsupported;
                     break;
 
+                case AdalError.HttpRequestTimeoutResilience:
+                    message = AdalErrorMessage.HttpRequestTimeoutResilience;
+                    break;
+
                 default:
                     message = AdalErrorMessage.Unknown;
                     break;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Http/AdalHttpClient.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Http/AdalHttpClient.cs
@@ -38,7 +38,7 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform;
 
 namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http
 {
-    class AdalHttpClient
+    internal class AdalHttpClient
     {
         private const string DeviceAuthHeaderName = "x-ms-PKeyAuth";
         private const string DeviceAuthHeaderValue = "1.0";
@@ -49,6 +49,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http
         private readonly RequestContext _requestContext;
         internal bool Resiliency = false;
         internal bool RetryOnce = true;
+        //private readonly HttpClient
 
         public AdalHttpClient(string uri, RequestContext requestContext)
         {
@@ -122,9 +123,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http
                         return await this.GetResponseAsync<T>(respondToDeviceAuthChallenge).ConfigureAwait(false);
                     }
 
-                    _requestContext.Logger.InfoPii(
+                    _requestContext.Logger.ErrorPii(
                         "Retry Failed, Exception message: " + ex.InnerException?.Message,
                         "Retry Failed, Exception type: " + ex.InnerException?.GetType());
+
+                     throw new AdalServiceException(AdalError.HttpRequestTimeoutResilience, ex);
                 }
 
                 if (!this.IsDeviceAuthChallenge(ex.WebResponse, respondToDeviceAuthChallenge))

--- a/tests/Test.ADAL.NET.Common/Mocks/MockHelpers.cs
+++ b/tests/Test.ADAL.NET.Common/Mocks/MockHelpers.cs
@@ -68,7 +68,7 @@ namespace Test.ADAL.NET.Common.Mocks
             return stream;
         }
 
-        public static HttpMessageHandler CreateInstanceDiscoveryMockHandler(string url)
+        public static MockHttpMessageHandler CreateInstanceDiscoveryMockHandler(string url)
         {
             return CreateInstanceDiscoveryMockHandler(url,
                 @"{
@@ -109,7 +109,7 @@ namespace Test.ADAL.NET.Common.Mocks
                 }");
         }
 
-        public static HttpMessageHandler CreateInstanceDiscoveryMockHandler(string url, string content)
+        public static MockHttpMessageHandler CreateInstanceDiscoveryMockHandler(string url, string content)
         {
             return new MockHttpMessageHandler(url)
             {

--- a/tests/Test.ADAL.NET.Unit.net45/InteractiveAuthTests.cs
+++ b/tests/Test.ADAL.NET.Unit.net45/InteractiveAuthTests.cs
@@ -127,6 +127,9 @@ namespace Test.ADAL.NET.Unit.net45
             Assert.AreEqual(0, AdalHttpMessageHandlerFactory.MockHandlersCount());
         }
 
+    
+
+
         [TestMethod]
         [Description("Positive Test for ExtendedLife Feature")]
         [TestCategory("AdalDotNet")]

--- a/tests/Test.ADAL.NET.Unit.net45/RegressionTests.cs
+++ b/tests/Test.ADAL.NET.Unit.net45/RegressionTests.cs
@@ -1,0 +1,95 @@
+﻿//----------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
+using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.ClientCreds;
+using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Test.ADAL.NET.Common;
+using Test.ADAL.NET.Common.Mocks;
+
+namespace Test.ADAL.NET.Unit.net45
+{
+    [TestClass]
+    public class RegressionTests
+    {
+        [TestInitialize]
+        public void Initialize()
+        {
+            ModuleInitializer.ForceModuleInitializationTestOnly();
+            AdalHttpMessageHandlerFactory.InitializeMockProvider();
+            InstanceDiscovery.InstanceCache.Clear();
+        }
+
+        [TestMethod]
+        [WorkItem(1489)] // https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1489
+        public async Task DoubleTimeoutDoesNotResultInANullRef_Async()
+        {
+            // Arrange 
+            MockHttpMessageHandler mockHandler1 = MockHelpers.CreateInstanceDiscoveryMockHandler(
+                AdalTestConstants.GetDiscoveryEndpoint(AdalTestConstants.DefaultAuthorityCommonTenant));
+            MockHttpMessageHandler mockHandler2 = MockHelpers.CreateInstanceDiscoveryMockHandler(
+                AdalTestConstants.GetDiscoveryEndpoint(AdalTestConstants.DefaultAuthorityCommonTenant));
+
+            mockHandler1.ExceptionToThrow = new TaskCanceledException("First Timeout");
+            mockHandler2.ExceptionToThrow = new TaskCanceledException("Second Timeout");
+
+            // Timeouts are retried once, so setup 2 timeouts
+            AdalHttpMessageHandlerFactory.AddMockHandler(mockHandler1);
+            AdalHttpMessageHandlerFactory.AddMockHandler(mockHandler2);
+
+            AuthenticationContext context = new AuthenticationContext(AdalTestConstants.DefaultAuthorityCommonTenant, true);
+
+            try
+            {
+                // Act
+                await context.AcquireTokenForClientCommonAsync(
+                    AdalTestConstants.DefaultResource, new ClientKey(AdalTestConstants.DefaultClientId))
+                    .ConfigureAwait(false);
+            }
+            catch (AdalException ex)
+            {
+                // Assert
+
+                // Instance Discovery will wrap all exceptions, so the task cancelled is burried 2 times deep
+                Assert.AreSame(mockHandler2.ExceptionToThrow, ex.InnerException.InnerException);
+                return;
+            }
+
+
+            Assert.Fail("Expecting a timeout ADAL Service Exception to have been thrown");
+        }
+    }
+}


### PR DESCRIPTION
Fix for  https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1489