### PR TITLE
add NSURLSessionHandler as HttpClient for iOS and MAC

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/AuthenticationContext.cs
@@ -109,10 +109,10 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
 
         /// <summary>
         /// Constructor to create the context with the address of the authority, flag to turn address validation off
-        /// and custom HttpClient.
+        /// and custom IHttpClientFactory.
         /// Make sure you are aware of the security implication of not validating the address.
         /// </summary>
-        /// <remarks>See https://aka.ms/adal-custom-httpclient for details</remarks>
+        /// <remarks>See https://aka.ms/adal-net-httpclient for details</remarks>
         /// <param name="authority">Address of the authority to issue token.</param>
         /// <param name="validateAuthority">Flag to turn address validation ON or OFF.</param>
         /// <param name="tokenCache">Token cache used to lookup cached tokens on calls to AcquireToken. Use <see cref="TokenCache.DefaultShared"/> 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/HttpClientFactory.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/HttpClientFactory.cs
@@ -28,28 +28,34 @@
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using System.Net.Http;
 using System.Net.Http.Headers;
+#if iOS || MAC
+using Foundation;
+#endif
 
 namespace Microsoft.Identity.Core.Http
-{ 
+{
     internal class HttpClientFactory : IHttpClientFactory
     {
         private readonly HttpClient _httpClient;
 
         // The HttpClient is a singleton per ClientApplication so that we don't have a process wide singleton.
-        public const long MaxResponseContentBufferSizeInBytes = 1024*1024;
+        public const long MaxResponseContentBufferSizeInBytes = 1024 * 1024;
 
         public HttpClientFactory()
         {
-            if (_httpClient == null)
+#if iOS || MAC
+            _httpClient = new HttpClient(new NSUrlSessionHandler())
             {
-                _httpClient = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true })
-                {
-                    MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
-                };
-
-                _httpClient.DefaultRequestHeaders.Accept.Clear();
-                _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-            }
+                MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
+            };
+#else
+            _httpClient = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true })
+            {
+                MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
+            };
+#endif
+            _httpClient.DefaultRequestHeaders.Accept.Clear();
+            _httpClient.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
         }
 
         public HttpClient GetHttpClient()

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/HttpClientFactory.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/HttpClientFactory.cs
@@ -28,8 +28,9 @@
 using Microsoft.IdentityModel.Clients.ActiveDirectory;
 using System.Net.Http;
 using System.Net.Http.Headers;
-#if iOS || MAC
+#if iOS
 using Foundation;
+using UIKit;
 #endif
 
 namespace Microsoft.Identity.Core.Http
@@ -43,11 +44,14 @@ namespace Microsoft.Identity.Core.Http
 
         public HttpClientFactory()
         {
-#if iOS || MAC
-            _httpClient = new HttpClient(new NSUrlSessionHandler())
+#if iOS
+            if (UIDevice.CurrentDevice.CheckSystemVersion(7, 0))
             {
-                MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
-            };
+                _httpClient = new HttpClient(new NSUrlSessionHandler())
+                {
+                    MaxResponseContentBufferSize = MaxResponseContentBufferSizeInBytes
+                };
+            }
 #else
             _httpClient = new HttpClient(new HttpClientHandler() { UseDefaultCredentials = true })
             {

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/HttpClientFactory.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/HttpClientFactory.cs
@@ -45,6 +45,7 @@ namespace Microsoft.Identity.Core.Http
         public HttpClientFactory()
         {
 #if iOS
+            // See https://aka.ms/adal-net-httpclient for details
             if (UIDevice.CurrentDevice.CheckSystemVersion(7, 0))
             {
                 _httpClient = new HttpClient(new NSUrlSessionHandler())


### PR DESCRIPTION
[issue](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1554)
tested w/iOS device