### PR TITLE
SilentWebUI needs a longer timeout

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/SilentWebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/SilentWebUI.cs
@@ -44,7 +44,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         /// This is how long all redirect navigations are allowed to run for before a graceful 
         /// termination of the entire browser based authentication process is attempted.
         /// </summary>
-        private const int NavigationOverallTimeout = 2000;
+        private const int NavigationOverallTimeout = 10000;
 
         private bool disposed;
 


### PR DESCRIPTION
SilentWebUI needs a longer timeout as the overall navigation time can significantly exceed 2 seconds