### PR TITLE
fix aka.ms link for missing entitlements

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/ClientInfo.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/ClientInfo.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Identity.Core
             if (string.IsNullOrEmpty(clientInfo))
             {
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.JsonParseError,
+                    ErrorCodes.JsonParseError,
                     "client info is null");
             }
 
@@ -64,7 +64,7 @@ namespace Microsoft.Identity.Core
             catch (Exception exc)
             {
                 throw AdalExceptionFactory.GetClientException(
-                     CoreErrorCodes.JsonParseError,
+                     ErrorCodes.JsonParseError,
                      "Failed to parse the returned client info.",
                      exc);
             }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Exceptions/ErrorCodes.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Exceptions/ErrorCodes.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Core
     /// Error codes attached to each exception.
     /// These need to be duplicated and publicly exposed in the MSAL and ADAL because users refer to them
     /// </summary>
-    internal class CoreErrorCodes
+    internal class ErrorCodes
     {
         public const string JsonParseError = "json_parse_failed";
         public const string RequestTimeout = "request_timeout";

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Exceptions/ErrorMessages.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Exceptions/ErrorMessages.cs
@@ -30,7 +30,7 @@ using System.Globalization;
 
 namespace Microsoft.Identity.Core
 {
-    internal class CoreErrorMessages
+    internal class ErrorMessages
     {
         public const string UnknownUser = "Could not identify the user logged into the OS. See http://aka.ms/msal-net-iwa for details.";
 
@@ -46,10 +46,7 @@ namespace Microsoft.Identity.Core
 
         public const string AuthorityUriInvalidPath =
          "'authority' Uri should have at least one segment in the path (i.e. https://<host>/<path>/...)";
-
-        public const string B2cAuthorityUriInvalidPath =
-          "B2C 'authority' Uri should have at least 3 segments in the path (i.e. https://<host>/tfp/<tenant>/<policy>/...)";
-
+        
         public const string UnsupportedAuthorityValidation =
             "Authority validation is not supported for this type of authority. See http://aka.ms/valid-authorities for details";
 
@@ -100,13 +97,13 @@ namespace Microsoft.Identity.Core
         public const string CannotAccessPublisherKeyChain =
            "The application cannot access the iOS keychain for the application publisher (the TeamId is null). " +
            "This is needed to enable Single Sign On between applications of the same publisher. " +
-           "This is an iOS configuration issue. See https://aka.ms/msal-net-enable-keychain-access for more details on enabling keychain access.";
+           "This is an iOS configuration issue. See https://aka.ms/adal-net-enable-keychain-groups for more details on enabling keychain access.";
 
         public const string MissingEntitlements =
             "The application does not have keychain access groups enabled in the Entitlements.plist. " +
             "As a result, there was a failure to save to the iOS keychain. " +
             "The keychain access group '{0}' is not enabled in the Entitlements.plist. " +
-            "See https://aka.ms/msal-net-enable-keychain-groups for more details on enabling keychain access groups and entitlements.";
+            "See https://aka.ms/adal-net-enable-keychain-groups for more details on enabling keychain access groups and entitlements.";
 
         public const string AndroidActivityNotFound = "The Activity cannot be found to launch the given Intent. To ensure authentication, a browser with custom tab support " +
             "is recommended. See https://aka.ms/msal-net-system-browsers for more details on using system browser on Android.";

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/HttpManager.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/HttpManager.cs
@@ -148,7 +148,7 @@ namespace Microsoft.Identity.Core.Http
                 }
 
                 requestContext?.Logger.Info(string.Format(CultureInfo.InvariantCulture,
-                    CoreErrorMessages.HttpRequestUnsuccessful,
+                    ErrorMessages.HttpRequestUnsuccessful,
                     (int)response.StatusCode, response.StatusCode));
 
                 if ((int)response.StatusCode >= 500 && (int)response.StatusCode < 600)
@@ -187,7 +187,7 @@ namespace Microsoft.Identity.Core.Http
                 if (timeoutException != null)
                 {
                     throw AdalExceptionFactory.GetServiceException(
-                        CoreErrorCodes.RequestTimeout,
+                        ErrorCodes.RequestTimeout,
                         "Request to the endpoint timed out.",
                         timeoutException,
                         ExceptionDetail.FromHttpResponse(response)); // no http response to add more details to this exception
@@ -211,7 +211,7 @@ namespace Microsoft.Identity.Core.Http
                 }
 
                 throw AdalExceptionFactory.GetServiceException(
-                        CoreErrorCodes.ServiceNotAvailable,
+                        ErrorCodes.ServiceNotAvailable,
                         "Service is unavailable to process the request",
                         response);
             }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/RedirectUriHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/Http/RedirectUriHelper.cs
@@ -41,15 +41,15 @@ namespace Microsoft.Identity.Core.Http
             if (redirectUri == null)
             {
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.NoRedirectUri,
-                    CoreErrorMessages.NoRedirectUri);
+                    ErrorCodes.NoRedirectUri,
+                    ErrorMessages.NoRedirectUri);
 
             }
 
             if (!string.IsNullOrWhiteSpace(redirectUri.Fragment))
             {
                 throw new ArgumentException(
-                    CoreErrorMessages.RedirectUriContainsFragment,
+                    ErrorMessages.RedirectUriContainsFragment,
                     nameof(redirectUri));
             }
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/MsalIdHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/MsalIdHelper.cs
@@ -74,8 +74,8 @@ namespace Microsoft.Identity.Core
                 if (platformProxy == null)
                 {
                     throw AdalExceptionFactory.GetClientException(
-                        CoreErrorCodes.PlatformNotSupported,
-                        CoreErrorMessages.PlatformNotSupported);
+                        ErrorCodes.PlatformNotSupported,
+                        ErrorMessages.PlatformNotSupported);
                 }
 
                 var parameters = new Dictionary<string, string>

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/UI/AuthorizationResult.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/UI/AuthorizationResult.cs
@@ -49,13 +49,13 @@ namespace Microsoft.Identity.Core.UI
         {
             if (Status == AuthorizationStatus.UserCancel)
             {
-                Error = CoreErrorCodes.AuthenticationCanceledError;
-                ErrorDescription = CoreErrorMessages.AuthenticationCanceled;
+                Error = ErrorCodes.AuthenticationCanceledError;
+                ErrorDescription = ErrorMessages.AuthenticationCanceled;
             }
             else if (Status == AuthorizationStatus.UnknownError)
             {
-                Error = CoreErrorCodes.UnknownError;
-                ErrorDescription = CoreErrorMessages.Unknown;
+                Error = ErrorCodes.UnknownError;
+                ErrorDescription = ErrorMessages.Unknown;
             }
             else
             {
@@ -128,8 +128,8 @@ namespace Microsoft.Identity.Core.UI
                 }
                 else
                 {
-                    Error = CoreErrorCodes.AuthenticationFailed;
-                    ErrorDescription = CoreErrorMessages.AuthorizationServerInvalidResponse;
+                    Error = ErrorCodes.AuthenticationFailed;
+                    ErrorDescription = ErrorMessages.AuthorizationServerInvalidResponse;
                     Status = AuthorizationStatus.UnknownError;
                 }
 
@@ -140,8 +140,8 @@ namespace Microsoft.Identity.Core.UI
             }
             else
             {
-                Error = CoreErrorCodes.AuthenticationFailed;
-                ErrorDescription = CoreErrorMessages.AuthorizationServerInvalidResponse;
+                Error = ErrorCodes.AuthenticationFailed;
+                ErrorDescription = ErrorMessages.AuthorizationServerInvalidResponse;
                 Status = AuthorizationStatus.UnknownError;
             }
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/UI/CustomWebUiHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/UI/CustomWebUiHandler.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Identity.Core.UI
                 {
                     throw new AdalException(
                         AdalError.CustomWebUiReturnedInvalidUri,
-                        CoreErrorMessages.CustomWebUiReturnedInvalidUri);
+                        ErrorMessages.CustomWebUiReturnedInvalidUri);
                 }
 
                 if (authCodeUri.Authority.Equals(redirectUri.Authority, StringComparison.OrdinalIgnoreCase) &&
@@ -89,7 +89,7 @@ namespace Microsoft.Identity.Core.UI
 
                 throw new AdalException(
                     AdalError.CustomWebUiRedirectUriMismatch,
-                    CoreErrorMessages.CustomWebUiRedirectUriMismatch(
+                    ErrorMessages.CustomWebUiRedirectUriMismatch(
                         authCodeUri.AbsolutePath,
                         redirectUri.AbsolutePath));
             }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/WsTrust/CommonNonInteractiveHandler.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/WsTrust/CommonNonInteractiveHandler.cs
@@ -61,8 +61,8 @@ namespace Microsoft.Identity.Core.WsTrust
                 _requestContext.Logger.Error("Could not find UPN for logged in user.");
 
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.UnknownUser,
-                    CoreErrorMessages.UnknownUser);
+                    ErrorCodes.UnknownUser,
+                    ErrorMessages.UnknownUser);
             }
 
             _requestContext.Logger.InfoPii($"Logged in user detected with user name '{platformUsername}'", "Logged in user detected");
