### PR TITLE
fix null ref in non broker calls when source app is null

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/AuthenticationContinuationHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/AuthenticationContinuationHelper.cs
@@ -72,13 +72,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="url"></param>
         public static void SetBrokerContinuationEventArgs(NSUrl url)
         {
-            if(url == null)
+            // url should always be present
+            // if coming from broker, will be the broker response
+            // check to prevent null ref later
+            if (url == null) 
             {
                 return;
             }
 
             string urlString = string.Format(CultureInfo.CurrentCulture, url.ToString());
-            if(urlString.Contains(BrokerConstants.Broker))
+            if(urlString.Contains(BrokerConstants.IdentifyiOSBrokerFromResponseUrl))
             {
                 iOSBroker.SetBrokerResponse(url);
             }           

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/AuthenticationContinuationHelper.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/AuthenticationContinuationHelper.cs
@@ -27,6 +27,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using Foundation;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform;
 
@@ -71,7 +72,16 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory
         /// <param name="url"></param>
         public static void SetBrokerContinuationEventArgs(NSUrl url)
         {
-            iOSBroker.SetBrokerResponse(url);
+            if(url == null)
+            {
+                return;
+            }
+
+            string urlString = string.Format(CultureInfo.CurrentCulture, url.ToString());
+            if(urlString.Contains(BrokerConstants.Broker))
+            {
+                iOSBroker.SetBrokerResponse(url);
+            }           
         }
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/BrokerConstants.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/BrokerConstants.cs
@@ -52,6 +52,6 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         public const string AttemptToSaveBrokerApplicationToken = "Attempt to save iOS broker application token resulted in: ";
         public const string SecStatusCodeFromTryGetBrokerApplicationToken = "The SecStatusCode from trying to get the broker application token is: ";
 
-        public const string Broker = "broker";
+        public const string IdentifyiOSBrokerFromResponseUrl = "broker";
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/BrokerConstants.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/BrokerConstants.cs
@@ -51,5 +51,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         public const string ApplicationToken = "application_token"; // sent in request and response with iOS broker v3
         public const string AttemptToSaveBrokerApplicationToken = "Attempt to save iOS broker application token resulted in: ";
         public const string SecStatusCodeFromTryGetBrokerApplicationToken = "The SecStatusCode from trying to get the broker application token is: ";
+
+        public const string Broker = "broker";
     }
 }

--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/iOSBroker.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/iOS/iOSBroker.cs
@@ -317,7 +317,7 @@ namespace Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform
         public static void SetBrokerResponse(NSUrl responseUrl)
         {
             brokerResponse = responseUrl;
-            brokerResponseReady.Release();
+            brokerResponseReady?.Release();
         }
     }
 }


### PR DESCRIPTION
now w/ios 13, sourceApplication can be null, and if null, we are throwing a null ref later in the code for non broker responses, as the SemaphoreSlim was never created during the creation of the ios broker object. have tested w/customer repro and our own broker app. see issue for more details.