### PR TITLE
fix null ref in tokenCache when UserInfo is absent

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Cache/AdalTokenCacheKey.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Cache/AdalTokenCacheKey.cs
@@ -57,18 +57,18 @@ namespace Microsoft.Identity.Core.Cache
     internal sealed class AdalTokenCacheKey
     {
         internal AdalTokenCacheKey(string authority, string resource, string clientId, TokenSubjectType tokenSubjectType, AdalUserInfo adalUserInfo)
-            : this(authority, resource, clientId, tokenSubjectType, (adalUserInfo != null) ? adalUserInfo.UniqueId : null, (adalUserInfo != null) ? adalUserInfo.DisplayableId : null)
+            : this(authority, resource, clientId, tokenSubjectType, adalUserInfo?.UniqueId, adalUserInfo?.DisplayableId)
         {
         }
 
         internal AdalTokenCacheKey(string authority, string resource, string clientId, TokenSubjectType tokenSubjectType, string uniqueId, string displayableId)
         {
-            this.Authority = authority;
-            this.Resource = resource;
-            this.ClientId = clientId;
-            this.TokenSubjectType = tokenSubjectType;
-            this.UniqueId = uniqueId;
-            this.DisplayableId = displayableId;
+            Authority = authority;
+            Resource = resource;
+            ClientId = clientId;
+            TokenSubjectType = tokenSubjectType;
+            UniqueId = uniqueId;
+            DisplayableId = displayableId;
         }
 
         public string Authority { get; }
@@ -93,7 +93,7 @@ namespace Microsoft.Identity.Core.Cache
         public override bool Equals(object obj)
         {
             AdalTokenCacheKey other = obj as AdalTokenCacheKey;
-            return (other != null) && this.Equals(other);
+            return (other != null) && Equals(other);
         }
 
         /// <summary>
@@ -111,12 +111,12 @@ namespace Microsoft.Identity.Core.Cache
             }
 
             return other != null
-                && other.Authority == this.Authority
-                && this.ResourceEquals(other.Resource)
-                && this.ClientIdEquals(other.ClientId)
-                && other.UniqueId == this.UniqueId
-                && this.DisplayableIdEquals(other.DisplayableId)
-                && other.TokenSubjectType == this.TokenSubjectType;
+                && other.Authority == Authority
+                && ResourceEquals(other.Resource)
+                && ClientIdEquals(other.ClientId)
+                && other.UniqueId == UniqueId
+                && DisplayableIdEquals(other.DisplayableId)
+                && other.TokenSubjectType == TokenSubjectType;
         }
 
         /// <summary>
@@ -128,28 +128,28 @@ namespace Microsoft.Identity.Core.Cache
         public override int GetHashCode()
         {
             const string delimiter = ":::";
-            var hashString = this.Authority + delimiter
-                           + this.Resource.ToLowerInvariant() + delimiter
-                           + this.ClientId.ToLowerInvariant() + delimiter
-                           + this.UniqueId + delimiter
-                           + this.DisplayableId?.ToLowerInvariant() + delimiter
-                           + (int) this.TokenSubjectType;
+            var hashString = Authority + delimiter
+                           + Resource.ToLowerInvariant() + delimiter
+                           + ClientId.ToLowerInvariant() + delimiter
+                           + UniqueId + delimiter
+                           + DisplayableId?.ToLowerInvariant() + delimiter
+                           + (int) TokenSubjectType;
             return hashString.GetHashCode();
         }
 
         internal bool ResourceEquals(string otherResource)
         {
-            return (string.Compare(otherResource, this.Resource, StringComparison.OrdinalIgnoreCase) == 0);
+            return (string.Compare(otherResource, Resource, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
         internal bool ClientIdEquals(string otherClientId)
         {
-            return (string.Compare(otherClientId, this.ClientId, StringComparison.OrdinalIgnoreCase) == 0);
+            return (string.Compare(otherClientId, ClientId, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
         internal bool DisplayableIdEquals(string otherDisplayableId)
         {
-            return (string.Compare(otherDisplayableId, this.DisplayableId, StringComparison.OrdinalIgnoreCase) == 0);
+            return (string.Compare(otherDisplayableId, DisplayableId, StringComparison.OrdinalIgnoreCase) == 0);
         }
 
         private string DebuggerDisplay

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/TokenCache.cs
@@ -690,8 +690,8 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
                         IdToken.TryParse(result.Result.IdToken, out IdToken idToken);
 
                         CacheFallbackOperations.WriteMsalRefreshToken(TokenCacheAccessor, result, authority, clientId, displayableId,
-                            result.Result.UserInfo.GivenName,
-                            result.Result.UserInfo.FamilyName,
+                            result.Result.UserInfo?.GivenName,
+                            result.Result.UserInfo?.FamilyName,
                             idToken?.GetUniqueId());
                     }
                 }


### PR DESCRIPTION
utest for IdToken and WriteMsalRefreshToken()

Alternative for [issue 1604](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1604)