### PR TITLE
Force usage of System.Net.Http 4.3.4 as 4.3.0 has security flaws

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Microsoft.IdentityModel.Clients.ActiveDirectory.csproj
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Microsoft.IdentityModel.Clients.ActiveDirectory.csproj
@@ -91,13 +91,14 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IdentityModel" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Net.Http" />
+
     <Compile Include="Platforms\net45\**\*.cs" />
     <Compile Include="Features\WinCommon\**\*.cs" />
     <Compile Include="Features\CertificateAssertion\**\*.cs" />
@@ -123,6 +124,8 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <!-- Component Governance mandatory upgrade (4.3.0 has vulnerabilities and is used by NETStandard.Library 1.6.1) -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
     <Compile Include="Platforms\uap\**\*.cs" />
@@ -160,6 +163,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="All" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <!-- This is here to workaround designer issues so VS sees them appropriately -->
@@ -175,6 +179,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup Label="Build Tools" Condition="$([MSBuild]::IsOsPlatform('Windows'))">
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/tests/Test.ADAL.NET.Common/Test.ADAL.NET.Common.csproj
+++ b/tests/Test.ADAL.NET.Common/Test.ADAL.NET.Common.csproj
@@ -35,6 +35,8 @@
     <PackageReference Include="System.Threading.Tasks" Version="4.3.0" />
     <PackageReference Include="System.Threading.Tasks.Parallel" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <!-- Component Governance mandatory upgrade because NSubstitute uses 4.3.0 which has known vulnerabilities-->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup>
     <None Include="oldcache.serialized">

--- a/tests/Test.ADAL.NET.Unit.net45/Test.ADAL.NET.Unit.net45.csproj
+++ b/tests/Test.ADAL.NET.Unit.net45/Test.ADAL.NET.Unit.net45.csproj
@@ -13,7 +13,6 @@
     <ProjectReference Include="..\Test.ADAL.NET.Common\Test.ADAL.NET.Common.csproj" />
     <!-- This reference is a workaround for a bug in .net46
     https://stackoverflow.com/questions/45563560/could-not-load-file-or-assembly-system-net-http-version-4-1-1-1-net-standard-->
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <Reference Include="System.Windows.Forms" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
       <PrivateAssets>all</PrivateAssets>
@@ -28,6 +27,8 @@
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.4" />
+    <!-- Component Governance mandatory upgrade because NSubstitute uses 4.3.0 which has known vulnerabilities-->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Test.ADAL.NET.Unit.netcore/Test.ADAL.NET.Unit.netcore.csproj
+++ b/tests/Test.ADAL.NET.Unit.netcore/Test.ADAL.NET.Unit.netcore.csproj
@@ -19,9 +19,6 @@
 
     <ProjectReference Include="..\..\src\Microsoft.IdentityModel.Clients.ActiveDirectory\Microsoft.IdentityModel.Clients.ActiveDirectory.csproj" />
     <ProjectReference Include="..\Test.ADAL.NET.Common\Test.ADAL.NET.Common.csproj" />
-    <!-- This reference is a workaround for a bug in .net46
-    https://stackoverflow.com/questions/45563560/could-not-load-file-or-assembly-system-net-http-version-4-1-1-1-net-standard-->
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
 
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003">
       <PrivateAssets>all</PrivateAssets>
@@ -36,6 +33,9 @@
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.1" />
     <PackageReference Include="MSTest.TestFramework" Version="1.3.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.2.4" />
+    <!-- Component Governance mandatory upgrade because NSubstitute uses 4.3.0 which has known vulnerabilities-->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/Test.Microsoft.Identity.LabInfrastructure/Test.Microsoft.Identity.LabInfrastructure.csproj
+++ b/tests/Test.Microsoft.Identity.LabInfrastructure/Test.Microsoft.Identity.LabInfrastructure.csproj
@@ -16,6 +16,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <!-- Component Governance mandatory upgrade (4.3.0 has vulnerabilities) -->
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Problem: System.Net.Http 4.3.0 has security issues. ADAL and some test projects use it indirectly (deep in the dependency tree). Cannot update high level components (NSubstitute, Azure.KeyVault.dll because even the latest version still use System.Net.Http 4.3.0), so I chose to force 4.3.3 by adding a direct reference to it. 


ADAL impact: ADAL will use this only for .NET Standard. 
Tests done: smoke testing with a .net core app (as it will exercise the .net standard code)

Passing build: https://identitydivision.visualstudio.com/IDDP/_build/results?buildId=354511&_a=summary