### PR TITLE
re-add adfs with tenantid tests...they were committed but not pushed :(

### DIFF
--- a/tests/Test.ADAL.NET.Common/AdalTestConstants.cs
+++ b/tests/Test.ADAL.NET.Common/AdalTestConstants.cs
@@ -35,6 +35,7 @@ namespace Test.ADAL.NET.Common
         public static readonly string DefaultResource = "resource1";
         public static readonly string AnotherResource = "resource2";
         public static readonly string DefaultAdfsAuthorityTenant = "https://login.contoso.com/adfs/";
+        public static readonly string AdfsAuthorityWithTenant = "https://login.contoso.com/adfs/" + SomeTenantId + "/";
         public static readonly string DefaultAuthorityHomeTenant = "https://login.microsoftonline.com/home/";
         public static readonly string SomeTenantId = "some-tenant-id";
         public static readonly string TenantSpecificAuthority = "https://login.microsoftonline.com/" + SomeTenantId + "/";

--- a/tests/Test.ADAL.NET.Unit.net45/InstanceDiscoveryTests.cs
+++ b/tests/Test.ADAL.NET.Unit.net45/InstanceDiscoveryTests.cs
@@ -34,7 +34,6 @@ using System.Net;
 using Microsoft.Identity.Core;
 using Microsoft.Identity.Core.Cache;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal;
-using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Http;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Instance;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Flows;
 using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.ClientCreds;
@@ -42,6 +41,7 @@ using Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Platform;
 using Test.ADAL.NET.Common;
 using Test.ADAL.NET.Common.Mocks;
 using MockHttpMessageHandler = Test.ADAL.NET.Common.Mocks.MockHttpMessageHandler;
+using AuthorityType = Microsoft.IdentityModel.Clients.ActiveDirectory.Internal.Instance.AuthorityType;
 
 namespace Test.ADAL.NET.Unit
 {
@@ -170,11 +170,27 @@ namespace Test.ADAL.NET.Unit
         [TestMethod]
         public async Task TestInstanceDiscovery_WhenAuthorityIsAdfs_ShouldNotDoInstanceDiscoveryAsync()
         {
+            await BasicAdfsTestAsync(AdalTestConstants.DefaultAdfsAuthorityTenant).ConfigureAwait(false);
+        }
+
+        [TestMethod]
+        public async Task TestInstanceDiscovery_WhenAuthorityIsAdfsWithTenantSpecified_ShouldNotDoInstanceDiscoveryAsync()
+        {
+            await BasicAdfsTestAsync(AdalTestConstants.AdfsAuthorityWithTenant).ConfigureAwait(false);
+        }
+
+        private async Task BasicAdfsTestAsync(string authority)
+        {
             using (var httpManager = new MockHttpManager())
             {
                 var serviceBundle = ServiceBundle.CreateWithCustomHttpManager(httpManager);
-                var authenticator = new Authenticator(serviceBundle, "https://login.contoso.com/adfs", false);
+                var authenticator = new Authenticator(serviceBundle, authority, false);
                 await authenticator.UpdateFromTemplateAsync(new RequestContext(null, new AdalLogger(new Guid()))).ConfigureAwait(false);
+                Assert.AreEqual(authority, authenticator.Authority);
+                Assert.AreEqual(AuthorityType.ADFS, authenticator.AuthorityType);
+                Assert.AreEqual("https://login.contoso.com/adfs/oauth2/authorize", authenticator.AuthorizationUri);
+                Assert.AreEqual("https://login.contoso.com/adfs/oauth2/token", authenticator.SelfSignedJwtAudience);
+                Assert.AreEqual("https://login.contoso.com/adfs/oauth2/token", authenticator.TokenUri);
             }
         }
 
@@ -214,7 +230,7 @@ namespace Test.ADAL.NET.Unit
                 CreateFailureMockHandler(httpManager);
                 CreateFailureMockHandler(httpManager);
 
-                 RequestContext requestContext = new RequestContext(null, new AdalLogger(new Guid()));
+                RequestContext requestContext = new RequestContext(null, new AdalLogger(new Guid()));
                 string givenHost = "sts.microsoft.com";
 
                 // ADAL still behaves correctly using developer provided authority


### PR DESCRIPTION
@henrik-me i committed these changes but forgot to push them last night. internal partner let me know...lol. so here they are, not needed for the release though.