@@ -79,8 +79,8 @@ namespace Microsoft.Identity.Core.WsTrust
             if (userRealmResponse == null)
             {
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.UserRealmDiscoveryFailed,
-                    CoreErrorMessages.UserRealmDiscoveryFailed);
+                    ErrorCodes.UserRealmDiscoveryFailed,
+                    ErrorMessages.UserRealmDiscoveryFailed);
             }
 
             _requestContext.Logger.InfoPii(
@@ -103,8 +103,8 @@ namespace Microsoft.Identity.Core.WsTrust
             catch (XmlException ex)
             {
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.ParsingWsMetadataExchangeFailed,
-                    CoreErrorMessages.ParsingMetadataDocumentFailed,
+                    ErrorCodes.ParsingWsMetadataExchangeFailed,
+                    ErrorMessages.ParsingMetadataDocumentFailed,
                     ex);
             }
 
@@ -115,8 +115,8 @@ namespace Microsoft.Identity.Core.WsTrust
             if (wsTrustEndpoint == null)
             {
                 throw AdalExceptionFactory.GetClientException(
-                  CoreErrorCodes.WsTrustEndpointNotFoundInMetadataDocument,
-                  CoreErrorMessages.WsTrustEndpointNotFoundInMetadataDocument);
+                  ErrorCodes.WsTrustEndpointNotFoundInMetadataDocument,
+                  ErrorMessages.WsTrustEndpointNotFoundInMetadataDocument);
             }
 
             _requestContext.Logger.InfoPii(
@@ -160,7 +160,7 @@ namespace Microsoft.Identity.Core.WsTrust
             catch (Exception ex)
             {
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.ParsingWsTrustResponseFailed,
+                    ErrorCodes.ParsingWsTrustResponseFailed,
                     ex.Message,
                     ex);
             }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/WsTrust/WsTrustWebRequestManager.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Core/WsTrust/WsTrustWebRequestManager.cs
