### PR TITLE
Throw an ArgNullEx when using PlatformParameters(prompt, null)

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/PlatformParameters.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/PlatformParameters.cs
@@ -53,7 +53,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         public PlatformParameters(PromptBehavior promptBehavior, object ownerWindow)
         {
             this.PromptBehavior = promptBehavior;
-            this.OwnerWindow = ownerWindow;
+            this.OwnerWindow = ownerWindow ?? throw new ArgumentNullException(nameof(ownerWindow));
         }
 
         /// <summary>

--- a/tests/Test.ADAL.NET.Unit.net45/InteractiveAuthTests.cs
+++ b/tests/Test.ADAL.NET.Unit.net45/InteractiveAuthTests.cs
@@ -129,8 +129,6 @@ namespace Test.ADAL.NET.Unit.net45
         }
 
 
-
-
         [TestMethod]
         [Description("Positive Test for ExtendedLife Feature")]
         [TestCategory("AdalDotNet")]
@@ -245,6 +243,22 @@ namespace Test.ADAL.NET.Unit.net45
             string expectedPkceCodeChanllenge = PlatformProxyFactory.GetPlatformProxy()
                 .CryptographyManager.CreateBase64UrlEncodedSha256Hash(actualPkceCode);
             Assert.AreEqual(expectedPkceCodeChanllenge, actualPkceCodeChallenge);
+        }
+
+
+        [TestMethod]
+        public void ArgNull_PlatformParamters()
+        {
+            AssertException.Throws<ArgumentNullException>(() =>
+          {
+              new PlatformParameters(PromptBehavior.SelectAccount, null);
+          });
+
+
+            AssertException.Throws<ArgumentNullException>(() =>
+            {
+                new PlatformParameters(PromptBehavior.SelectAccount, (object)null);
+            });
         }
 
 


### PR DESCRIPTION
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1519#event-2187369043