### PR TITLE
Component governance - system.private.uri updated only on netstandard

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Microsoft.IdentityModel.Clients.ActiveDirectory.csproj
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Microsoft.IdentityModel.Clients.ActiveDirectory.csproj
@@ -139,9 +139,9 @@
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
 
     <!-- 4.1.3 has CVE-2018-0786 -->
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.1" Condition="'$(TargetFramework)' == 'uap10.0'" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.1" Condition="'$(TargetFramework)' == 'uap10.0'" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.1" Condition="'$(TargetFramework)' == 'uap10.0'" />
+    <PackageReference Include="System.ServiceModel.Http" Version="4.4.1" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.1" />
+    <PackageReference Include="System.ServiceModel.Security" Version="4.4.1" />
     
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS10' ">

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Microsoft.IdentityModel.Clients.ActiveDirectory.csproj
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Microsoft.IdentityModel.Clients.ActiveDirectory.csproj
@@ -88,12 +88,8 @@
   </ItemGroup>
 
   <ItemGroup Label="Dependency overrides due to security vulnerabilities">
-    <!-- 4.3.0 has CVE-2019-0657 -->
-    <PackageReference Include="System.Private.Uri" Version="4.3.1" />
-    <!-- 4.1.3 has CVE-2018-0786 -->
-    <PackageReference Include="System.ServiceModel.Http" Version="4.4.1" Condition="'$(TargetFramework)' == 'uap10.0'" />
-    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.1" Condition="'$(TargetFramework)' == 'uap10.0'" />
-    <PackageReference Include="System.ServiceModel.Security" Version="4.4.1" Condition="'$(TargetFramework)' == 'uap10.0'" />
+   
+   
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
@@ -136,6 +132,8 @@
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
     <!-- Component Governance mandatory upgrade (4.3.0 has vulnerabilities and is used by NETStandard.Library 1.6.1) -->
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <!-- 4.3.0 has CVE-2019-0657 -->
+    <PackageReference Include="System.Private.Uri" Version="4.3.2" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'uap10.0' ">
     <Compile Include="Platforms\uap\**\*.cs" />
@@ -144,6 +142,12 @@
     <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
     <PackageReference Include="System.Xml.XDocument" Version="4.3.0" />
     <PackageReference Include="System.Net.NameResolution" Version="4.3.0" />
+
+    <!-- 4.1.3 has CVE-2018-0786 -->
+    <PackageReference Include="System.ServiceModel.Http" Version="4.4.1" Condition="'$(TargetFramework)' == 'uap10.0'" />
+    <PackageReference Include="System.ServiceModel.NetTcp" Version="4.4.1" Condition="'$(TargetFramework)' == 'uap10.0'" />
+    <PackageReference Include="System.ServiceModel.Security" Version="4.4.1" Condition="'$(TargetFramework)' == 'uap10.0'" />
+    
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'Xamarin.iOS10' ">
     <Reference Include="System" />

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Microsoft.IdentityModel.Clients.ActiveDirectory.csproj
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Microsoft.IdentityModel.Clients.ActiveDirectory.csproj
@@ -87,11 +87,6 @@
     <EmbeddedResource Include="Properties\Microsoft.IdentityModel.Clients.ActiveDirectory.rd.xml" />
   </ItemGroup>
 
-  <ItemGroup Label="Dependency overrides due to security vulnerabilities">
-   
-   
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
     <Reference Include="System.Core" />


### PR DESCRIPTION
Fix for https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1659