@@ -56,9 +56,9 @@ namespace Microsoft.Identity.Core.WsTrust
             if (httpResponse.StatusCode != System.Net.HttpStatusCode.OK)
             {
                 throw AdalExceptionFactory.GetServiceException(
-                    CoreErrorCodes.AccessingWsMetadataExchangeFailed,
+                    ErrorCodes.AccessingWsMetadataExchangeFailed,
                     string.Format(CultureInfo.CurrentCulture,
-                        CoreErrorMessages.HttpRequestUnsuccessful,
+                        ErrorMessages.HttpRequestUnsuccessful,
                         (int)httpResponse.StatusCode, httpResponse.StatusCode),
                     new ExceptionDetail()
                     {
@@ -107,10 +107,10 @@ namespace Microsoft.Identity.Core.WsTrust
                 }
 
                 throw AdalExceptionFactory.GetServiceException(
-                    CoreErrorCodes.FederatedServiceReturnedError,
+                    ErrorCodes.FederatedServiceReturnedError,
                     string.Format(
                         CultureInfo.CurrentCulture,
-                        CoreErrorMessages.FederatedServiceReturnedErrorTemplate,
+                        ErrorMessages.FederatedServiceReturnedErrorTemplate,
                         wsTrustEndpoint.Uri,
                         errorMessage),
                     new ExceptionDetail()
@@ -128,7 +128,7 @@ namespace Microsoft.Identity.Core.WsTrust
             catch (System.Xml.XmlException ex)
             {
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.ParsingWsTrustResponseFailed, CoreErrorCodes.ParsingWsTrustResponseFailed, ex);
+                    ErrorCodes.ParsingWsTrustResponseFailed, ErrorCodes.ParsingWsTrustResponseFailed, ex);
             }
         }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AndroidTokenCacheAccessor.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/AndroidTokenCacheAccessor.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Identity.Core
                 || _idTokenSharedPreference == null || _accountSharedPreference == null)
             {
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.FailedToCreateSharedPreference,
+                    ErrorCodes.FailedToCreateSharedPreference,
                     "Fail to create SharedPreference");
             }
         }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/EmbeddedWebview/AuthenticationAgentActivity.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/EmbeddedWebview/AuthenticationAgentActivity.cs
