### PR TITLE
broker log updates

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Internal/Flows/AcquireTokenHandlerBase.cs
@@ -203,7 +203,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows
                     //broker token acquisition failed
                     if (ResultEx != null && ResultEx.Exception != null)
                     {
-                        RequestContext.Logger.Verbose("Broker token acquisition failed, throwing...");
+                        string msg = "Broker token acquisition failed, throwing...";
+                        RequestContext.Logger.VerbosePii(msg + ResultEx.Exception, msg);
                         throw ResultEx.Exception;
                     }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AndroidBrokerProxy.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AndroidBrokerProxy.cs
@@ -429,7 +429,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
             };
         }
 
-
         private string GetRedirectUriForBroker()
         {
             string packageName = Application.Context.PackageName;
@@ -534,7 +533,9 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
             if (!string.Equals(computedRedirectUri, request.RedirectUri, StringComparison.OrdinalIgnoreCase))
             {
-                throw new AdalException(AdalError.BrokerRedirectUriIncorrectFormat, string.Format(CultureInfo.CurrentCulture, AdalErrorMessage.BrokerRedirectUriIncorrectFormat, computedRedirectUri));
+                string msg = string.Format(CultureInfo.CurrentCulture, AdalErrorMessage.BrokerRedirectUriIncorrectFormat, computedRedirectUri);
+                _logger.Info(msg);
+                throw new AdalException(AdalError.BrokerRedirectUriIncorrectFormat, msg);
             }
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AndroidBrokerProxy.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AndroidBrokerProxy.cs
@@ -214,11 +214,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
                 // to get the calling app's metadata if needed at BrokerActivity.
                 Bundle addAccountOptions = GetBrokerOptions(request);
 
-                _logger.InfoPii("BrokerProxy: Broker options:" +
-                    "\nAuthority: " + request.Authority +
-                    "\nBroker Account Name: " + request.BrokerAccountName,
-                    "BrokerProxy: Broker options: "  +
-                    "\nBroker Account Name: " + request.BrokerAccountName);
+                _logger.Info("BrokerProxy: Broker Account Name: " + request.BrokerAccountName);
 
                 result = _androidAccountManager.AddAccount(BrokerConstants.BrokerAccountType,
                     BrokerConstants.AuthtokenType, null, addAccountOptions, null,
@@ -226,7 +222,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
 
                 if (result == null)
                 {
-                    _logger.Info("BrokerProxy: IAccountManagerFuture returned null. ");
+                    _logger.Info("BrokerProxy: Android account manager AddAccount didn't return any results. ");
                 }
 
                 // Making blocking request here

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AndroidBrokerProxy.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AndroidBrokerProxy.cs
@@ -214,10 +214,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
                 // to get the calling app's metadata if needed at BrokerActivity.
                 Bundle addAccountOptions = GetBrokerOptions(request);
 
-                _logger.Info("BrokerProxy: Broker options:" +
+                _logger.InfoPii("BrokerProxy: Broker options:" +
                     "\nAuthority: " + request.Authority +
-                    "\nBroker Account Name: " + request.BrokerAccountName +
-                    "\nClaims: " + request.Claims);
+                    "\nBroker Account Name: " + request.BrokerAccountName,
+                    "BrokerProxy: Broker options: "  +
+                    "\nBroker Account Name: " + request.BrokerAccountName);
 
                 result = _androidAccountManager.AddAccount(BrokerConstants.BrokerAccountType,
                     BrokerConstants.AuthtokenType, null, addAccountOptions, null,
@@ -234,8 +235,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
                 // token is not available
                 intent = (Intent)bundleResult?.GetParcelable(AccountManager.KeyIntent);
 
-                // Add flag to this intent to signal that request is for broker
-                // logic
+                // Add flag to this intent to signal that request is for broker logic
                 if (intent != null)
                 {
                     _logger.Info("BrokerProxy: Intent created from BundleResult is not null. ");
@@ -244,6 +244,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
                 else
                 {
                     _logger.Info("BrokerProxy: Intent created from BundleResult is null. ");
+                    throw new AdalException(AdalErrorAndroidEx.NullIntentReturnedFromBroker, AdalErrorMessageAndroidEx.NullIntentReturnedFromBroker);
                 }
             }
             catch (AdalException ex)
@@ -256,14 +257,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
                 _logger.ErrorPii(e);
             }
 
-            if (intent == null)
-            {
-                _logger.Info("BrokerProxy outside Try/Catch: null intent returned from Bundle result. ");
-            }
-            else
-            {
-                _logger.Info("BrokerProxy outside Try/Catch: intent returned from Bundle result. ");
-            }
             return intent;
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AuthenticationAgentContinuationHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AuthenticationAgentContinuationHelper.cs
@@ -78,6 +78,11 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
             {
                 WebviewBase.SetAuthorizationResult(authorizationResult);
             }
+            else
+            {
+                authorizationResult = new AuthorizationResult(AuthorizationStatus.UnknownError, "the authorization result is null");
+                WebviewBase.SetAuthorizationResult(authorizationResult);
+            }
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/Constants.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/Constants.cs
@@ -40,6 +40,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         public const string NoBrokerAccountFound = "broker_account_not_found";
         public const string BrokerApplicationRequired = "broker_application_required";
         public const string IncorrectBrokerRedirectUri = "incorrect_broker_redirecturi";
+        public const string NullIntentReturnedFromBroker = "null_intent_returned_from_broker";
     }
 
     internal static class AdalErrorMessageAndroidEx
@@ -54,6 +55,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal
         public const string SignatureVerificationFailed = "Error in verifying broker app's signature";
         public const string NoBrokerAccountFound = "No account found in broker app";
         public const string BrokerApplicationRequired = "Broker application must be installed to continue authentication";
+        public const string NullIntentReturnedFromBroker = "Broker returned a null intent. Check the Xamarin Android app settings and logs for more information. " +
+            "See https://aka.ms/adal-net-broker-android for details. ";
     }
 
     internal static class BrokerResponseCode

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/WebviewBase.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/WebviewBase.cs
@@ -35,23 +35,13 @@ namespace Microsoft.Identity.Core.UI
         protected static SemaphoreSlim returnedUriReady;
         protected static AuthorizationResult authorizationResult;
 
-        public static void SetAuthorizationResult(AuthorizationResult authorizationResultInput, RequestContext requestContext)
+        public static void SetAuthorizationResult(AuthorizationResult authorizationResultInput)
         {
             if (returnedUriReady != null)
             {
                 authorizationResult = authorizationResultInput;
                 returnedUriReady.Release();
             }
-            else
-            {
-                requestContext.Logger.Info("No pending request for response from web ui.");
-            }
-        }
-
-        public static void SetAuthorizationResult(AuthorizationResult authorizationResultInput)
-        {
-            authorizationResult = authorizationResultInput;
-            returnedUriReady.Release();
         }
 
         public abstract Task<AuthorizationResult> AcquireAuthorizationAsync(Uri authorizationUri, Uri redirectUri, RequestContext requestContext);


### PR DESCRIPTION
According to Android team, we should be using the [Looper.MyLooper()](https://stackoverflow.com/questions/7597742/what-is-the-purpose-of-looper-and-how-to-use-it) and then going w/the MainLooper if all else fails. Just following what the Android team is advising us to do.
I don't think this will resolve [1588](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1588), but at least we'll be fixing this. 

Tested w/Company Portal