### PR TITLE
use activity and not applicationContext w/android embedded webview

### DIFF
--- a/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/EmbeddedWebview/AuthenticationAgentActivity.cs
+++ b/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/android/EmbeddedWebview/AuthenticationAgentActivity.cs
@@ -50,8 +50,8 @@ namespace Microsoft.Identity.Core.UI.EmbeddedWebview
             base.OnCreate(bundle);
             // Create your application here
 
-            WebView webView = new WebView(ApplicationContext);
-            var relativeLayout = new RelativeLayout(ApplicationContext);
+            WebView webView = new WebView(this);
+            var relativeLayout = new RelativeLayout(this);
             webView.LayoutParameters = new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MatchParent, RelativeLayout.LayoutParams.MatchParent);
 
             relativeLayout.AddView(webView);


### PR DESCRIPTION
[issue](https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/issues/1684) this was fixed in MSAL, but customer needs the fix in ADAL as they are waiting for Android broker to move to MSAL. They are currently blocked on this.