@@ -160,7 +160,7 @@ namespace Microsoft.Identity.Core.UI.EmbeddedWebview
                 {
                     UriBuilder errorUri = new UriBuilder(callback);
                     errorUri.Query = string.Format(CultureInfo.InvariantCulture, "error={0}&error_description={1}",
-                        CoreErrorCodes.NonHttpsRedirectNotSupported, CoreErrorMessages.NonHttpsRedirectNotSupported);
+                        ErrorCodes.NonHttpsRedirectNotSupported, ErrorMessages.NonHttpsRedirectNotSupported);
                     this.Finish(Activity, errorUri.ToString());
                     return true;
                 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/EmbeddedWebview/EmbeddedWebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/EmbeddedWebview/EmbeddedWebUI.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Identity.Core.UI.EmbeddedWebview
             catch (Exception ex)
             {
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.AuthenticationUiFailedError, 
+                    ErrorCodes.AuthenticationUiFailedError, 
                     "AuthenticationActivity failed to start", 
                     ex);
             }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/SystemWebview/AuthenticationActivity.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/SystemWebview/AuthenticationActivity.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Identity.Core.UI.SystemWebview
             if (Intent == null)
             {
                 SendError(
-                    CoreErrorCodes.UnresolvableIntentError,
+                    ErrorCodes.UnresolvableIntentError,
                     "Received null data intent from caller");
                 return;
             }
@@ -85,7 +85,7 @@ namespace Microsoft.Identity.Core.UI.SystemWebview
             _requestId = Intent.GetIntExtra(AndroidConstants.RequestId, 0);
             if (string.IsNullOrEmpty(_requestUrl))
             {
-                SendError(CoreErrorCodes.InvalidRequest, "Request url is not set on the intent");
+                SendError(ErrorCodes.InvalidRequest, "Request url is not set on the intent");
             }
         }
 
@@ -137,8 +137,8 @@ namespace Microsoft.Identity.Core.UI.SystemWebview
                 catch (ActivityNotFoundException ex)
                 {
                     throw AdalExceptionFactory.GetClientException(
-                           CoreErrorCodes.AndroidActivityNotFound,
-                           CoreErrorMessages.AndroidActivityNotFound, ex);
+                           ErrorCodes.AndroidActivityNotFound,
+                           ErrorMessages.AndroidActivityNotFound, ex);
                 }
             }
             else

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/SystemWebview/SystemWebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/SystemWebview/SystemWebUI.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Identity.Core.UI.SystemWebview
             {
                 requestContext.Logger.ErrorPii(ex);
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.AuthenticationUiFailedError, 
+                    ErrorCodes.AuthenticationUiFailedError, 
                     "AuthenticationActivity failed to start", 
                     ex);
             }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/EmbeddedWebview/EmbeddedWebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/EmbeddedWebview/EmbeddedWebUI.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Identity.Core.UI.EmbeddedWebview
             catch (Exception ex)
             {
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.AuthenticationUiFailed, 
+                    ErrorCodes.AuthenticationUiFailed, 
                     "See inner exception for details", 
                     ex);
             }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/EmbeddedWebview/WKWebNavigationDelegate.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/EmbeddedWebview/WKWebNavigationDelegate.cs
@@ -103,8 +103,8 @@ namespace Microsoft.Identity.Core.UI.EmbeddedWebview
                 && !navigationAction.Request.Url.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
             {
                 AuthorizationResult result = new AuthorizationResult(AuthorizationStatus.ErrorHttp);
-                result.Error = CoreErrorCodes.NonHttpsRedirectNotSupported;
-                result.ErrorDescription = CoreErrorMessages.NonHttpsRedirectNotSupported;
+                result.Error = ErrorCodes.NonHttpsRedirectNotSupported;
+                result.ErrorDescription = ErrorMessages.NonHttpsRedirectNotSupported;
                 AuthenticationAgentUIViewController.DismissViewController(true, () => AuthenticationAgentUIViewController.callbackMethod(result));
                 decisionHandler(WKNavigationActionPolicy.Cancel);
                 return;

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/SystemWebview/SystemWebUI.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/SystemWebview/SystemWebUI.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Identity.Core.UI.SystemWebview
             {
                 requestContext.Logger.ErrorPii(ex);
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.AuthenticationUiFailedError,
+                    ErrorCodes.AuthenticationUiFailedError,
                     "Failed to invoke SFSafariViewController",
                     ex);
             }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/iOSTokenCacheAccessor.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/iOSTokenCacheAccessor.cs
@@ -129,8 +129,8 @@ namespace Microsoft.Identity.Core
             }
 
             throw AdalExceptionFactory.GetClientException(
-                CoreErrorCodes.CannotAccessPublisherKeyChain,
-                CoreErrorMessages.CannotAccessPublisherKeyChain);
+                ErrorCodes.CannotAccessPublisherKeyChain,
+                ErrorMessages.CannotAccessPublisherKeyChain);
         }
 
         public void SaveAccessToken(MsalAccessTokenCacheItem item)
@@ -247,10 +247,10 @@ namespace Microsoft.Identity.Core
             if (secStatusCode == SecStatusCode.MissingEntitlement)
             {
                 throw AdalExceptionFactory.GetClientException(
-                CoreErrorCodes.MissingEntitlements,
+                ErrorCodes.MissingEntitlements,
                 string.Format(
                     CultureInfo.InvariantCulture,
-                    CoreErrorMessages.MissingEntitlements,
+                    ErrorMessages.MissingEntitlements,
                     recordToSave.AccessGroup));
             }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/NetDesktopPlatformProxy.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/NetDesktopPlatformProxy.cs
@@ -63,8 +63,8 @@ namespace Microsoft.Identity.Core
                 if (userNameSize == 0)
                 {
                     throw AdalExceptionFactory.GetClientException(
-                        CoreErrorCodes.GetUserNameFailed,
-                        CoreErrorMessages.GetUserNameFailed,
+                        ErrorCodes.GetUserNameFailed,
+                        ErrorMessages.GetUserNameFailed,
                         new Win32Exception(Marshal.GetLastWin32Error()));
                 }
 
@@ -72,8 +72,8 @@ namespace Microsoft.Identity.Core
                 if (!WindowsNativeMethods.GetUserNameEx(NameUserPrincipal, sb, ref userNameSize))
                 {
                     throw AdalExceptionFactory.GetClientException(
-                       CoreErrorCodes.GetUserNameFailed,
-                       CoreErrorMessages.GetUserNameFailed,
+                       ErrorCodes.GetUserNameFailed,
+                       ErrorMessages.GetUserNameFailed,
                        new Win32Exception(Marshal.GetLastWin32Error()));
                 }
 

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/uap/UapPlatformProxy.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/uap/UapPlatformProxy.cs
@@ -63,8 +63,8 @@ namespace Microsoft.Identity.Core
             if (users == null || !users.Any())
             {
                 throw AdalExceptionFactory.GetClientException(
-                    CoreErrorCodes.CannotAccessUserInformationOrUserNotDomainJoined,
-                    CoreErrorMessages.UapCannotFindDomainUser);
+                    ErrorCodes.CannotAccessUserInformationOrUserNotDomainJoined,
+                    ErrorMessages.UapCannotFindDomainUser);
             }
 
             var getUserDetailTasks = users.Select(async u =>
@@ -82,8 +82,8 @@ namespace Microsoft.Identity.Core
 
             // try to get a user that has both domain name and upn
             var userDetailWithDomainAndPn = userDetails.FirstOrDefault(
-                d => !String.IsNullOrWhiteSpace(d.Domain) &&
-                !String.IsNullOrWhiteSpace(d.PrincipalName));
+                d => !string.IsNullOrWhiteSpace(d.Domain) &&
+                !string.IsNullOrWhiteSpace(d.PrincipalName));
 
             if (userDetailWithDomainAndPn != null)
             {
@@ -92,7 +92,7 @@ namespace Microsoft.Identity.Core
 
             // try to get a user that at least has upn
             var userDetailWithPn = userDetails.FirstOrDefault(
-              d => !String.IsNullOrWhiteSpace(d.PrincipalName));
+              d => !string.IsNullOrWhiteSpace(d.PrincipalName));
 
             if (userDetailWithPn != null)
             {
@@ -100,17 +100,17 @@ namespace Microsoft.Identity.Core
             }
 
             // user has domain name, but no upn -> missing Enterprise Auth capability
-            if (userDetails.Any(d => !String.IsNullOrWhiteSpace(d.Domain)))
+            if (userDetails.Any(d => !string.IsNullOrWhiteSpace(d.Domain)))
             {
                 throw AdalExceptionFactory.GetClientException(
-                   CoreErrorCodes.CannotAccessUserInformationOrUserNotDomainJoined,
-                   CoreErrorMessages.UapCannotFindUpn);
+                   ErrorCodes.CannotAccessUserInformationOrUserNotDomainJoined,
+                   ErrorMessages.UapCannotFindUpn);
             }
 
             // no domain, no upn -> missing User Info capability
             throw AdalExceptionFactory.GetClientException(
-                CoreErrorCodes.CannotAccessUserInformationOrUserNotDomainJoined,
-                CoreErrorMessages.UapCannotFindDomainUser);
+                ErrorCodes.CannotAccessUserInformationOrUserNotDomainJoined,
+                ErrorMessages.UapCannotFindDomainUser);
 
         }
 

--- a/tests/Test.ADAL.NET.Unit.net45/CoreTests/WsTrustTests/MexParserTests.cs
+++ b/tests/Test.ADAL.NET.Unit.net45/CoreTests/WsTrustTests/MexParserTests.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
                 }
                 catch (AdalException ex)
                 {
-                    Assert.AreEqual(CoreErrorCodes.AccessingWsMetadataExchangeFailed, ex.ErrorCode);
+                    Assert.AreEqual(ErrorCodes.AccessingWsMetadataExchangeFailed, ex.ErrorCode);
                 }
             }
         }

--- a/tests/Test.ADAL.NET.Unit.net45/CoreTests/WsTrustTests/WsTrustTests.cs
+++ b/tests/Test.ADAL.NET.Unit.net45/CoreTests/WsTrustTests/WsTrustTests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Identity.Test.Unit.CoreTests.WsTrustTests
                 }
                 catch (AdalException ex)
                 {
-                    Assert.AreEqual(CoreErrorCodes.FederatedServiceReturnedError, ex.ErrorCode);
+                    Assert.AreEqual(ErrorCodes.FederatedServiceReturnedError, ex.ErrorCode);
                 }
             }
         }


### PR DESCRIPTION
remove "core" from error messages and code

[issue](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1634). Also, checked the wiki and i think we generally have the same info for msal and adal, but fixed the links.